### PR TITLE
[ActomatonStore] Remove `Proxy.map(action:)`

### DIFF
--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -81,13 +81,6 @@ extension Store.Proxy
     {
         .init(state: self.$state, send: { self.send(f($0), priority: $1, tracksFeedbacks: $2) })
     }
-
-    /// Transforms `Action` to `Action2` using casePath.
-    public func map<Action2>(action: CasePath<Action, Action2>)
-        -> Store<Action2, State>.Proxy
-    {
-        self.contramap(action: action.embed)
-    }
 }
 
 // MARK: - Traversable


### PR DESCRIPTION
This PR partly reverts #4 `Store.Proxy.map(action: CasePath)` as existing `contramap` is usually sufficient.

- #4 