### PR TITLE
Use Swift Concurrency back-deploy to support macOS 10.15, iOS 13, tvOS 13, and watchOS 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Actomaton",
-    platforms: [.macOS(.v12), .iOS(.v15), .watchOS(.v8), .tvOS(.v15)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v6), .tvOS(.v13)],
     products: [
         .library(
             name: "Actomaton",


### PR DESCRIPTION
Xcode 13.2 Beta now allows **Swift Concurrency back-deploy** to support macOS 10.15, iOS 13, tvOS 13, and watchOS 6.

So far the functionality works as expected in [Actomaton-Gallery](https://github.com/inamiy/Actomaton-Gallery) 
(tested with iOS 14 simulator, with noticing slow-down than iOS 15 simulator which I haven't elaborated further yet).

See below for more details:

- [Xcode 13.2 Beta Release Notes | Apple Developer Documentation](https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2-release-notes)