### PR TITLE
Add ActomatonDebugging (using CustomDump)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -9,6 +9,24 @@
           "revision": "d226d167bd4a68b51e352af5655c92bce8ee0463",
           "version": "0.7.0"
         }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,14 @@ let package = Package(
     products: [
         .library(
             name: "Actomaton",
-            targets: ["Actomaton"]),
+            targets: ["Actomaton", "ActomatonDebugging"]),
         .library(
             name: "ActomatonStore",
-            targets: ["ActomatonStore"]),
+            targets: ["ActomatonStore", "ActomatonDebugging"])
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0")
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0")
     ],
     targets: [
         .target(
@@ -25,6 +26,12 @@ let package = Package(
             dependencies: [
                 "Actomaton",
                 .product(name: "CasePaths", package: "swift-case-paths")
+            ]),
+        .target(
+            name: "ActomatonDebugging",
+            dependencies: [
+                "Actomaton",
+                .product(name: "CustomDump", package: "swift-custom-dump")
             ]),
         .testTarget(
             name: "ActomatonTests",

--- a/Sources/ActomatonDebugging/Reducer+Debugging.swift
+++ b/Sources/ActomatonDebugging/Reducer+Debugging.swift
@@ -1,0 +1,113 @@
+import Actomaton
+
+#if DEBUG
+import CustomDump
+#endif
+
+extension Reducer
+{
+    /// Convenient constructor for debug-logging `Action` and `State` before target reducer's run,
+    /// either by replacing `targetReducer = Reducer.init { ... }` with `Reducer.debug { ... }`
+    /// or prepending as `Reducer.debug() + targetReducer`.
+    ///
+    /// - Warning: Only for debugging purpose, so should not use in production.
+    public static func debug(
+        name: String? = nil,
+        action actionDebugStyle: ReducerDebugLogStyle? = .all(maxDepth: .max),
+        state stateDebugStyle: ReducerDebugLogStyle? = .all(maxDepth: .max),
+        _ nextRun: @escaping (Action, inout State, Environment) -> Effect<Action> = Reducer.empty.run
+    ) -> Reducer
+    {
+#if DEBUG
+        .init { action, state, environment in
+            let state = state // Needs copy to not carry `inout`.
+            return .fireAndForget {
+                let name = name.map { "\($0) " } ?? ""
+
+                if let actionDebugStyle = actionDebugStyle {
+                    switch actionDebugStyle.style {
+                    case .simple:
+                        print("\(name)action = \(debugCaseOutput(action))")
+
+                    case let .all(maxDepth):
+                        print("\(name)action = ", terminator: "") // NOTE: No linebreak before `customDump`.
+                        customDump(action, maxDepth: maxDepth)
+                    }
+                }
+
+                if let stateDebugStyle = stateDebugStyle {
+                    print("\(name)state = ", terminator: "") // NOTE: No linebreak before `customDump`.
+
+                    switch stateDebugStyle.style {
+                    case .simple:
+                        var output = ""
+                        customDump(state, to: &output, maxDepth: 1)
+                        output = output.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                        print(output)
+
+                    case let .all(maxDepth):
+                        customDump(state, maxDepth: maxDepth)
+                    }
+                }
+            }
+        }
+        + .init(nextRun)
+#else
+        .init(nextRun)
+#endif
+    }
+}
+
+/// Debug-logging style for `Reducer.debug` .
+public struct ReducerDebugLogStyle: Equatable
+{
+    fileprivate let style: _DebugStyle
+
+    /// Simple oneline-printing mode.
+    public static let simple: ReducerDebugLogStyle = ReducerDebugLogStyle(style: .simple)
+
+    /// Uses `CustomDump` to multiline-print all data.
+    public static func all(maxDepth: Int = .max) -> ReducerDebugLogStyle
+    {
+        ReducerDebugLogStyle(style: .all(maxDepth: maxDepth))
+    }
+
+    enum _DebugStyle: Equatable
+    {
+        case simple
+        case all(maxDepth: Int = .max)
+    }
+}
+
+// MARK: - Private
+
+// Code from swift-composable-architecture:
+// https://github.com/pointfreeco/swift-composable-architecture/blob/0.33.0/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+private func debugCaseOutput(_ value: Any) -> String {
+    func debugCaseOutputHelp(_ value: Any) -> String {
+        let mirror = Mirror(reflecting: value)
+        switch mirror.displayStyle {
+        case .enum:
+            guard let child = mirror.children.first else {
+                let childOutput = "\(value)"
+                return childOutput == "\(type(of: value))" ? "" : ".\(childOutput)"
+            }
+            let childOutput = debugCaseOutputHelp(child.value)
+            return ".\(child.label ?? "")\(childOutput.isEmpty ? "" : "(\(childOutput))")"
+        case .tuple:
+            return mirror.children.map { label, value in
+                let childOutput = debugCaseOutputHelp(value)
+                return "\(label.map { isUnlabeledArgument($0) ? "_:" : "\($0):" } ?? "")\(childOutput.isEmpty ? "" : " \(childOutput)")"
+            }
+            .joined(separator: ", ")
+        default:
+            return ""
+        }
+    }
+
+    return "\(type(of: value))\(debugCaseOutputHelp(value))"
+}
+
+private func isUnlabeledArgument(_ label: String) -> Bool {
+    label.firstIndex(where: { $0 != "." && !$0.isNumber }) == nil
+}


### PR DESCRIPTION
This PR adds a new `ActomatonDebugging` module which uses [CustomDump](https://github.com/pointfreeco/swift-custom-dump) to pretty-print actions and states via `Reducer.debug` .

Also, this PR uses nested enum case pretty-printing technique from:
https://github.com/pointfreeco/swift-composable-architecture/blob/0.33.0/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift