### PR TITLE
[Debugging] Add `StateDebugLogFormat.diff`

### DIFF
--- a/Sources/ActomatonDebugging/Reducer+Debugging.swift
+++ b/Sources/ActomatonDebugging/Reducer+Debugging.swift
@@ -6,26 +6,38 @@ import CustomDump
 
 extension Reducer
 {
-    /// Convenient constructor for debug-logging `Action` and `State` before target reducer's run,
-    /// either by replacing `targetReducer = Reducer.init { ... }` with `Reducer.debug { ... }`
-    /// or prepending as `Reducer.debug() + targetReducer`.
+    /// Debug-logging `Action` and `State` during `self`'s reducer's run.
+    /// - Warning: Only for debugging purpose, so should not use in production.
+    public func debug(
+        name: String? = nil,
+        action actionLogFormat: ActionDebugLogFormat? = .all(maxDepth: .max),
+        state stateLogFormat: StateDebugLogFormat? = .diff
+    ) -> Reducer
+    {
+        Self.debug(name: name, action: actionLogFormat, state: stateLogFormat, self.run)
+    }
+
+    /// Convenient constructor for debug-logging `Action` and `State` during target reducer's run,
+    /// by replacing `targetReducer = Reducer.init { ... }` with `Reducer.debug { ... }`.
     ///
     /// - Warning: Only for debugging purpose, so should not use in production.
     public static func debug(
         name: String? = nil,
-        action actionDebugStyle: ReducerDebugLogStyle? = .all(maxDepth: .max),
-        state stateDebugStyle: ReducerDebugLogStyle? = .all(maxDepth: .max),
+        action actionLogFormat: ActionDebugLogFormat? = .all(maxDepth: .max),
+        state stateLogFormat: StateDebugLogFormat? = .all(maxDepth: .max),
         _ nextRun: @escaping (Action, inout State, Environment) -> Effect<Action> = Reducer.empty.run
     ) -> Reducer
     {
 #if DEBUG
         .init { action, state, environment in
-            let state = state // Needs copy to not carry `inout`.
-            return .fireAndForget {
+            let currentState = state // Needs copy to not carry `inout`.
+
+            /// Effect for  Action & State `.simple` or `.all` printing.
+            let preEffect = Effect<Action>.fireAndForget {
                 let name = name.map { "\($0) " } ?? ""
 
-                if let actionDebugStyle = actionDebugStyle {
-                    switch actionDebugStyle.style {
+                if let actionLogFormat = actionLogFormat {
+                    switch actionLogFormat.format {
                     case .simple:
                         print("\(name)action = \(debugCaseOutput(action))")
 
@@ -35,47 +47,105 @@ extension Reducer
                     }
                 }
 
-                if let stateDebugStyle = stateDebugStyle {
-                    print("\(name)state = ", terminator: "") // NOTE: No linebreak before `customDump`.
-
-                    switch stateDebugStyle.style {
+                if let stateLogFormat = stateLogFormat {
+                    switch stateLogFormat.format {
                     case .simple:
+                        print("\(name)state = ", terminator: "") // NOTE: No linebreak before `customDump`.
+
                         var output = ""
-                        customDump(state, to: &output, maxDepth: 1)
+                        customDump(currentState, to: &output, maxDepth: 1)
                         output = output.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
                         print(output)
 
                     case let .all(maxDepth):
-                        customDump(state, maxDepth: maxDepth)
+                        print("\(name)state = ", terminator: "") // NOTE: No linebreak before `customDump`.
+                        customDump(currentState, maxDepth: maxDepth)
+
+                    case .diff:
+                        break
                     }
                 }
             }
+
+            let effect = nextRun(action, &state, environment)
+
+            let nextState = state // Needs copy to not carry `inout`.
+
+            /// Effect for State's `.diff` printing.
+            let postEffect = Effect<Action>.fireAndForget {
+                if let stateLogFormat = stateLogFormat {
+                    switch stateLogFormat.format {
+                    case .simple, .all:
+                        break
+
+                    case .diff:
+                        let name = name.map { "\($0) " } ?? ""
+
+                        if let diffString = diff(currentState, nextState) {
+                            print("\(name)state diff = ") // NOTE: Adds linebreak because `diffString` contains +- symbols.
+                            print(diffString)
+                        }
+                    }
+                }
+            }
+
+            return preEffect + effect + postEffect
         }
-        + .init(nextRun)
 #else
         .init(nextRun)
 #endif
     }
 }
 
-/// Debug-logging style for `Reducer.debug` .
-public struct ReducerDebugLogStyle: Equatable
+// MARK: - ActionDebugLogFormat
+
+/// Action debug-logging format for `Reducer.debug` .
+/// Available formats are: ``simple``, ``all(maxDepth:)``.
+public struct ActionDebugLogFormat: Equatable
 {
-    fileprivate let style: _DebugStyle
+    fileprivate let format: _LogFormat
 
     /// Simple oneline-printing mode.
-    public static let simple: ReducerDebugLogStyle = ReducerDebugLogStyle(style: .simple)
+    public static let simple = ActionDebugLogFormat(format: .simple)
 
     /// Uses `CustomDump` to multiline-print all data.
-    public static func all(maxDepth: Int = .max) -> ReducerDebugLogStyle
+    public static func all(maxDepth: Int = .max) -> ActionDebugLogFormat
     {
-        ReducerDebugLogStyle(style: .all(maxDepth: maxDepth))
+        ActionDebugLogFormat(format: .all(maxDepth: maxDepth))
     }
 
-    enum _DebugStyle: Equatable
+    fileprivate enum _LogFormat: Equatable
     {
         case simple
         case all(maxDepth: Int = .max)
+    }
+}
+
+// MARK: - StateDebugLogFormat
+
+/// State debug-logging format for `Reducer.debug` .
+/// Available formats are: ``simple``, ``all(maxDepth:)``, ``diff``.
+public struct StateDebugLogFormat: Equatable
+{
+    fileprivate let format: _LogFormat
+
+    /// Simple oneline-printing mode.
+    public static let simple = StateDebugLogFormat(format: .simple)
+
+    /// Uses `CustomDump` to multiline-print all data.
+    public static func all(maxDepth: Int = .max) -> StateDebugLogFormat
+    {
+        StateDebugLogFormat(format: .all(maxDepth: maxDepth))
+    }
+
+    /// State diff-printing.
+    public static let diff = StateDebugLogFormat(format: .diff)
+
+    fileprivate enum _LogFormat: Equatable
+    {
+        case simple
+        case all(maxDepth: Int = .max)
+        case diff
     }
 }
 


### PR DESCRIPTION
Successor of:
- #27

This PR enhances #27 by adding state-`diff` format from CustomDump so that gigantic state printing will be narrowed down to only show important diffs.

Also, there are some additions and renaming of #27 's new APIs.