### PR TITLE
Add `TaskPriority` & `tracksFeedbacks`

### DIFF
--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -9,9 +9,9 @@ extension Store
         @Binding
         public private(set) var state: State
 
-        public let send: (Action) -> Void
+        public let send: (Action, TaskPriority) -> Void
 
-        public init(state: Binding<State>, send: @escaping (Action) -> Void)
+        public init(state: Binding<State>, send: @escaping (Action, TaskPriority) -> Void)
         {
             self._state = state
             self.send = send
@@ -29,7 +29,7 @@ extension Store
         public func contramap<Action2>(action f: @escaping (Action2) -> Action)
             -> Store<Action2, State>.Proxy
         {
-            .init(state: self.$state, send: { self.send(f($0)) })
+            .init(state: self.$state, send: { self.send(f($0), $1) })
         }
 
         // MARK: - To Binding
@@ -54,7 +54,7 @@ extension Store
                 },
                 set: {
                     if let action = onChange($0) {
-                        self.send(action)
+                        self.send(action, stateBindingTaskPriority)
                     }
                 }
             )

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -56,6 +56,8 @@ public final class Store<Action, State>: ObservableObject
 
 }
 
+let stateBindingTaskPriority: TaskPriority = .high
+
 // MARK: - Private
 
 // NOTE:
@@ -64,10 +66,10 @@ public final class Store<Action, State>: ObservableObject
 // To call these methods, use `proxy` instead.
 extension Store
 {
-    private func send(_ action: Action)
+    private func send(_ action: Action, priority: TaskPriority? = nil)
     {
-        Task {
-            await self.actomaton.send(.action(action))
+        Task(priority: priority) {
+            await self.actomaton.send(.action(action), priority: priority)
         }
     }
 
@@ -78,8 +80,8 @@ extension Store
                 self.state
             },
             set: { newValue in
-                Task {
-                    await self.actomaton.send(.state(newValue))
+                Task(priority: stateBindingTaskPriority) {
+                    await self.actomaton.send(.state(newValue), priority: stateBindingTaskPriority)
                 }
             }
         )

--- a/Tests/ActomatonTests/EffectCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectCancellationTests.swift
@@ -32,6 +32,7 @@ final class EffectCancellationTests: XCTestCase
                         if Task.isCancelled {
                             Debug.print("_1To2 cancelled")
                             self.is1To2Cancelled = true
+                            return nil
                         }
                         return ._2To3
                     }
@@ -45,6 +46,7 @@ final class EffectCancellationTests: XCTestCase
                         if Task.isCancelled {
                             Debug.print("_2To3 cancelled")
                             self.is2To3Cancelled = true
+                            return nil
                         }
                         return ._3To4
                     }

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -31,6 +31,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
                         if Task.isCancelled {
                             Debug.print("_1To2 cancelled")
                             self.is1To2Cancelled = true
+                            return nil
                         }
                         return ._2To3
                     }
@@ -44,6 +45,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
                         if Task.isCancelled {
                             Debug.print("_2To3 cancelled")
                             self.is2To3Cancelled = true
+                            return nil
                         }
                         return ._3To4
                     }

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import Actomaton
+
+import Combine
+
+/// Tests for `actomaton.send`'s returned `Task`.
+final class FeedbackTrackingTaskTests: XCTestCase
+{
+    fileprivate var actomaton: Actomaton<Action, State>!
+
+    private func setupActomaton(initalState: State) async
+    {
+        let actomaton = Actomaton<Action, State>(
+            state: initalState,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case ._1To2:
+                    guard state == ._1 else { return .empty }
+
+                    state = ._2
+                    return Effect {
+                        await tick(1)
+                        if Task.isCancelled {
+                            Debug.print("_1To2 cancelled")
+                            return nil
+                        }
+                        return ._2To3
+                    }
+
+                case ._2To3:
+                    guard state == ._2 else { return .empty }
+
+                    state = ._3
+                    return Effect {
+                        await tick(1)
+                        if Task.isCancelled {
+                            Debug.print("_2To3 cancelled")
+                            return nil
+                        }
+                        return ._3To4
+                    }
+
+                case ._3To4: // 3-tick timer
+                    guard state == ._3 else { return .empty }
+
+                    state = ._4(count: 0)
+                    return Effect(sequence: AsyncStream<Action> { continuation in
+                        let task = Task<(), Never> {
+                            for _ in 1 ... 2 {
+                                await tick(1)
+                                if Task.isCancelled {
+                                    Debug.print("_3To4 cancelled")
+                                    return
+                                }
+                                continuation.yield(._increment)
+                            }
+
+                            await tick(1)
+                            continuation.yield(._4To5)
+                            continuation.finish()
+                        }
+                        continuation.onTermination = { @Sendable _ in
+                            task.cancel()
+                        }
+                    })
+
+                case ._increment:
+                    guard case let ._4(count) = state else { return .empty }
+
+                    state = ._4(count: count + 1)
+                    return .empty
+
+                case ._4To5:
+                    guard case ._4 = state else { return .empty }
+
+                    state = ._5
+                    return Effect {
+                        await tick(1)
+                        if Task.isCancelled {
+                            Debug.print("_4To5 cancelled")
+                            return nil
+                        }
+                        return ._5To6
+                    }
+
+                case ._5To6:
+                    guard case ._5 = state else { return .empty }
+
+                    state = ._6
+                    return .empty
+
+                case ._toEnd:
+                    state = ._end
+                    return Effect {
+                        await tick(1)
+                        return nil
+                    }
+                }
+
+            }
+        )
+        self.actomaton = actomaton
+
+        var cancellables: [AnyCancellable] = []
+
+        await actomaton.$state
+            .sink(receiveValue: { state in
+                Debug.print("publisher: state = \(state)")
+            })
+            .store(in: &cancellables)
+    }
+
+    func test_no_tracksFeedbacks() async throws
+    {
+        await setupActomaton(initalState: ._1)
+
+        assertEqual(await actomaton.state, ._1)
+
+        let task = await actomaton.send(._1To2, tracksFeedbacks: false)
+
+        // Wait for `._1To2`'s effect only (upto `_2To3`'s next state-transition without its effect)
+        await task?.value
+
+        assertEqual(await actomaton.state, ._3,
+                    """
+                    "State should be `_3` because `._2To3` (next action and state change) will also be triggered
+                    as part of `._1To2`'s effect. (NOTE: `._2To3`'s effect won't be awaited)
+                    """)
+
+        await tick(1.3)
+        assertEqual(await actomaton.state, ._4(count: 0))
+
+        await tick(1.3)
+        assertEqual(await actomaton.state, ._4(count: 1))
+
+        await tick(1.3)
+        assertEqual(await actomaton.state, ._4(count: 2))
+
+        // Comment-Out: A bit flaky to check this intermediate state, so ignore it.
+        //await tick(1.3)
+        //assertEqual(await actomaton.state, ._5)
+
+        await tick(2)
+        assertEqual(await actomaton.state, ._6)
+    }
+
+    func test_tracksFeedbacks_single() async throws
+    {
+        // Start from `._1` for `single`-first (async) effect test.
+        await setupActomaton(initalState: ._1)
+
+        assertEqual(await actomaton.state, ._1)
+
+        // Single effect, tracking feedbacks.
+        let task = await actomaton.send(._1To2, tracksFeedbacks: true)
+
+        // Wait for all: `._1To2`, `._2To3`, `._3To4`, `._increment`, `._4To5`, `._5To6`.
+        await task?.value
+
+        assertEqual(await actomaton.state, ._6,
+                    "Should wait for final result `._6` because `tracksFeedbacks = true`")
+    }
+
+    func test_tracksFeedbacks_sequence() async throws
+    {
+        // Start from `._3` for `sequence`-first effect test.
+        await setupActomaton(initalState: ._3)
+
+        assertEqual(await actomaton.state, ._3)
+
+        // Sequence effect, tracking feedbacks.
+        let task = await actomaton.send(._3To4, tracksFeedbacks: true)
+
+        // Wait for all: `._3To4`, `._increment`, `._4To5`, `._5To6`.
+        await task?.value
+
+        assertEqual(await actomaton.state, ._6,
+                    "Should wait for final result `._5` because `tracksFeedbacks = true`")
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case _1To2
+    case _2To3
+    case _3To4 // start 3-tick timer
+    case _increment
+    case _4To5
+    case _5To6
+    case _toEnd
+}
+
+private enum State: Equatable
+{
+    case _1
+    case _2
+    case _3
+    case _4(count: Int)
+    case _5
+    case _6
+    case _end
+}


### PR DESCRIPTION
This PR adds `TaskPriority` & `tracksFeedbacks` features to `Actomaton.send(_ action: Action)`.

```swift
    /// Sends `action` to `Actomaton`.
    ///
    /// - Parameters:
    ///   - priority:
    ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
    ///   - tracksFeedbacks:
    ///     If `true`, returned `Task` will also track its feedback effects that are triggered by next actions,
    ///     so that their wait-for-all and cancellations are possible.
    ///     Default is `false`.
    ///
    /// - Returns:
    ///   Unified task that can handle (wait for or cancel) all combined effects triggered by `action` in `Reducer`.
    @discardableResult
    public func send(
        _ action: Action,
        priority: TaskPriority? = nil,
        tracksFeedbacks: Bool = false
    ) -> Task<(), Never>?
```