### PR TITLE
[ActomatonStore] Add `directStateBinding` to allow making internal `Binding<State>` public

### DIFF
--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -138,4 +138,15 @@ extension Store.Proxy
             }
         )
     }
+
+    /// **Direct** state binding which skips sending `Action` and running `Reducer` by directly modifying state,
+    /// just as plain SwiftUI does 2-way state binding.
+    ///
+    /// - Note:
+    ///   If you prefer more "strict" Elm-like architecture to always run `Action` & `Reducer`,
+    ///   do not use this method, and use `stateBinding` that converts state-setter to `Action` for indirection instead.
+    public var directStateBinding: Binding<State>
+    {
+        self._state
+    }
 }


### PR DESCRIPTION
This PR adds `directStateBinding` to expose internal `Binding<State>` as public
to allow users to perform SwiftUI's plain 2-way binding without sending `Action` and running `Reducer`.

```swift
    /// **Direct** state binding which skips sending `Action` and running `Reducer` by directly modifying state,
    /// just as plain SwiftUI does 2-way state binding.
    ///
    /// - Note:
    ///   If you prefer more "strict" Elm-like architecture to always run `Action` & `Reducer`,
    ///   do not use this method, and use `stateBinding` that converts state-setter to `Action` for indirection instead.
    public var directStateBinding: Binding<State>
    {
        self._state
    }
```