### PR TITLE
[Actomaton] Refactor AsyncSequence-based Effect by building it via async closure

### DIFF
--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -219,7 +219,9 @@ extension Actomaton
             do {
                 var feedbackTasks: [Task<(), Error>] = []
 
-                for try await nextAction in sequence.sequence {
+                let seq = try await sequence.sequence()
+
+                for try await nextAction in seq {
                     if Task.isCancelled { break }
 
                     // Feed back `nextAction`.

--- a/Sources/Actomaton/Internal/AnyAsyncSequence.swift
+++ b/Sources/Actomaton/Internal/AnyAsyncSequence.swift
@@ -1,11 +1,11 @@
 // Code from: https://github.com/Apodini/Apodini/blob/develop/Sources/ApodiniExtension/AsyncSequenceHelpers/AnyAsyncSequence.swift
 
 /// A type-erased version of a `AsyncSequence` that contains values of type `Element`.
-struct AnyAsyncSequence<Element>: AsyncSequence, Sendable
+struct AnyAsyncSequence<Element>: AsyncSequence
 {
-    private let _makeAsyncIterator: @Sendable () -> AsyncIterator
+    private let _makeAsyncIterator: () -> AsyncIterator
 
-    init<S>(_ sequence: S) where S: AsyncSequence, S: Sendable, S.Element == Element
+    init<S>(_ sequence: S) where S: AsyncSequence, S.Element == Element
     {
         self._makeAsyncIterator = {
             AsyncIterator(sequence.makeAsyncIterator())
@@ -47,7 +47,7 @@ extension AnyAsyncSequence
     }
 }
 
-extension AsyncSequence where Self: Sendable
+extension AsyncSequence
 {
     var typeErased: AnyAsyncSequence<Element>
     {

--- a/Sources/Actomaton/UncheckedSendable.swift
+++ b/Sources/Actomaton/UncheckedSendable.swift
@@ -2,10 +2,6 @@ import CasePaths
 
 // TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
 
-extension AsyncMapSequence: @unchecked Sendable {}
-extension AsyncStream: @unchecked Sendable {}
-extension AsyncThrowingStream: @unchecked Sendable {}
-
 extension WritableKeyPath: @unchecked Sendable {}
 
 extension CasePath: @unchecked Sendable {}

--- a/Sources/ActomatonStore/Effect+Combine.swift
+++ b/Sources/ActomatonStore/Effect+Combine.swift
@@ -3,11 +3,11 @@ import Actomaton
 
 // MARK: - toEffect
 
-extension Publisher
+extension Publisher where Self: Sendable
 {
     public func toEffect() -> Effect<Output>
     {
-        Effect(sequence: self.toAsyncThrowingStream())
+        Effect(sequence: { self.toAsyncThrowingStream() })
     }
 
     public func toEffect<ID>(
@@ -15,7 +15,7 @@ extension Publisher
     ) -> Effect<Output>
         where ID: EffectIDProtocol
     {
-        Effect(id: id, sequence: self.toAsyncThrowingStream())
+        Effect(id: id, sequence: { self.toAsyncThrowingStream() })
     }
 
     public func toEffect<Queue>(
@@ -23,7 +23,7 @@ extension Publisher
     ) -> Effect<Output>
         where Queue: EffectQueueProtocol
     {
-        Effect(queue: queue, sequence: self.toAsyncThrowingStream())
+        Effect(queue: queue, sequence: { self.toAsyncThrowingStream() })
     }
 
     public func toEffect<ID, Queue>(
@@ -32,7 +32,7 @@ extension Publisher
     ) -> Effect<Output>
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
-        Effect(id: id, queue: queue, sequence: self.toAsyncThrowingStream())
+        Effect(id: id, queue: queue, sequence: { self.toAsyncThrowingStream() })
     }
 }
 
@@ -44,6 +44,7 @@ extension Publisher
     {
         self.map(Result.success)
             .catch { Just(.failure($0)) }
+            .eraseToAnyPublisher() // NOTE: For `@unchecked Sendable`
             .toEffect()
     }
 
@@ -54,6 +55,7 @@ extension Publisher
     {
         self.map(Result.success)
             .catch { Just(.failure($0)) }
+            .eraseToAnyPublisher() // NOTE: For `@unchecked Sendable`
             .toEffect(id: id)
     }
 
@@ -64,6 +66,7 @@ extension Publisher
     {
         self.map(Result.success)
             .catch { Just(.failure($0)) }
+            .eraseToAnyPublisher() // NOTE: For `@unchecked Sendable`
             .toEffect(queue: queue)
     }
 
@@ -75,6 +78,7 @@ extension Publisher
     {
         self.map(Result.success)
             .catch { Just(.failure($0)) }
+            .eraseToAnyPublisher() // NOTE: For `@unchecked Sendable`
             .toEffect(id: id, queue: queue)
     }
 }

--- a/Sources/ActomatonStore/UncheckedSendable.swift
+++ b/Sources/ActomatonStore/UncheckedSendable.swift
@@ -6,4 +6,6 @@ extension PassthroughSubject: @unchecked Sendable {}
 
 extension Published.Publisher: @unchecked Sendable {}
 
+extension AnyPublisher: @unchecked Sendable {}
+
 extension AnyCancellable: @unchecked Sendable {}

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -44,22 +44,24 @@ final class FeedbackTrackingTaskTests: XCTestCase
                     guard state == ._3 else { return .empty }
 
                     state = ._4(count: 0)
-                    return Effect(sequence: AsyncStream<Action> { continuation in
-                        let task = Task<(), Error> {
-                            for _ in 1 ... 2 {
-                                try await tick(1) {
-                                    continuation.yield(._increment)
-                                } ifCancelled: {
-                                    Debug.print("_3To4 cancelled")
+                    return Effect(sequence: {
+                        AsyncStream<Action> { continuation in
+                            let task = Task<(), Error> {
+                                for _ in 1 ... 2 {
+                                    try await tick(1) {
+                                        continuation.yield(._increment)
+                                    } ifCancelled: {
+                                        Debug.print("_3To4 cancelled")
+                                    }
                                 }
-                            }
 
-                            try await tick(1)
-                            continuation.yield(._4To5)
-                            continuation.finish()
-                        }
-                        continuation.onTermination = { @Sendable _ in
-                            task.cancel()
+                                try await tick(1)
+                                continuation.yield(._4To5)
+                                continuation.finish()
+                            }
+                            continuation.onTermination = { @Sendable _ in
+                                task.cancel()
+                            }
                         }
                     })
 


### PR DESCRIPTION
Note: This is a **Breaking Change**.

## Overview

This PR refactors `AsyncSequence`-based `Effect` by wrapping it with `async` closure so that:

1. Asynchronous work can be done before building `AsyncSequence`
2. Allows adding global actor to async-closure, e.g. `@MainActor`
    - This allows easy global-actor-based sequential operation among multiple effect composition (without using `EffectQueue`)
3. `AsyncSequence` will no longer requires conforming to `Sendable`

## Usage

Previously:

```swift
let effect = Effect(sequence: AsyncStream { continuation in
    ...
})
```

Now becomes:

```swift
let sequenceEffect = Effect(sequence: { @MainActor in // NOTE: Can attach global actor as a builder actor if needed
    // NOTE: Can run more async work before creating AsyncSequence
    let someValue = await doSomeWork()

    return AsyncStream { continuation in
        ...
    }
})
```

Attachable global actor is sometimes useful, e.g. 

```swift
let singleEffect = Effect { @MainActor in
    let someValue = await doSomeOtherWork()
    return Effect.nextAction(.next(someValue))
}

// NOTE: 
// If both effects use the same global-actor, the call order is guaranteed.
// Otherwise, plain `Effect`'s `+` will run in parallel so the call order will not be guaranteed.
let combinedEffect = singleEffect + sequenceEffect
```

## API change

```swift
// Before (ver 0.3.1)
public init<S>(sequence: S)
    where S: AsyncSequence, S: Sendable, S.Element == Action

// After (This PR)
public init<S>(sequence: @Sendable @escaping () async throws -> S)
    where S: AsyncSequence, S.Element == Action
```