### PR TITLE
[Actomaton] Add internal `DefaultEffectID` to always be able to cancel on `deinit`

### DIFF
--- a/Sources/Actomaton/EffectID.swift
+++ b/Sources/Actomaton/EffectID.swift
@@ -3,3 +3,6 @@ public typealias EffectID = AnyHashable
 
 /// A protocol that every effect-identifier should conform to.
 public protocol EffectIDProtocol: Hashable {}
+
+/// Default anonymous efffect.
+internal struct DefaultEffectID: EffectIDProtocol {}


### PR DESCRIPTION
This PR adds internal `DefaultEffectID` to always track running `Task`s so that
Actomaton can cancel them on `deinit`, even when users don't track them manually.