### PR TITLE
[ActomatonStore] Add `RouteStore` & `HostingViewController` (UIKit support)

### DIFF
--- a/Sources/ActomatonStore/HostingViewController.swift
+++ b/Sources/ActomatonStore/HostingViewController.swift
@@ -1,0 +1,71 @@
+import UIKit
+import Combine
+import SwiftUI
+
+/// SwiftUI `View` & `Store` wrapper view controller that holds `UIHostingController`.
+@MainActor
+open class HostingViewController<Action, State, V: SwiftUI.View>: UIViewController
+{
+    private let store: Store<Action, State>
+    private let makeView: @MainActor (Store<Action, State>.Proxy) -> V
+
+    public init(
+        store: Store<Action, State>,
+        makeView: @escaping @MainActor (Store<Action, State>.Proxy) -> V
+    )
+    {
+        self.store = store
+        self.makeView = makeView
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    public required init?(coder: NSCoder)
+    {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad()
+    {
+        super.viewDidLoad()
+
+        let rootView = StoreView(store: self.store, makeView: self.makeView)
+        let hostVC = UIHostingController(rootView: rootView)
+        hostVC.view.translatesAutoresizingMaskIntoConstraints = false
+
+        self.addChild(hostVC)
+        self.view.addSubview(hostVC.view)
+        hostVC.didMove(toParent: self)
+
+        NSLayoutConstraint.activate([
+            self.view.leadingAnchor.constraint(equalTo: hostVC.view.leadingAnchor),
+            self.view.trailingAnchor.constraint(equalTo: hostVC.view.trailingAnchor),
+            self.view.topAnchor.constraint(equalTo: hostVC.view.topAnchor),
+            self.view.bottomAnchor.constraint(equalTo: hostVC.view.bottomAnchor)
+        ])
+    }
+}
+
+// MARK: - Private
+
+/// View to hold `Store` as `@ObservedObject`.
+private struct StoreView<Action, State, V: View>: View
+{
+    @ObservedObject
+    var store: Store<Action, State>
+
+    private let makeView: @MainActor (Store<Action, State>.Proxy) -> V
+
+    init(
+        store: Store<Action, State>,
+        makeView: @escaping @MainActor (Store<Action, State>.Proxy) -> V
+    )
+    {
+        self.store = store
+        self.makeView = makeView
+    }
+
+    var body: some View
+    {
+        self.makeView(self.store.proxy)
+    }
+}

--- a/Sources/ActomatonStore/RouteStore.swift
+++ b/Sources/ActomatonStore/RouteStore.swift
@@ -1,0 +1,56 @@
+import Dispatch
+import Combine
+
+/// Subclass of `Store` that also outputs `routes`, mainly used for UIKit's navigation handling
+/// without using `State` as a single source of truth.
+@MainActor
+open class RouteStore<Action, State, Route>: Store<Action, State>
+{
+    private let _routes = PassthroughSubject<Route, Never>()
+    private var cancellables: [AnyCancellable] = []
+
+    public init<Environment>(
+        state: State,
+        reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>>,
+        environment: Environment,
+        routeType: Route.Type = Route.self // for quick type-inference
+    )
+    {
+        super.init(
+            state: state,
+            reducer: reducer,
+            environment: .init(environment: environment, sendRoute: self._routes.send)
+        )
+    }
+
+    /// `Route` publisher.
+    public var routes: AnyPublisher<Route, Never>
+    {
+        self._routes
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    /// Subscribes `routes` until `Store`'s lifetime.
+    public func subscribeRoutes(_ routeHandler: @escaping (Route) -> Void)
+    {
+        self.routes
+            .sink(receiveValue: routeHandler)
+            .store(in: &self.cancellables)
+    }
+}
+
+// MARK: - SendRouteEnvironment
+
+/// Wrapper of original `environment` with attaching `sendRoute`.
+public struct SendRouteEnvironment<Environment, Route>
+{
+    public var environment: Environment
+    public var sendRoute: (Route) -> Void
+
+    public init(environment: Environment, sendRoute: @escaping (Route) -> Void)
+    {
+        self.environment = environment
+        self.sendRoute = sendRoute
+    }
+}

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -4,7 +4,7 @@ import Combine
 
 /// Store of `Actomaton` optimized for SwiftUI's 2-way binding.
 @MainActor
-public final class Store<Action, State>: ObservableObject
+open class Store<Action, State>: ObservableObject
 {
     private let actomaton: Actomaton<BindableAction, State>
 


### PR DESCRIPTION
This PR adds following features (especially for working with UIKit)

### `RouteStore`

A subclass of `Store` that also emits `route: AnyPublisher<Route, Never>` as output,
which is a common pattern in UIKit-based MVVM that triggers actions outside of its domain.

Note that `RouteStore` has a type of `Reducer<Action, State, SendRouteEnvironment<Environment, Route>>`,
and may additionally need `contramap(environment:)` in case of migrating from SwiftUI-based reducer.

```swift
let store = RouteStore(
    state: state,
    reducer: reducer, // NOTE: has type of Reducer<Action, State, SendRouteEnvironment<Environment, Route>>
    environment: environment,
    routeType: Route.self // for quick type-inference
)
```

### `HostingViewController`

A wrapper of `UIHostingController` that takes `Store` and `View`'s initializer to be lazily instantiated on `viewDidLoad`.