### PR TITLE
Add `Sendable` conformances, `-warn-concurrency` & `-enable-actor-data-race-checks` compiler options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,27 @@ let package = Package(
     targets: [
         .target(
             name: "Actomaton",
-            dependencies: [.product(name: "CasePaths", package: "swift-case-paths")]),
+            dependencies: [.product(name: "CasePaths", package: "swift-case-paths")],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        ),
         .target(
             name: "ActomatonStore",
             dependencies: [
                 "Actomaton",
                 .product(name: "CasePaths", package: "swift-case-paths")
-            ]),
+            ],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        ),
         .target(
             name: "ActomatonDebugging",
             dependencies: [
@@ -35,6 +49,13 @@ let package = Package(
             ]),
         .testTarget(
             name: "ActomatonTests",
-            dependencies: ["Actomaton"]),
+            dependencies: ["Actomaton"],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        )
     ]
 )

--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -5,6 +5,7 @@ import Foundation
 /// Deterministic finite state machine that receives "action"
 /// and with "current state" transform to "next state" & additional "effect".
 public actor Actomaton<Action, State>
+    where Action: Sendable, State: Sendable
 {
 #if os(Linux)
     public private(set) var state: State
@@ -40,7 +41,7 @@ public actor Actomaton<Action, State>
         state: State,
         reducer: Reducer<Action, State, Environment>,
         environment: Environment
-    )
+    ) where Environment: Sendable
     {
         self.init(state: state, reducer: Reducer { action, state, _ in
             reducer.run(action, &state, environment)

--- a/Sources/Actomaton/Effect.swift
+++ b/Sources/Actomaton/Effect.swift
@@ -11,14 +11,14 @@ extension Effect
     // MARK: - Single async
 
     /// Single-`async` side-effect.
-    public init(run: @escaping () async throws -> Action?)
+    public init(run: @Sendable @escaping () async throws -> Action?)
     {
         self.init(kinds: [.single(Single(id: nil, queue: nil, run: run))])
     }
 
     /// Single-`async` side-effect.
     /// - Parameter id: Cancellation identifier.
-    public init<ID>(id: ID? = nil, run: @escaping () async throws -> Action?)
+    public init<ID>(id: ID? = nil, run: @Sendable @escaping () async throws -> Action?)
         where ID: EffectIDProtocol
     {
         self.init(kinds: [.single(Single(id: id, queue: nil, run: run))])
@@ -26,7 +26,7 @@ extension Effect
 
     /// Single-`async` side-effect.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<Queue>(queue: Queue? = nil, run: @escaping () async throws -> Action?)
+    public init<Queue>(queue: Queue? = nil, run: @Sendable @escaping () async throws -> Action?)
         where Queue: EffectQueueProtocol
     {
         self.init(kinds: [.single(Single(id: nil, queue: queue.map(AnyEffectQueue.init), run: run))])
@@ -35,7 +35,7 @@ extension Effect
     /// Single-`async` side-effect.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @escaping () async throws -> Action?)
+    public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @Sendable @escaping () async throws -> Action?)
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
         self.init(kinds: [.single(Single(id: id, queue: queue.map(AnyEffectQueue.init), run: run))])
@@ -46,7 +46,7 @@ extension Effect
     /// `AsyncSequence` side-effect.
     /// - Parameter id: Cancellation identifier.
     public init<S>(sequence: S)
-        where S: AsyncSequence, S.Element == Action
+        where S: AsyncSequence, S: Sendable, S.Element == Action
     {
         self.init(kinds: [.sequence(_Sequence(id: nil, queue: nil, sequence: sequence.typeErased))])
     }
@@ -54,7 +54,7 @@ extension Effect
     /// `AsyncSequence` side-effect.
     /// - Parameter id: Cancellation identifier.
     public init<ID, S>(id: ID? = nil, sequence: S)
-        where ID: EffectIDProtocol, S: AsyncSequence, S.Element == Action
+        where ID: EffectIDProtocol, S: AsyncSequence, S: Sendable, S.Element == Action
     {
         self.init(kinds: [.sequence(_Sequence(id: id, queue: nil, sequence: sequence.typeErased))])
     }
@@ -62,7 +62,7 @@ extension Effect
     /// `AsyncSequence` side-effect.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<S, Queue>(queue: Queue? = nil, sequence: S)
-        where S: AsyncSequence, S.Element == Action, Queue: EffectQueueProtocol
+        where S: AsyncSequence, S: Sendable, S.Element == Action, Queue: EffectQueueProtocol
     {
         self.init(kinds: [.sequence(_Sequence(id: nil, queue: queue.map(AnyEffectQueue.init), sequence: sequence.typeErased))])
     }
@@ -71,7 +71,7 @@ extension Effect
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<ID, S, Queue>(id: ID? = nil, queue: Queue? = nil, sequence: S)
-        where ID: EffectIDProtocol, S: AsyncSequence, S.Element == Action, Queue: EffectQueueProtocol
+        where ID: EffectIDProtocol, S: AsyncSequence, S: Sendable, S.Element == Action, Queue: EffectQueueProtocol
     {
         self.init(kinds: [.sequence(_Sequence(id: id, queue: queue.map(AnyEffectQueue.init), sequence: sequence.typeErased))])
     }
@@ -79,7 +79,7 @@ extension Effect
     // MARK: - fireAndForget
 
     /// Single-`async` side-effect without returning next action.
-    public static func fireAndForget(run: @escaping () async throws -> ()) -> Effect<Action>
+    public static func fireAndForget(run: @Sendable @escaping () async throws -> ()) -> Effect<Action>
     {
         self.init(run: {
             try await run()
@@ -91,7 +91,7 @@ extension Effect
     /// - Parameter id: Cancellation identifier.
     public static func fireAndForget<ID>(
         id: ID? = nil,
-        run: @escaping () async throws -> ()
+        run: @Sendable @escaping () async throws -> ()
     ) -> Effect<Action>
         where ID: EffectIDProtocol
     {
@@ -105,7 +105,7 @@ extension Effect
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func fireAndForget<Queue>(
         queue: Queue? = nil,
-        run: @escaping () async throws -> ()
+        run: @Sendable @escaping () async throws -> ()
     ) -> Effect<Action>
         where Queue: EffectQueueProtocol
     {
@@ -121,7 +121,7 @@ extension Effect
     public static func fireAndForget<ID, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
-        run: @escaping () async throws -> ()
+        run: @Sendable @escaping () async throws -> ()
     ) -> Effect<Action>
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
@@ -135,6 +135,7 @@ extension Effect
 
     /// No `async` side-effect, only returning next action.
     public static func nextAction(_ action: Action) -> Effect<Action>
+        where Action: Sendable
     {
         self.init(kinds: [.single(Single { action })])
     }
@@ -142,7 +143,7 @@ extension Effect
     // MARK: - cancel
 
     /// Cancels running `async`s by specifying `ids`.
-    public static func cancel(ids: @escaping (EffectID) -> Bool) -> Effect<Action>
+    public static func cancel(ids: @Sendable @escaping (EffectID) -> Bool) -> Effect<Action>
     {
         Effect(kinds: [.cancel(ids)])
     }
@@ -185,7 +186,7 @@ extension Effect
 extension Effect
 {
     /// Changes `Action`.
-    public func map<Action2>(_ f: @escaping (Action) -> Action2) -> Effect<Action2>
+    public func map<Action2>(_ f: @Sendable @escaping (Action) -> Action2) -> Effect<Action2>
     {
         .init(kinds: self.kinds.map { kind in
             switch kind {
@@ -260,11 +261,11 @@ extension Effect
 
 extension Effect
 {
-    internal enum Kind
+    internal enum Kind: Sendable
     {
         case single(Single)
         case sequence(_Sequence)
-        case cancel((EffectID) -> Bool)
+        case cancel(@Sendable (EffectID) -> Bool)
 
         internal var single: Single?
         {
@@ -310,20 +311,20 @@ extension Effect
     }
 
     /// Wrapper of `async`.
-    internal struct Single
+    internal struct Single: Sendable
     {
         internal let id: EffectID?
         internal let queue: AnyEffectQueue?
-        internal let run: () async throws -> Action?
+        internal let run: @Sendable () async throws -> Action?
 
-        internal init(id: EffectID? = nil, queue: AnyEffectQueue? = nil, run: @escaping () async throws -> Action?)
+        internal init(id: EffectID? = nil, queue: AnyEffectQueue? = nil, run: @Sendable @escaping () async throws -> Action?)
         {
             self.id = id
             self.queue = queue
             self.run = run
         }
 
-        internal func map<Action2>(action f: @escaping (Action) -> Action2) -> Effect<Action2>.Single
+        internal func map<Action2>(action f: @Sendable @escaping (Action) -> Action2) -> Effect<Action2>.Single
         {
             .init(id: id, queue: queue) {
                 (try await run()).map(f)
@@ -344,7 +345,7 @@ extension Effect
     }
 
     /// Wrapper of `AsyncSequence`.
-    internal struct _Sequence
+    internal struct _Sequence: Sendable
     {
         internal let id: EffectID?
         internal let queue: AnyEffectQueue?

--- a/Sources/Actomaton/EffectID.swift
+++ b/Sources/Actomaton/EffectID.swift
@@ -2,7 +2,7 @@
 public typealias EffectID = AnyHashable
 
 /// A protocol that every effect-identifier should conform to.
-public protocol EffectIDProtocol: Hashable {}
+public protocol EffectIDProtocol: Hashable, Sendable {}
 
 /// Default anonymous efffect.
 internal struct DefaultEffectID: EffectIDProtocol {}

--- a/Sources/Actomaton/EffectQueue.swift
+++ b/Sources/Actomaton/EffectQueue.swift
@@ -48,7 +48,7 @@ extension Oldest1SuspendNewEffectQueueProtocol
 
 // MARK: - Internals
 
-struct AnyEffectQueue: EffectQueueProtocol
+struct AnyEffectQueue: EffectQueueProtocol, Sendable
 {
     let queue: EffectQueue
     let effectQueuePolicy: EffectQueuePolicy

--- a/Sources/Actomaton/EffectQueuePolicy.swift
+++ b/Sources/Actomaton/EffectQueuePolicy.swift
@@ -1,5 +1,5 @@
 /// `EffectQueueProtocol`'s buffering policy.
-public enum EffectQueuePolicy: Hashable
+public enum EffectQueuePolicy: Hashable, Sendable
 {
     /// Runs `maxCount` newest effects, cancelling old running effects.
     case runNewest(maxCount: Int)
@@ -7,7 +7,7 @@ public enum EffectQueuePolicy: Hashable
     /// Runs `maxCount` old effects with either suspending or discarding new effects.
     case runOldest(maxCount: Int, OverflowPolicy)
 
-    public enum OverflowPolicy
+    public enum OverflowPolicy: Sendable
     {
         /// Suspends new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
         case suspendNew

--- a/Sources/Actomaton/Internal/AnyAsyncSequence.swift
+++ b/Sources/Actomaton/Internal/AnyAsyncSequence.swift
@@ -1,11 +1,11 @@
 // Code from: https://github.com/Apodini/Apodini/blob/develop/Sources/ApodiniExtension/AsyncSequenceHelpers/AnyAsyncSequence.swift
 
 /// A type-erased version of a `AsyncSequence` that contains values of type `Element`.
-public struct AnyAsyncSequence<Element>: AsyncSequence
+public struct AnyAsyncSequence<Element>: AsyncSequence, Sendable
 {
-    private let _makeAsyncIterator: () -> AsyncIterator
+    private let _makeAsyncIterator: @Sendable () -> AsyncIterator
 
-    init<S>(_ sequence: S) where S: AsyncSequence, S.Element == Element
+    init<S>(_ sequence: S) where S: AsyncSequence, S: Sendable, S.Element == Element
     {
         self._makeAsyncIterator = {
             AsyncIterator(sequence.makeAsyncIterator())
@@ -46,7 +46,7 @@ extension AnyAsyncSequence {
     }
 }
 
-public extension AsyncSequence
+extension AsyncSequence where Self: Sendable
 {
     var typeErased: AnyAsyncSequence<Element>
     {

--- a/Sources/Actomaton/Reducer.swift
+++ b/Sources/Actomaton/Reducer.swift
@@ -1,9 +1,9 @@
 /// A composable, `State`-transforming function wrapper that is triggered by `Action`.
-public struct Reducer<Action, State, Environment>
+public struct Reducer<Action, State, Environment>: Sendable
 {
-    public let run: (Action, inout State, Environment) -> Effect<Action>
+    public let run: @Sendable (Action, inout State, Environment) -> Effect<Action>
 
-    public init(_ run: @escaping (Action, inout State, Environment) -> Effect<Action>)
+    public init(_ run: @Sendable @escaping (Action, inout State, Environment) -> Effect<Action>)
     {
         self.run = run
     }
@@ -48,7 +48,7 @@ public struct Reducer<Action, State, Environment>
                     &state,
                     environment
                 )
-                .map(toLocalAction.embed)
+                .map { toLocalAction.embed($0) }
         }
     }
 
@@ -86,7 +86,7 @@ public struct Reducer<Action, State, Environment>
 
     /// Transforms `Environment`.
     public func contramap<GlobalEnvironment>(
-        environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment
+        environment toLocalEnvironment: @Sendable @escaping (GlobalEnvironment) -> Environment
     ) -> Reducer<Action, State, GlobalEnvironment>
     {
         .init { action, state, environment in

--- a/Sources/Actomaton/UncheckedSendable.swift
+++ b/Sources/Actomaton/UncheckedSendable.swift
@@ -1,0 +1,13 @@
+import CasePaths
+
+// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
+
+extension AnyHashable: @unchecked Sendable {}
+
+extension AsyncMapSequence: @unchecked Sendable {}
+
+extension AsyncStream: @unchecked Sendable {}
+
+extension WritableKeyPath: @unchecked Sendable {}
+
+extension CasePath: @unchecked Sendable {}

--- a/Sources/ActomatonStore/Effect+Combine.swift
+++ b/Sources/ActomatonStore/Effect+Combine.swift
@@ -5,7 +5,7 @@ import Actomaton
 
 extension Publisher where Failure == Never
 {
-    public func toEffect() -> Effect<Output>
+    public func toEffect() -> Effect<Output> where Output: Sendable
     {
         Effect(sequence: self.toAsyncStream())
     }
@@ -41,6 +41,7 @@ extension Publisher where Failure == Never
 extension Publisher
 {
     public func toResultEffect() -> Effect<Result<Output, Failure>>
+        where Output: Sendable
     {
         self.map(Result.success)
             .catch { Just(.failure($0)) }

--- a/Sources/ActomatonStore/ForEach+Store.swift
+++ b/Sources/ActomatonStore/ForEach+Store.swift
@@ -11,7 +11,8 @@ extension ForEach where Content: View
         @ViewBuilder content: @escaping (Store<Action, C.Element>.Proxy) -> Content
     ) where
         Data == [Zip2Sequence<C.Indices, C>.Element],
-        C: MutableCollection, C: RandomAccessCollection, C.Index: Hashable
+        C: MutableCollection & RandomAccessCollection,
+        C.Index: Hashable & Sendable
     {
         let firstKeyPath = \Zip2Sequence<C.Indices, C>.Element.1
 
@@ -31,8 +32,10 @@ extension ForEach where Content: View
         @ViewBuilder content: @escaping (Store<Action, C.Element>.Proxy) -> Content
     ) where
         Data == [Zip2Sequence<C.Indices, C>.Element],
-        C: MutableCollection, C: RandomAccessCollection, C.Index: Hashable,
-        C.Element: Identifiable, C.Element.ID == ID
+        C: MutableCollection & RandomAccessCollection,
+        C.Index: Hashable & Sendable,
+        C.Element: Identifiable,
+        C.Element.ID == ID
     {
         self.init(store: store, id: \.id, content: content)
     }

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -5,6 +5,7 @@ import Combine
 /// Store of `Actomaton` optimized for SwiftUI's 2-way binding.
 @MainActor
 open class Store<Action, State>: ObservableObject
+    where Action: Sendable, State: Sendable
 {
     private let actomaton: Actomaton<BindableAction, State>
 
@@ -27,7 +28,7 @@ open class Store<Action, State>: ObservableObject
         state initialState: State,
         reducer: Reducer<Action, State, Environment>,
         environment: Environment
-    )
+    ) where Environment: Sendable
     {
         self.state = initialState
 
@@ -114,7 +115,7 @@ extension Store
 
 extension Store {
     /// `action` as indirect messaging, or `state` that can directly replace `actomaton.state` via SwiftUI 2-way binding.
-    fileprivate enum BindableAction
+    fileprivate enum BindableAction: Sendable
     {
         case action(Action)
         case state(State)
@@ -130,7 +131,7 @@ private func lift<Action, State, Environment>(
         switch action {
         case let .action(innerAction):
             let effect = reducer.run(innerAction, &state, environment)
-            return effect.map(Store<Action, State>.BindableAction.action)
+            return effect.map { Store<Action, State>.BindableAction.action($0) }
 
         case let .state(newState):
             state = newState

--- a/Sources/ActomatonStore/UIKit-Support/HostingViewController.swift
+++ b/Sources/ActomatonStore/UIKit-Support/HostingViewController.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// SwiftUI `View` & `Store` wrapper view controller that holds `UIHostingController`.
 @MainActor
 open class HostingViewController<Action, State, V: SwiftUI.View>: UIViewController
+    where Action: Sendable, State: Sendable
 {
     private let rootView: AnyView
 
@@ -66,6 +67,7 @@ open class HostingViewController<Action, State, V: SwiftUI.View>: UIViewControll
 
 /// View to hold `Store` as `@ObservedObject`.
 private struct StoreView<Action, State, V: View>: View
+    where Action: Sendable, State: Sendable
 {
     @ObservedObject
     var store: Store<Action, State>
@@ -89,6 +91,7 @@ private struct StoreView<Action, State, V: View>: View
 
 /// View to hold `Store.ObservableProxy` as `@ObservedObject`.
 private struct ObservableProxyView<Action, State, V: View>: View
+    where Action: Sendable, State: Sendable
 {
     @ObservedObject
     var store: Store<Action, State>.ObservableProxy

--- a/Sources/ActomatonStore/UncheckedSendable.swift
+++ b/Sources/ActomatonStore/UncheckedSendable.swift
@@ -1,0 +1,7 @@
+import Combine
+
+// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
+
+extension PassthroughSubject: @unchecked Sendable {}
+
+extension Published.Publisher: @unchecked Sendable {}

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -8,19 +8,36 @@ final class EffectIDAutoCancellationTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 
-    fileprivate var is1To2Cancelled = false
-    fileprivate var is2To3Cancelled = false
+    private var flags = Flags()
+
+    private actor Flags
+    {
+        var is1To2Cancelled = false
+        var is2To3Cancelled = false
+
+        func mark(
+            is1To2Cancelled: Bool? = nil,
+            is2To3Cancelled: Bool? = nil
+        )
+        {
+            if let is1To2Cancelled = is1To2Cancelled {
+                self.is1To2Cancelled = is1To2Cancelled
+            }
+            if let is2To3Cancelled = is2To3Cancelled {
+                self.is2To3Cancelled = is2To3Cancelled
+            }
+        }
+    }
 
     override func setUp() async throws
     {
-        is1To2Cancelled = false
-        is2To3Cancelled = false
+        flags = Flags()
 
         struct Newest1EffectQueue: Newest1EffectQueueProtocol {}
 
         let actomaton = Actomaton<Action, State>(
             state: ._1,
-            reducer: Reducer { action, state, _ in
+            reducer: Reducer { [flags] action, state, _ in
                 switch action {
                 case ._1To2:
                     guard state == ._1 else { return .empty }
@@ -30,7 +47,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
                         await tick(1)
                         if Task.isCancelled {
                             Debug.print("_1To2 cancelled")
-                            self.is1To2Cancelled = true
+                            await flags.mark(is1To2Cancelled: true)
                             return nil
                         }
                         return ._2To3
@@ -44,7 +61,7 @@ final class EffectIDAutoCancellationTests: XCTestCase
                         await tick(1)
                         if Task.isCancelled {
                             Debug.print("_2To3 cancelled")
-                            self.is2To3Cancelled = true
+                            await flags.mark(is2To3Cancelled: true)
                             return nil
                         }
                         return ._3To4
@@ -90,7 +107,10 @@ final class EffectIDAutoCancellationTests: XCTestCase
         await tick(1.5)
         assertEqual(await actomaton.state, ._4)
 
+        let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertFalse(is1To2Cancelled)
+
+        let is2To3Cancelled = await flags.is2To3Cancelled
         XCTAssertFalse(is2To3Cancelled)
     }
 
@@ -112,7 +132,10 @@ final class EffectIDAutoCancellationTests: XCTestCase
         assertEqual(await actomaton.state, ._end,
                     "Waited for enough time, and state should not change")
 
+        let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertTrue(is1To2Cancelled)
+
+        let is2To3Cancelled = await flags.is2To3Cancelled
         XCTAssertFalse(is2To3Cancelled)
     }
 
@@ -138,7 +161,10 @@ final class EffectIDAutoCancellationTests: XCTestCase
         assertEqual(await actomaton.state, ._end,
                     "Waited for enough time, and state should not change")
 
+        let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertFalse(is1To2Cancelled)
+
+        let is2To3Cancelled = await flags.is2To3Cancelled
         XCTAssertTrue(is2To3Cancelled)
     }
 }

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -181,7 +181,7 @@ final class FeedbackTrackingTaskTests: XCTestCase
 
 // MARK: - Private
 
-private enum Action
+private enum Action: Sendable
 {
     case _1To2
     case _2To3
@@ -192,7 +192,7 @@ private enum Action
     case _toEnd
 }
 
-private enum State: Equatable
+private enum State: Equatable, Sendable
 {
     case _1
     case _2

--- a/Tests/ActomatonTests/Fixtures/UncheckedSendable.swift
+++ b/Tests/ActomatonTests/Fixtures/UncheckedSendable.swift
@@ -1,0 +1,5 @@
+import Combine
+
+// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
+
+extension Published.Publisher: @unchecked Sendable {}

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Combine
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runNewest(maxCount: n)`.
+@MainActor
 final class RunNewestDiscardOldTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Combine
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
+@MainActor
 final class RunOldestDiscardNewTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Combine
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
+@MainActor
 final class RunOldestSuspendNewTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!


### PR DESCRIPTION
This PR adds:

- Swift Concurrency compiler options `-warn-concurrency` and `-enable-actor-data-race-checks` 
as discussed in: [Concurrency in Swift 5 and 6 - Evolution / Discussion - Swift Forums](https://forums.swift.org/t/concurrency-in-swift-5-and-6/49337)
- Conform to `Sendable` / `@Sendable` wherever appropriate
