### PR TITLE
[ActomatonStore] Add `Store` transform functions

### DIFF
--- a/Sources/ActomatonStore/Binding+Helper.swift
+++ b/Sources/ActomatonStore/Binding+Helper.swift
@@ -46,3 +46,15 @@ extension Binding
         )
     }
 }
+
+// MARK: - Traversable
+
+extension Binding where Value: OptionalProtocol
+{
+    /// Transforms `Binding<Value?>` to `Binding<Value>?`.
+    public var sequence: Binding<Value.Wrapped>?
+    {
+        let binding: Binding<Value.Wrapped?> = self[casePath: CasePath(embed: Value.init, extract: { $0.asOptional() })]
+        return Binding<Value.Wrapped>(binding)
+    }
+}

--- a/Sources/ActomatonStore/OptionalProtocol.swift
+++ b/Sources/ActomatonStore/OptionalProtocol.swift
@@ -1,0 +1,20 @@
+public protocol OptionalProtocol
+{
+    associatedtype Wrapped
+
+    init(_ value: Wrapped?)
+    func asOptional() -> Wrapped?
+}
+
+extension Optional: OptionalProtocol
+{
+    public init(_ value: Wrapped?)
+    {
+        self = value
+    }
+
+    public func asOptional() -> Wrapped?
+    {
+        self
+    }
+}

--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -52,6 +52,8 @@ extension Store
             self._send(action, priority, tracksFeedbacks)
         }
 
+        // MARK: - Functor
+
         /// Transforms `<Action, State>` to `<Action, SubState>` using keyPath `@dynamicMemberLookup`.
         public subscript<SubState>(
             dynamicMember keyPath: WritableKeyPath<State, SubState>
@@ -60,11 +62,26 @@ extension Store
             .init(state: self.$state[dynamicMember: keyPath], send: self.send)
         }
 
+        /// Transforms `<Action, State>` to `<Action, SubState?>` using casePath.
+        public subscript<SubState>(
+            casePath casePath: CasePath<State, SubState>
+        ) -> Store<Action, SubState?>.Proxy
+        {
+            .init(state: self.$state[casePath: casePath], send: self.send)
+        }
+
         /// Transforms `Action` to `Action2`.
         public func contramap<Action2>(action f: @escaping (Action2) -> Action)
             -> Store<Action2, State>.Proxy
         {
             .init(state: self.$state, send: { self.send(f($0), priority: $1, tracksFeedbacks: $2) })
+        }
+
+        /// Transforms `Action` to `Action2` using casePath.
+        public func map<Action2>(action: CasePath<Action, Action2>)
+            -> Store<Action2, State>.Proxy
+        {
+            self.contramap(action: action.embed)
         }
 
         // MARK: - To Binding

--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -113,3 +113,19 @@ extension Store
         }
     }
 }
+
+// MARK: - Traversable
+
+extension Store.Proxy where State: OptionalProtocol
+{
+    /// Transforms `Store.Proxy<Action, State?>` to `Store.Proxy<Action, State>?`.
+    public var sequence: Store<Action, State.Wrapped>.Proxy?
+    {
+        guard let binding = $state.sequence else { return nil }
+
+        return Store<Action, State.Wrapped>.Proxy(
+            state: binding,
+            send: self.send
+        )
+    }
+}


### PR DESCRIPTION
This PR adds `Store`-transforming functions for more easy creation of child-Stores 
to avoid `Binding`-transform-based approach so that the code from [Actomaton-Gallery](https://github.com/inamiy/Actomaton-Gallery) will drastically improve from:

```swift
extension Example
{
    func exampleView<ChildAction, ChildState, V: View>(
        store: Store<Root.Action, Root.State>.Proxy,
        actionPath: CasePath<Root.Action, ChildAction>,
        statePath: CasePath<Root.State.Current, ChildState>,
        makeView: (Store<ChildAction, ChildState>.Proxy) -> V
    ) -> AnyView
    {
        guard let currentBinding = Binding(store.$state.current),
              let stateBinding = Binding(currentBinding[casePath: statePath])
        else {
            return EmptyView().toAnyView()
        }

        let substore = Store<ChildAction, ChildState>.Proxy(
            state: stateBinding,
            send: {
                store.send(actionPath.embed($0), priority: $1, tracksFeedbacks: $2)
            }
        )

        return makeView(substore).toAnyView()
    }
}
```

to:

```swift
extension Example
{
    @ViewBuilder
    static func exampleView<ChildAction, ChildState, V: View>(
        store: Store<Root.Action, Root.State>.Proxy,
        actionPath: CasePath<Root.Action, ChildAction>,
        statePath: CasePath<Root.State.Current, ChildState>,
        makeView: (Store<ChildAction, ChildState>.Proxy) -> V
    ) -> some View
    {
        if let substore = store.current
            .sequence?[casePath: statePath]
            .sequence?
            .map(action: actionPath)
        {
            makeView(substore)
        }
    }
}
```