### PR TITLE
[Store] Support SwiftUI Transaction

### DIFF
--- a/Sources/ActomatonStore/Binding+Helper.swift
+++ b/Sources/ActomatonStore/Binding+Helper.swift
@@ -13,7 +13,7 @@ extension Binding
     {
         Binding<SubValue>(
             get: { get(self.wrappedValue) },
-            set: { self.wrappedValue = set(self.wrappedValue, $0) }
+            set: { self.transaction($1).wrappedValue = set(self.wrappedValue, $0) }
         )
     }
 
@@ -27,7 +27,7 @@ extension Binding
     {
         Binding<SubValue>(
             get: { self.wrappedValue[keyPath: keyPath] },
-            set: { self.wrappedValue[keyPath: keyPath] = $0 }
+            set: { self.transaction($1).wrappedValue[keyPath: keyPath] = $0 }
         )
     }
 
@@ -40,9 +40,9 @@ extension Binding
             get: {
                 casePath.extract(from: self.wrappedValue)
             },
-            set: { value in
+            set: { value, transaction in
                 if let value = value {
-                    self.wrappedValue = casePath.embed(value)
+                    self.transaction(transaction).wrappedValue = casePath.embed(value)
                 }
             }
         )
@@ -67,7 +67,7 @@ extension Binding
 
         return Binding<SubValue>(
             get: { subValue },
-            set: { self.wrappedValue[keyPath: keyPath] = $0 }
+            set: { self.transaction($1).wrappedValue[keyPath: keyPath] = $0 }
         )
     }
 }

--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -148,9 +148,11 @@ extension Store.Proxy
             get: {
                 get(self.state)
             },
-            set: {
-                if let action = onChange($0) {
-                    self.send(action)
+            set: { value, transaction in
+                if let action = onChange(value) {
+                    _ = withTransaction(transaction) {
+                        self.send(action)
+                    }
                 }
             }
         )


### PR DESCRIPTION
This PR adds SwiftUI `Transaction` (animation) support for `ActomatonStore` by adding following changes:

1. Use `transaction` wherever necessary in custom `Binding` extensions
2. Pre-execute state changes on `Store`'s `@MainActor` thread so that SwiftUI's UI animations will work correctly.

While there is **no API breaking change** in this PR, 2. adds **extra complexity in Reducer-run that will now be called twice per action**.

This twice-call of Reducer is done on both `@MainActor` (Store) and background actor (`Actomaton`), keeping current architectural design as is.
(`Actomaton` is aimed to be built on top of non-main actor as the general-purpose core engine)

Note that while Reducer runs twice per action, only the one in the background `Actomaton` will handle its returning effects.
So, as long as Reducer keeps its referential transparency, it is usually (and should be) safe for calling multiple times.

See also fixed demo: 
- https://github.com/inamiy/Actomaton-Gallery/pull/38