### PR TITLE
[Actomaton] Introduce `AnySendableHashable` to avoid `extension AnyHashable: @unchecked Sendable`

### DIFF
--- a/Sources/Actomaton/EffectID.swift
+++ b/Sources/Actomaton/EffectID.swift
@@ -1,5 +1,19 @@
 /// Effect identifier for manual cancellation via `Effect.cancel`.
-public typealias EffectID = AnyHashable
+public struct EffectID: Hashable, Sendable
+{
+    private let _value: AnySendableHashable
+
+    internal init<Value>(_ value: Value) where Value: Hashable & Sendable
+    {
+        self._value = AnySendableHashable(value)
+    }
+
+    /// Raw value that conforms to `EffectIDProtocol`.
+    public var value: AnyHashable
+    {
+        _value.value
+    }
+}
 
 /// A protocol that every effect-identifier should conform to.
 public protocol EffectIDProtocol: Hashable, Sendable {}

--- a/Sources/Actomaton/EffectQueue.swift
+++ b/Sources/Actomaton/EffectQueue.swift
@@ -1,8 +1,22 @@
 /// Effect queue for automatic cancellation of existing tasks or suspending of new effects.
-public typealias EffectQueue = AnyHashable
+public struct EffectQueue: Hashable, Sendable
+{
+    private let _value: AnySendableHashable
+
+    internal init<Value>(_ value: Value) where Value: Hashable & Sendable
+    {
+        self._value = AnySendableHashable(value)
+    }
+
+    /// Raw value that conforms to `EffectQueueProtocol`.
+    public var value: AnyHashable
+    {
+        _value.value
+    }
+}
 
 /// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of new effects.
-public protocol EffectQueueProtocol: Hashable
+public protocol EffectQueueProtocol: Hashable, Sendable
 {
     var effectQueuePolicy: EffectQueuePolicy { get }
 }
@@ -56,7 +70,7 @@ struct AnyEffectQueue: EffectQueueProtocol, Sendable
     init<Queue>(_ queue: Queue)
         where Queue: EffectQueueProtocol
     {
-        self.queue = queue
+        self.queue = EffectQueue(queue)
         self.effectQueuePolicy = queue.effectQueuePolicy
     }
 }

--- a/Sources/Actomaton/Internal/AnySendableHashable.swift
+++ b/Sources/Actomaton/Internal/AnySendableHashable.swift
@@ -1,0 +1,20 @@
+/// A wrapper for `AnyHashable` as well as `Sendable`.
+struct AnySendableHashable: Hashable, @unchecked Sendable
+{
+    let value: AnyHashable
+
+    init<Value>(_ value: Value) where Value: Hashable & Sendable
+    {
+        self.value = AnyHashable(value)
+    }
+
+    static func == (l: Self, r: Self) -> Bool
+    {
+        l.value == r.value
+    }
+
+    func hash(into hasher: inout Hasher)
+    {
+        value.hash(into: &hasher)
+    }
+}

--- a/Sources/Actomaton/UncheckedSendable.swift
+++ b/Sources/Actomaton/UncheckedSendable.swift
@@ -2,8 +2,6 @@ import CasePaths
 
 // TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
 
-extension AnyHashable: @unchecked Sendable {}
-
 extension AsyncMapSequence: @unchecked Sendable {}
 extension AsyncStream: @unchecked Sendable {}
 extension AsyncThrowingStream: @unchecked Sendable {}


### PR DESCRIPTION
This PR adds **`AnySendableHashable` that wraps `AnyHashable` as well as conforming to `@unchecked Sendable`**, as this approach is a better implementation than `extension AnyHashable: @unchecked Sendable` in case of some class-based Hashable might also be type-erased into sendable `AnyHashable` which is potentially dangerous.

See also:
https://twitter.com/inamiy/status/1487671398914936835