### PR TITLE
[Actomaton] Fix running tasks retaining `Actomaton`

### DIFF
--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Actomaton
+
+import Combine
+
+/// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
+final class DeinitTests: XCTestCase
+{
+    fileprivate var actomaton: Actomaton<Action, State>!
+
+    fileprivate var resultsCollector: ResultsCollector<Int> = .init()
+
+    override func setUp() async throws
+    {
+        self.resultsCollector = ResultsCollector<Int>()
+
+        let actomaton = Actomaton<Action, State>(
+            state: State(),
+            reducer: Reducer { [resultsCollector] action, state, _ in
+                Debug.print("===> \(action)")
+                state.count += 1
+
+                return Effect { [state, resultsCollector] in
+                    await tick(1)
+                    if Task.isCancelled {
+                        Debug.print("Effect cancelled")
+                        await resultsCollector.append(state.count)
+                        return nil
+                    }
+                    return .next
+                }
+            }
+        )
+        self.actomaton = actomaton
+    }
+
+    func test_deinit() async throws
+    {
+        weak var weakActomaton = self.actomaton
+
+        let task = await actomaton.send(.next)
+        await tick(2.5)
+
+        self.actomaton = nil
+        XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
+
+        await task?.value
+
+        let results = await resultsCollector.results
+        XCTAssertEqual(
+            results, [],
+            """
+            Will be empty because task cancellation won't normally take place.
+            Instead, next task won't even get started because of `send` not working
+            due to missing Actomaton.
+            """
+        )
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case next
+}
+
+private struct State
+{
+    var count: Int = 0
+
+    init() {}
+}


### PR DESCRIPTION
This PR fixes running `Task`s retaining `Actomaton` which may cause memory-leak issue
when infinite action feedback loop is taken place (though it's rather rare situation).

This PR fixes by using `[weak self]` inside `Task`'s closure 
so that consecutive effects won't run after `Actomaton` is deinit-ed.

See `DeinitTests` for more info.

This issue exists in [ver 0.1.0](https://github.com/inamiy/Actomaton/releases/tag/0.1.0) and will be fixed by this PR in ver 0.2.0.