### PR TITLE
[Actomaton] Support `EffectQueue`

### DIFF
--- a/Sources/Actomaton/EffectID.swift
+++ b/Sources/Actomaton/EffectID.swift
@@ -1,0 +1,5 @@
+/// Effect identifier for manual cancellation via `Effect.cancel`.
+public typealias EffectID = AnyHashable
+
+/// A protocol that every effect-identifier should conform to.
+public protocol EffectIDProtocol: Hashable {}

--- a/Sources/Actomaton/EffectQueue.swift
+++ b/Sources/Actomaton/EffectQueue.swift
@@ -1,0 +1,49 @@
+/// Effect queue for automatic cancellation of existing tasks or suspending of new effects.
+public typealias EffectQueue = AnyHashable
+
+/// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of new effects.
+public protocol EffectQueueProtocol: Hashable
+{
+    var effectQueuePolicy: EffectQueuePolicy { get }
+}
+
+// MARK: - Newest1EffectQueueProtocol
+
+/// A helper protocol where `effectQueuePolicy` is set to `.runNewest(maxCount: 1)`.
+public protocol Newest1EffectQueueProtocol: EffectQueueProtocol {}
+
+extension Newest1EffectQueueProtocol
+{
+    public var effectQueuePolicy: EffectQueuePolicy
+    {
+        .runNewest(maxCount: 1)
+    }
+}
+
+// MARK: - Oldest1EffectQueueProtocol
+
+/// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .discardNew)`.
+public protocol Oldest1EffectQueueProtocol: EffectQueueProtocol {}
+
+extension Oldest1EffectQueueProtocol
+{
+    public var effectQueuePolicy: EffectQueuePolicy
+    {
+        .runOldest(maxCount: 1, .discardNew)
+    }
+}
+
+// MARK: - Internals
+
+struct AnyEffectQueue: EffectQueueProtocol
+{
+    let queue: EffectQueue
+    let effectQueuePolicy: EffectQueuePolicy
+
+    init<Queue>(_ queue: Queue)
+        where Queue: EffectQueueProtocol
+    {
+        self.queue = queue
+        self.effectQueuePolicy = queue.effectQueuePolicy
+    }
+}

--- a/Sources/Actomaton/EffectQueuePolicy.swift
+++ b/Sources/Actomaton/EffectQueuePolicy.swift
@@ -1,0 +1,18 @@
+/// `EffectQueueProtocol`'s buffering policy.
+public enum EffectQueuePolicy: Hashable
+{
+    /// Runs `maxCount` newest effects, cancelling old running effects.
+    case runNewest(maxCount: Int)
+
+    /// Runs `maxCount` old effects with either suspending or discarding new effects.
+    case runOldest(maxCount: Int, OverflowPolicy)
+
+    public enum OverflowPolicy
+    {
+        /// Suspends new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
+        case suspendNew
+
+        /// Discards new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
+        case discardNew
+    }
+}

--- a/Sources/Actomaton/Internal/DebugLog.swift
+++ b/Sources/Actomaton/Internal/DebugLog.swift
@@ -1,0 +1,11 @@
+// MARK: - DebugLog
+
+enum Debug
+{
+    static func print(_ msg: Any)
+    {
+#if DEBUG
+//        Swift.print("===>", msg)
+#endif
+    }
+}

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 import Combine
 
-/// Tests for same `EffectID` where previous effect will be automatically cancelled by the next effect.
+/// Tests for `Newest1EffectQueueProtocol` where previous effect will be automatically cancelled by the next effect.
 final class EffectIDAutoCancellationTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -16,7 +16,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
         is1To2Cancelled = false
         is2To3Cancelled = false
 
-        let commonEffectID = "id"
+        struct Newest1EffectQueue: Newest1EffectQueueProtocol {}
 
         let actomaton = Actomaton<Action, State>(
             state: ._1,
@@ -26,7 +26,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
                     guard state == ._1 else { return .empty }
 
                     state = ._2
-                    return Effect(id: commonEffectID) {
+                    return Effect(queue: Newest1EffectQueue()) {
                         await tick(1)
                         if Task.isCancelled {
                             Debug.print("_1To2 cancelled")
@@ -40,7 +40,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
                     guard state == ._2 else { return .empty }
 
                     state = ._3
-                    return Effect(id: commonEffectID) {
+                    return Effect(queue: Newest1EffectQueue()) {
                         await tick(1)
                         if Task.isCancelled {
                             Debug.print("_2To3 cancelled")
@@ -58,7 +58,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
 
                 case ._toEnd:
                     state = ._end
-                    return Effect(id: commonEffectID) {
+                    return Effect(queue: Newest1EffectQueue()) {
                         await tick(1)
                         return nil
                     }

--- a/Tests/ActomatonTests/Fixtures/Fixtures.swift
+++ b/Tests/ActomatonTests/Fixtures/Fixtures.swift
@@ -2,13 +2,13 @@ import XCTest
 
 // MARK: - Tick
 
-/// - Note: For safe async testing, leeway should have at least 3 millisec.
+/// - Note: For safe async testing, leeway should have at least 50 millisec (30 millsec isn't enough for MacBook Pro (15-inch, 2018)).
 func tick(_ n: Double) async
 {
     await Task.sleep(UInt64(Double(tickTimeInterval) * n))
 }
 
-private let tickTimeInterval: UInt64 = 10_000_000 // 10 ms
+private let tickTimeInterval: UInt64 = 50_000_000 // 50 ms
 
 // MARK: - Assert
 
@@ -23,15 +23,14 @@ func assertEqual<T>(
     XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
 }
 
-// MARK: - DebugLog
+// MARK: - ResultsCollector
 
-enum Debug
+actor ResultsCollector<T>
 {
-    static func print(_ msg: Any)
+    var results: [T] = []
+
+    func append(_ value: T)
     {
-#if DEBUG
-        Swift.print(msg)
-#endif
+        results.append(value)
     }
 }
-

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -13,7 +13,7 @@ final class LoginLogoutTests: XCTestCase
     {
         isLoginCancelled = false
 
-        struct LoginFlowEffectID: EffectIDProtocol {}
+        struct LoginFlowEffectQueue: Newest1EffectQueueProtocol {}
 
         let actomaton = Actomaton<Action, State>(
             state: .loggedOut,
@@ -21,7 +21,7 @@ final class LoginLogoutTests: XCTestCase
                 switch (action, state) {
                 case (.login, .loggedOut):
                     state = .loggingIn
-                    return Effect(id: LoginFlowEffectID()) {
+                    return Effect(queue: LoginFlowEffectQueue()) {
                         await tick(1)
                         if Task.isCancelled {
                             self.isLoginCancelled = true
@@ -38,7 +38,7 @@ final class LoginLogoutTests: XCTestCase
                     (.forceLogout, .loggingIn),
                     (.forceLogout, .loggedIn):
                     state = .loggingOut
-                    return Effect(id: LoginFlowEffectID()) {
+                    return Effect(queue: LoginFlowEffectQueue()) {
                         await tick(1)
                         return .logoutOK
                     }

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import Actomaton
+
+import Combine
+
+/// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runNewest(maxCount: n)`.
+final class RunNewestDiscardOldTests: XCTestCase
+{
+    fileprivate var actomaton: Actomaton<Action, State>!
+
+    fileprivate var resultsCollector: ResultsCollector<Int> = .init()
+
+    private func setupActomaton(maxCount: Int)
+    {
+        self.resultsCollector = ResultsCollector<Int>()
+
+        struct NewestEffectQueue: EffectQueueProtocol
+        {
+            var maxCount: Int
+
+            var effectQueuePolicy: EffectQueuePolicy
+            {
+                .runNewest(maxCount: maxCount)
+            }
+        }
+
+        let actomaton = Actomaton<Action, State>(
+            state: State(),
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+
+                    return Effect(queue: NewestEffectQueue(maxCount: maxCount)) { [state] in
+                        await tick(1)
+                        if Task.isCancelled {
+                            await self.resultsCollector.append(state.count)
+                            Debug.print("Effect cancelled: \(state.count)")
+                            return nil
+                        }
+                        Debug.print("Effect success")
+                        return .effectCompleted
+                    }
+
+                case .effectCompleted:
+                    state.effectCompletedCount += 1
+                    return .empty
+                }
+            }
+        )
+        self.actomaton = actomaton
+    }
+
+    func test_maxCount1() async throws
+    {
+        setupActomaton(maxCount: 1)
+
+        assertEqual(await actomaton.state, State(count: 0, effectCompletedCount: 0))
+
+        // 1st `increment` (effect will be auto-cancelled because of 2nd increment & `NewestEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 1, effectCompletedCount: 0))
+
+        // 2nd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
+
+        await tick(3)
+
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 1),
+                    "`effectCompletedCount` should increment by 1 (not 2) because of `NewestEffectQueue`")
+
+        // 3rd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 1))
+
+        await tick(3)
+
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
+
+        let results = await resultsCollector.results.sorted()
+        XCTAssertEqual(results, [1], "1st increment should be cancelled.")
+    }
+
+    func test_maxCount2() async throws
+    {
+        setupActomaton(maxCount: 2)
+
+        assertEqual(await actomaton.state, State(count: 0, effectCompletedCount: 0))
+
+        // 1st `increment` (effect will be auto-cancelled because of 3rd increment & `NewestEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 1, effectCompletedCount: 0))
+
+        // 2nd `increment` (effect will be auto-cancelled because of 4th increment & `NewestEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
+
+        // 3rd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 0))
+
+        // 4th `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 0))
+
+        await tick(5)
+
+        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 2),
+                    "`effectCompletedCount` will increment by 2 because of `NewestEffectQueue`")
+
+        // 4th `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 5, effectCompletedCount: 2))
+
+        await tick(3)
+
+        assertEqual(await actomaton.state, State(count: 5, effectCompletedCount: 3))
+
+        let results = await resultsCollector.results.sorted()
+        XCTAssertEqual(results, [1, 2], "1st & 2nd increment should be cancelled.")
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case increment
+    case effectCompleted
+}
+
+private struct State: Equatable
+{
+    var count: Int = 0
+    var effectCompletedCount: Int = 0
+}

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import Actomaton
+
+import Combine
+
+/// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
+final class RunOldestDiscardNewTests: XCTestCase
+{
+    fileprivate var actomaton: Actomaton<Action, State>!
+
+    fileprivate var resultsCollector: ResultsCollector<Int> = .init()
+
+    private func setupActomaton(maxCount: Int)
+    {
+        self.resultsCollector = ResultsCollector<Int>()
+
+        struct OldestDiscardNewEffectQueue: EffectQueueProtocol
+        {
+            var maxCount: Int
+
+            var effectQueuePolicy: EffectQueuePolicy
+            {
+                .runOldest(maxCount: maxCount, .discardNew)
+            }
+        }
+
+        let actomaton = Actomaton<Action, State>(
+            state: State(),
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+
+                    return Effect(queue: OldestDiscardNewEffectQueue(maxCount: maxCount)) { [state] in
+                        await tick(1)
+                        if Task.isCancelled {
+                            await self.resultsCollector.append(state.count)
+                            Debug.print("Effect cancelled")
+                            return nil
+                        }
+                        Debug.print("Effect success")
+                        return .effectCompleted
+                    }
+
+                case .effectCompleted:
+                    state.effectCompletedCount += 1
+                    return .empty
+                }
+            }
+        )
+        self.actomaton = actomaton
+    }
+
+    func test_maxCount1() async throws
+    {
+        setupActomaton(maxCount: 1)
+
+        assertEqual(await actomaton.state, State(count: 0, effectCompletedCount: 0))
+
+        // 1st `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 1, effectCompletedCount: 0))
+
+        // 2nd `increment` (effect won't be executed because of `OldestDiscardNewEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
+
+        await tick(3)
+
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 1),
+                    "`effectCompletedCount` should increment by 1 (not 2) because of `OldestDiscardNewEffectQueue`")
+
+        // 3rd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 1))
+
+        await tick(3)
+
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
+
+        let results = await resultsCollector.results.sorted()
+        XCTAssertEqual(results, [],
+                       "Should be empty, because 2nd increment's effect is discarded without start nor cancellation.")
+    }
+
+    func test_maxCount2() async throws
+    {
+        setupActomaton(maxCount: 2)
+
+        assertEqual(await actomaton.state, State(count: 0, effectCompletedCount: 0))
+
+        // 1st `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 1, effectCompletedCount: 0))
+
+        // 2nd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
+
+        // 3rd `increment` (effect won't be executed because of `OldestDiscardNewEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 0))
+
+        await tick(4)
+
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2),
+                    "`effectCompletedCount` will increment by 2 (not 3) because of `OldestDiscardNewEffectQueue`")
+
+        // 4th `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 2))
+
+        await tick(3)
+
+        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 3))
+
+        let results = await resultsCollector.results.sorted()
+        XCTAssertEqual(results, [],
+                       "Should be empty, because 3nd increment's effect is discarded without start nor cancellation.")
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case increment
+    case effectCompleted
+}
+
+private struct State: Equatable
+{
+    var count: Int = 0
+    var effectCompletedCount: Int = 0
+}

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import Actomaton
+
+import Combine
+
+/// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
+final class RunOldestSuspendNewTests: XCTestCase
+{
+    fileprivate var actomaton: Actomaton<Action, State>!
+
+    fileprivate var resultsCollector: ResultsCollector<Int> = .init()
+
+    private func setupActomaton(maxCount: Int)
+    {
+        self.resultsCollector = ResultsCollector<Int>()
+
+        struct OldestSuspendNewEffectQueue: EffectQueueProtocol
+        {
+            var maxCount: Int
+
+            var effectQueuePolicy: EffectQueuePolicy
+            {
+                .runOldest(maxCount: maxCount, .suspendNew)
+            }
+        }
+
+        let actomaton = Actomaton<Action, State>(
+            state: State(),
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+
+                    return Effect(queue: OldestSuspendNewEffectQueue(maxCount: maxCount)) { [state] in
+                        await tick(1)
+                        if Task.isCancelled {
+                            await self.resultsCollector.append(state.count)
+                            Debug.print("Effect cancelled")
+                            return nil
+                        }
+                        Debug.print("Effect success")
+                        return .effectCompleted
+                    }
+
+                case .effectCompleted:
+                    state.effectCompletedCount += 1
+                    return .empty
+                }
+            }
+        )
+        self.actomaton = actomaton
+    }
+
+    func test_maxCount1() async throws
+    {
+        setupActomaton(maxCount: 1)
+
+        assertEqual(await actomaton.state, State(count: 0, effectCompletedCount: 0))
+
+        // 1st `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 1, effectCompletedCount: 0))
+
+        // 2nd `increment` (effect will start delayed because of `OldestSuspendNewEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
+
+        // Wait until 1st effect is finished.
+        await tick(1.5)
+
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 1),
+                    "`effectCompletedCount` should increment by 1 because of `OldestSuspendNewEffectQueue`.")
+
+        // Wait until 2nd effect is finished.
+        await tick(1.5)
+
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 2),
+                    "`effectCompletedCount` should increment by 2 because of `OldestSuspendNewEffectQueue`.")
+
+        // 3rd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
+
+        await tick(1.5)
+
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 3))
+
+        let results = await resultsCollector.results.sorted()
+        XCTAssertEqual(results, [], "Should be empty because no cancellation won't happen in this policy.")
+    }
+
+    func test_maxCount2() async throws
+    {
+        setupActomaton(maxCount: 2)
+
+        assertEqual(await actomaton.state, State(count: 0, effectCompletedCount: 0))
+
+        // 1st `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 1, effectCompletedCount: 0))
+
+        // 2nd `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
+
+        // 3rd `increment` (effect will start delayed because of `OldestSuspendNewEffectQueue`).
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 0))
+
+        // Wait until 1st & 2nd effect is finished.
+        await tick(1.5)
+
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2),
+                    "`effectCompletedCount` should increment by 2 because of `OldestSuspendNewEffectQueue`.")
+
+        // Wait until 3rd effect is finished.
+        await tick(1.5)
+
+        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 3),
+                    "`effectCompletedCount` should increment by 3 because of `OldestSuspendNewEffectQueue`.")
+
+        // 4th `increment`.
+        await actomaton.send(.increment)
+        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 3))
+
+        await tick(1.5)
+
+        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 4))
+
+        let results = await resultsCollector.results.sorted()
+        XCTAssertEqual(results, [], "Should be empty because no cancellation won't happen in this policy.")
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case increment
+    case effectCompleted
+}
+
+private struct State: Equatable
+{
+    var count: Int = 0
+    var effectCompletedCount: Int = 0
+}


### PR DESCRIPTION
This PR refactors `Actomaton` to support **EffectQueue** where the original idea is derived from [Harvest](https://github.com/inamiy/Harvest) and reactive programming (Rx).

In a nutshell, this PR adds **`EffectQueuePolicy` to let multiple effects run sequentially, suspend and run 1 by 1, or discard newest (e.g. preventing chattering actions)**:

```swift
/// `EffectQueueProtocol`'s buffering policy.
public enum EffectQueuePolicy: Hashable
{
    /// Runs `maxCount` newest effects, cancelling old running effects.
    case runNewest(maxCount: Int)

    /// Runs `maxCount` old effects with either suspending or discarding new effects.
    case runOldest(maxCount: Int, OverflowPolicy)

    public enum OverflowPolicy
    {
        /// Suspends new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
        case suspendNew

        /// Discards new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
        case discardNew
    }
}
```

If one is familiar with Rx:

- `.runNewest(maxCount: n)` works like `flatMapLatest` (up to latest `n` count)
- `.runOldest(maxCount: n, .suspendNew)` works like `flatMapConcat`
- `.runOldest(maxCount: n, .discardNew)` works like `flatMapFirst`

So that more fine-grained effect management becomes possible.

Note that without this feature, **one usually needs to manage effect queue manually by adding verbose `Action` cases and `State` flag / queue**, for example:

```swift
// runOld suspendNew
Reducer { action, state, _ in
    switch action {
    case .run:
        let effect = Effect {
            ...
            return .completed 
        }
        if state.isRunning {
            state.pendingEffs.append(effect)
            return .empty
         } else {
            state.isRunning = true
            return effect
        }
    case .completed:
        state.isRunning = false
        if let pendingEffect = state.pendingEffects.removeFirst() {
            state.isRunning = true
            return pendingEffect
        } else {
            return .empty
        }
    }
}
```

or:

```swift
// runOld discardNew
Reducer { action, state, _ in
    switch action {
    case .run:
        if state.isRunning {
            return .empty
        } else {
            state.isRunning = true
            return Effect {
                ...
                return .completed 
            }
        }
    case .completed:
        state.isRunning = false
        return .empty
    }
}
```

### Important Change from `0.1.0`

As `EffectQueue` is introduced in this PR, **automatic cancellation of previous effect with same `EffectID` is no longer supported by default** (superseded by `EffectQueuePolicy.runNewest`), and `EffectID` will now be used for **manual cancellation only**.
(Now, `EffectID` and `EffectQueue` clearly separates the domain of concerns)

Note that multiple effects with same `EffectID` can now run concurrently, so one can perform bulk-cancellation too.