### PR TITLE
[Store] Make `environment` as public property to be able to pass to `SwiftUI.View`

### DIFF
--- a/Sources/ActomatonStore/ForEach+Store.swift
+++ b/Sources/ActomatonStore/ForEach+Store.swift
@@ -5,10 +5,10 @@ extension ForEach where Content: View
     /// `ForEach` for `Store` where its state is a collection of child states identified by `id` keyPath.
     /// - SeeAlso: Why `zip` is used: https://stackoverflow.com/a/63145650/666371
     @MainActor
-    public init<C, Action>(
-        store: Store<Action, C>.Proxy,
+    public init<C, Action, Environment>(
+        store: Store<Action, C, Environment>.Proxy,
         id: KeyPath<C.Element, ID>,
-        @ViewBuilder content: @escaping (Store<Action, C.Element>.Proxy) -> Content
+        @ViewBuilder content: @escaping (Store<Action, C.Element, Environment>.Proxy) -> Content
     ) where
         Data == [Zip2Sequence<C.Indices, C>.Element],
         C: MutableCollection & RandomAccessCollection,
@@ -27,9 +27,9 @@ extension ForEach where Content: View
     /// `ForEach` for `Store` where its state is a collection of child states identified by `Identifiable` protocol.
     /// - SeeAlso: Why `zip` is used: https://stackoverflow.com/a/63145650/666371
     @MainActor
-    public init<C, Action>(
-        store: Store<Action, C>.Proxy,
-        @ViewBuilder content: @escaping (Store<Action, C.Element>.Proxy) -> Content
+    public init<C, Action, Environment>(
+        store: Store<Action, C, Environment>.Proxy,
+        @ViewBuilder content: @escaping (Store<Action, C.Element, Environment>.Proxy) -> Content
     ) where
         Data == [Zip2Sequence<C.Indices, C>.Element],
         C: MutableCollection & RandomAccessCollection,

--- a/Sources/ActomatonStore/UIKit-Support/RouteStore.swift
+++ b/Sources/ActomatonStore/UIKit-Support/RouteStore.swift
@@ -4,13 +4,13 @@ import Combine
 /// Subclass of `Store` that also outputs `routes`, mainly used for UIKit's navigation handling
 /// without using `State` as a single source of truth.
 @MainActor
-open class RouteStore<Action, State, Route>: Store<Action, State>
-    where Action: Sendable, State: Sendable
+open class RouteStore<Action, State, Environment, Route>: Store<Action, State, SendRouteEnvironment<Environment, Route>>
+    where Action: Sendable, State: Sendable, Environment: Sendable
 {
     private let _routes: PassthroughSubject<Route, Never>
     private var cancellables: [AnyCancellable] = []
 
-    public init<Environment>(
+    public init(
         state: State,
         reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>>,
         environment: Environment,


### PR DESCRIPTION
**Breaking Change**.

## Overview

This PR refactors `ActomatonStore` module to allow **`Store`, `Store.Proxy`, and `Store.ObservableProxy` to hold `environment` as a public property**.

This change is especially needed for `Store` to gracefully interact with other stateful dynamic objects, e.g. `AVPlayer`, due to the following reasons:

1. To put `AVPlayer`  into `Environment` as an external dependency (as usual) to subscribe & unsubscribe its changes inside `Effect` (rather than splitting `AVPlayer` from `Environment`, subscribing inside View, and interacting through public `Action`s)
2. And still be able to pass `Environment`'s `AVPlayer` to `AVKit.VideoPlayer` (passing down to View-level)

### Background

In common MVVM architecture, `AVPlayer` normally sits inside ViewModel, performing subscriptions inside, and passes down to View for setting player to `AVPlayerLayer`.
This is a decent, object-oriented implementation so far.

In Elm-like Reducer-based functional architecture, following the same approach means that `AVPlayer` will live inside `Environment` (which is more preferred than putting inside `State` because `AVPlayer` is effectful reference) to interact inside `Reducer`-level, but **also need to be exposed to `View`-level (e.g. `AVKit.VideoPlayer` or `AVPlayerLayer`'s `setPlayer`).**
However, current Reducer architecture lacks in such use cases (including Actomaton, Composable Architecture, and probably many others too).

While there are many alternatives to be considered (see next section), I decided to keep `Reducer` and `Environment` as the grand central unit of architectural module (which doesn't matter whether UI exists or not), then make `environment` as a public property to allow `View` to register its dependency.

This means, best practice or slogan in Actomaton (when dealing with dynamic objects) is now defined as follows:

- **Always put dynamic objects inside `Environment`** (and make them mockable for testability)
    - **Views will not own dynamic objects**, and let `Store` handle all the dynamism.
- Reducers come first, Views (UI component) come secondary

This new approach will mostly be the same as existing MVVM, with more precise state management being carefully handled by functional Reducer.

On the other hand, reducers being fully decoupled from UI components also has a significant downside: **Environment decomposition needs to be handled manually by `Store.Proxy.map(environment:)`** when creating a child `Store`, which seems like a duplication code of `Reducer.contramap(environment:)`, but currently I don't have a clear solution to minimize this redundancy.
(This is perhaps one positive reason of why UI-component-driven effect handling is relatively easier to learn and is more popular in many frontend architectures nowadays)

### Current impl (as of ver 0.3.1)

```swift
// `Store` doesn't have `Environment` type parameter.
@MainActor
open class Store<Action, State>: ObservableObject
    where Action: Sendable, State: Sendable
{
    ...

    public init<Environment>(
        state initialState: State,
        reducer: Reducer<Action, State, Environment>,
        environment: Environment
    ) where Environment: Sendable
    { ... }
}
```

### This PR's impl

```swift
// `Store` will have `Environment` type parameter because `let environment` is added.
@MainActor
open class Store<Action, State, Environment>: ObservableObject
    where Action: Sendable, State: Sendable, Environment: Sendable
{
    ...

    // NEW!
    public let environment: Environment

    public init(
        state initialState: State,
        reducer: Reducer<Action, State, Environment>,
        environment: Environment
    ) 
    { ... }
}

// SwiftUI View example
struct MyView: View {
    ...

    var body: some View {
        // `store.environment` is now accessible.
        AVKit.VideoPlayer(player: store.environment.getPlayer())
    }
}
```

## Alternatives considered

### Put dynamic object inside `State` rather than `Environment`

While it may sound better that putting dynamic objects inside `State` is easier (with `store.state` already having `public` access), as mentioned in the previous section, putting dynamic objects inside `Environment` is more preferred due to the following reasons:

1. `State` needs to be `Sendable` in Actomaton, but dynamic objects may not be able to conform to `Sendable`
2. In general, `State` should normally not have a reference type (even it is wrapped by `Actor`) because its operation will be side-effect and doesn't nicely fit to Actomaton's basic concept of `State` solely being as a pure value-type structure.

Note that in plain Actor-based ViewModel implementation, such "pure value-type" states and "effectful reference" states can easily get mixed up, which is handy on one side, but becomes easily complicated on the downside.

### Put dynamic objects inside `View`

Storing dynamic objects inside `SwiftUI.View` is another decent approach.
For example, [ios-superplayer](https://github.com/tokopedia/ios-superplayer) is developed using Composable Architecture with thoroughly designed APIs.

However, this approach has the following downsides:

1. `AVPlayer` binding to `Store` is done inside `View`, which makes the whole View code very complicated
    - e.g. [ios-superplayer/SuperPlayerViewController.swift](https://github.com/tokopedia/ios-superplayer/blob/5cf78be495a70e3d998b269fdcfe62f63aa56d8f/Sources/SuperPlayer/SuperPlayerViewController.swift#L313)
    - In ordinary MVVM, this kind of verbose bindings wants to live inside ViewModel
3. In order to send `AVPlayer` messages to `Store`, many of `Action` `case`s need to be `public`

Please note that we sometimes want this kind of workaround when subscribing system-level messages, e.g. `@SwiftUI.Environment(\.scenePhase)` from View-level, bubbling message up to `Store` via public Actions.