### PR TITLE
Support `async throws` functions for Effect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ let actomaton = Actomaton<Action, State>(
 @main
 enum Main {
     static func test_login_logout() async {
-        var t: Task<(), Never>?
+        var t: Task<(), Error>?
 
         assertEqual(await actomaton.state, .loggedOut)
 
@@ -215,7 +215,7 @@ enum Main {
     }
 
     static func test_login_forceLogout() async throws {
-        var t: Task<(), Never>?
+        var t: Task<(), Error>?
 
         assertEqual(await actomaton.state, .loggedOut)
 
@@ -236,11 +236,11 @@ enum Main {
 }
 ```
 
-Here we see the notions of `EffectID`, `Environment`, and `let task: Task<(), Never> = actomaton.send(...)`
+Here we see the notions of `EffectID`, `Environment`, and `let task: Task<(), Error> = actomaton.send(...)`
 
 - `EffectID` is for both manual & automatic cancellation of previous running effects. In this example, `forceLogout` will cancel `login`'s networking effect.
 - `Environment` is useful for injecting effects to be called inside `Reducer` so that they become replaceable. **`Environment` is known as Dependency Injection** (using Reader monad).
-- (Optional) `Task<(), Never>` returned from `actomaton.send(action)` is another fancy way of dealing with "all the effects triggered by `action`". We can call `await task.value` to wait for all of them to be completed, or `task.cancel()` to cancel all. Note that `Actomaton` already manages such `task`s for us internally, so we normally don't need to handle them by ourselves (use this as a last resort!).
+- (Optional) `Task<(), Error>` returned from `actomaton.send(action)` is another fancy way of dealing with "all the effects triggered by `action`". We can call `await task.value` to wait for all of them to be completed, or `task.cancel()` to cancel all. Note that `Actomaton` already manages such `task`s for us internally, so we normally don't need to handle them by ourselves (use this as a last resort!).
 
 ### Example 1-3. Timer (using `AsyncSequence`)
 

--- a/Sources/Actomaton/Effect.swift
+++ b/Sources/Actomaton/Effect.swift
@@ -11,14 +11,14 @@ extension Effect
     // MARK: - Single async
 
     /// Single-`async` side-effect.
-    public init(run: @escaping () async -> Action?)
+    public init(run: @escaping () async throws -> Action?)
     {
         self.init(kinds: [.single(Single(id: nil, queue: nil, run: run))])
     }
 
     /// Single-`async` side-effect.
     /// - Parameter id: Cancellation identifier.
-    public init<ID>(id: ID? = nil, run: @escaping () async -> Action?)
+    public init<ID>(id: ID? = nil, run: @escaping () async throws -> Action?)
         where ID: EffectIDProtocol
     {
         self.init(kinds: [.single(Single(id: id, queue: nil, run: run))])
@@ -26,7 +26,7 @@ extension Effect
 
     /// Single-`async` side-effect.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<Queue>(queue: Queue? = nil, run: @escaping () async -> Action?)
+    public init<Queue>(queue: Queue? = nil, run: @escaping () async throws -> Action?)
         where Queue: EffectQueueProtocol
     {
         self.init(kinds: [.single(Single(id: nil, queue: queue.map(AnyEffectQueue.init), run: run))])
@@ -35,7 +35,7 @@ extension Effect
     /// Single-`async` side-effect.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @escaping () async -> Action?)
+    public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @escaping () async throws -> Action?)
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
         self.init(kinds: [.single(Single(id: id, queue: queue.map(AnyEffectQueue.init), run: run))])
@@ -79,10 +79,10 @@ extension Effect
     // MARK: - fireAndForget
 
     /// Single-`async` side-effect without returning next action.
-    public static func fireAndForget(run: @escaping () async -> ()) -> Effect<Action>
+    public static func fireAndForget(run: @escaping () async throws -> ()) -> Effect<Action>
     {
         self.init(run: {
-            await run()
+            try await run()
             return nil
         })
     }
@@ -91,12 +91,12 @@ extension Effect
     /// - Parameter id: Cancellation identifier.
     public static func fireAndForget<ID>(
         id: ID? = nil,
-        run: @escaping () async -> ()
+        run: @escaping () async throws -> ()
     ) -> Effect<Action>
         where ID: EffectIDProtocol
     {
         self.init(id: id, run: {
-            await run()
+            try await run()
             return nil
         })
     }
@@ -105,12 +105,12 @@ extension Effect
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func fireAndForget<Queue>(
         queue: Queue? = nil,
-        run: @escaping () async -> ()
+        run: @escaping () async throws -> ()
     ) -> Effect<Action>
         where Queue: EffectQueueProtocol
     {
         self.init(queue: queue, run: {
-            await run()
+            try await run()
             return nil
         })
     }
@@ -121,12 +121,12 @@ extension Effect
     public static func fireAndForget<ID, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
-        run: @escaping () async -> ()
+        run: @escaping () async throws -> ()
     ) -> Effect<Action>
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
         self.init(id: id, queue: queue, run: {
-            await run()
+            try await run()
             return nil
         })
     }
@@ -314,9 +314,9 @@ extension Effect
     {
         internal let id: EffectID?
         internal let queue: AnyEffectQueue?
-        internal let run: () async -> Action?
+        internal let run: () async throws -> Action?
 
-        internal init(id: EffectID? = nil, queue: AnyEffectQueue? = nil, run: @escaping () async -> Action?)
+        internal init(id: EffectID? = nil, queue: AnyEffectQueue? = nil, run: @escaping () async throws -> Action?)
         {
             self.id = id
             self.queue = queue
@@ -326,7 +326,7 @@ extension Effect
         internal func map<Action2>(action f: @escaping (Action) -> Action2) -> Effect<Action2>.Single
         {
             .init(id: id, queue: queue) {
-                (await run()).map(f)
+                (try await run()).map(f)
             }
         }
 

--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -10,12 +10,12 @@ extension Store
         @Binding
         public private(set) var state: State
 
-        private let _send: (Action, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Never>?
+        private let _send: (Action, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Error>?
 
         /// Designated initializer with receiving `send` from single-source-of-truth `Store`.
         public init(
             state: Binding<State>,
-            send: @escaping (Action, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Never>?
+            send: @escaping (Action, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Error>?
         )
         {
             self._state = state
@@ -48,7 +48,7 @@ extension Store
             _ action: Action,
             priority: TaskPriority? = nil,
             tracksFeedbacks: Bool = false
-        ) -> Task<(), Never>?
+        ) -> Task<(), Error>?
         {
             self._send(action, priority, tracksFeedbacks)
         }

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -65,7 +65,7 @@ open class Store<Action, State>: ObservableObject
 // To call these methods, use `proxy` instead.
 extension Store
 {
-    private nonisolated func send(_ action: Action, priority: TaskPriority? = nil, tracksFeedbacks: Bool) -> Task<(), Never>
+    private nonisolated func send(_ action: Action, priority: TaskPriority? = nil, tracksFeedbacks: Bool) -> Task<(), Error>
     {
         Task(priority: priority) {
             await self.actomaton.send(.action(action), priority: priority, tracksFeedbacks: tracksFeedbacks)

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -44,7 +44,7 @@ final class DeinitTests: XCTestCase
         self.actomaton = nil
         XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
 
-        await task?.value
+        try await task?.value
 
         let results = await resultsCollector.results
         XCTAssertEqual(

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -45,7 +45,7 @@ final class FeedbackTrackingTaskTests: XCTestCase
 
                     state = ._4(count: 0)
                     return Effect(sequence: AsyncStream<Action> { continuation in
-                        let task = Task<(), Never> {
+                        let task = Task<(), Error> {
                             for _ in 1 ... 2 {
                                 await tick(1)
                                 if Task.isCancelled {
@@ -119,7 +119,7 @@ final class FeedbackTrackingTaskTests: XCTestCase
         let task = await actomaton.send(._1To2, tracksFeedbacks: false)
 
         // Wait for `._1To2`'s effect only (upto `_2To3`'s next state-transition without its effect)
-        await task?.value
+        try await task?.value
 
         assertEqual(await actomaton.state, ._3,
                     """
@@ -155,7 +155,7 @@ final class FeedbackTrackingTaskTests: XCTestCase
         let task = await actomaton.send(._1To2, tracksFeedbacks: true)
 
         // Wait for all: `._1To2`, `._2To3`, `._3To4`, `._increment`, `._4To5`, `._5To6`.
-        await task?.value
+        try await task?.value
 
         assertEqual(await actomaton.state, ._6,
                     "Should wait for final result `._6` because `tracksFeedbacks = true`")
@@ -172,7 +172,7 @@ final class FeedbackTrackingTaskTests: XCTestCase
         let task = await actomaton.send(._3To4, tracksFeedbacks: true)
 
         // Wait for all: `._3To4`, `._increment`, `._4To5`, `._5To6`.
-        await task?.value
+        try await task?.value
 
         assertEqual(await actomaton.state, ._6,
                     "Should wait for final result `._5` because `tracksFeedbacks = true`")

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -76,20 +76,20 @@ final class LoginLogoutTests: XCTestCase
     // `loggedOut => loggingIn => loggedIn => loggingOut => loggedOut` succeeds.
     func test_login_logout() async throws
     {
-        var t: Task<(), Never>?
+        var t: Task<(), Error>?
 
         assertEqual(await actomaton.state, .loggedOut)
 
         t = await actomaton.send(.login)
         assertEqual(await actomaton.state, .loggingIn)
 
-        await t?.value // wait for previous effect
+        try await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedIn)
 
         t = await actomaton.send(.logout)
         assertEqual(await actomaton.state, .loggingOut)
 
-        await t?.value // wait for previous effect
+        try await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
 
         XCTAssertFalse(isLoginCancelled)
@@ -98,7 +98,7 @@ final class LoginLogoutTests: XCTestCase
     // `loggedOut => loggingIn ==(ForceLogout)==> loggingOut => loggedOut` succeeds.
     func test_login_forceLogout() async throws
     {
-        var t: Task<(), Never>?
+        var t: Task<(), Error>?
 
         assertEqual(await actomaton.state, .loggedOut)
 
@@ -111,7 +111,7 @@ final class LoginLogoutTests: XCTestCase
 
         assertEqual(await actomaton.state, .loggingOut)
 
-        await t?.value // wait for previous effect
+        try await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
 
         XCTAssertTrue(isLoginCancelled,


### PR DESCRIPTION
This PR refactors Actomaton effect handling by also supporting `async throws` functions.