### PR TITLE
[Store] Add `StoreConfiguration`

### DIFF
--- a/Sources/ActomatonStore/Store.Configuration.swift
+++ b/Sources/ActomatonStore/Store.Configuration.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// ``Store`` configuration.
+public struct StoreConfiguration
+{
+    /// A flag to run `Reducer` to update state on `@MainActor` immediately on ``Store/send(_:priority:tracksFeedbacks:)``
+    /// so that SwiftUI `Transaction` (including animation) will work correctly for ``Store`` and ``Store/Proxy-swift.struct``.
+    ///
+    /// - Note:
+    ///   If this value is `true`, **`Reducer` will run twice per `Action`**: on both `@MainActor` and `Actomaton`'s background actor.
+    ///   This behavior is for updating state on main-thread to run SwiftUI `Transaction` correctly
+    ///   while background-thread also takes care of `Reducer`-run including effect-handling.
+    ///   However, if effects aren't correctly inside `Reducer`'s returning `Effect` scope, this twice-reducer-call may cause duplicated effect-run issue,
+    ///   so make sure to write a proper, referentially-transparent `Reducer` first before setting this flag to `true`.
+    let updatesStateImmediately: Bool
+
+    public init(
+        updatesStateImmediately: Bool = false
+    )
+    {
+        self.updatesStateImmediately = updatesStateImmediately
+    }
+}

--- a/Sources/ActomatonStore/Store.Configuration.swift
+++ b/Sources/ActomatonStore/Store.Configuration.swift
@@ -6,12 +6,15 @@ public struct StoreConfiguration
     /// A flag to run `Reducer` to update state on `@MainActor` immediately on ``Store/send(_:priority:tracksFeedbacks:)``
     /// so that SwiftUI `Transaction` (including animation) will work correctly for ``Store`` and ``Store/Proxy-swift.struct``.
     ///
-    /// - Note:
-    ///   If this value is `true`, **`Reducer` will run twice per `Action`**: on both `@MainActor` and `Actomaton`'s background actor.
-    ///   This behavior is for updating state on main-thread to run SwiftUI `Transaction` correctly
-    ///   while background-thread also takes care of `Reducer`-run including effect-handling.
-    ///   However, if effects aren't correctly inside `Reducer`'s returning `Effect` scope, this twice-reducer-call may cause duplicated effect-run issue,
-    ///   so make sure to write a proper, referentially-transparent `Reducer` first before setting this flag to `true`.
+    /// If this value is `true`, **`Reducer` will run twice per `Action`**: on both `@MainActor` and `Actomaton`'s background actor.
+    /// This behavior is for updating state on main-thread immediately to run SwiftUI `Transaction` correctly (discarding effect-handling)
+    /// while background-thread also takes care of `Reducer`-run which also includes effect-handling.
+    ///
+    /// However, if effects aren't correctly handled inside `Reducer`'s returning `Effect` scope,
+    /// this twice-reducer-call may cause duplicated effect-run issue,
+    /// so make sure to write a proper, referentially-transparent `Reducer` first before setting this flag to `true`.
+    ///
+    /// - Important: If `withAnimation { store.send(...) }` is needed, this flag must be `true`.
     let updatesStateImmediately: Bool
 
     public init(

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -17,27 +17,37 @@ open class Store<Action, State, Environment>: ObservableObject
     /// For example, `AVPlayer` may be needed in both `Reducer` and `AVKit.VideoPlayer`.
     public let environment: Environment
 
+    private let configuration: StoreConfiguration
+
     private var task: Task<Void, Never>?
 
     /// Initializer without `environment`.
     public convenience init(
         state initialState: State,
-        reducer: Reducer<Action, State, Void>
+        reducer: Reducer<Action, State, Void>,
+        configuration: StoreConfiguration = .init()
     ) where Environment == Void
     {
-        self.init(state: initialState, reducer: reducer, environment: ())
+        self.init(
+            state: initialState,
+            reducer: reducer,
+            environment: (),
+            configuration: configuration
+        )
     }
 
     /// Initializer with `environment`.
     public init(
         state initialState: State,
         reducer: Reducer<Action, State, Environment>,
-        environment: Environment
+        environment: Environment,
+        configuration: StoreConfiguration = .init()
     )
     {
         self.state = initialState
         self.reducer = reducer
         self.environment = environment
+        self.configuration = configuration
 
         self.actomaton = Actomaton(
             state: initialState,
@@ -82,7 +92,9 @@ open class Store<Action, State, Environment>: ObservableObject
     {
         // Run `reducer` on `@MainActor` to update `state` immediately, discarding returned effects.
         // NOTE: Immediate UI update is often needed in SwiftUI, e.g. `withAnimation`.
-        _ = self.reducer.run(action, &state, environment)
+        if self.configuration.updatesStateImmediately {
+            _ = self.reducer.run(action, &state, environment)
+        }
 
         // Send `action` to `actomaton` asynchronously,
         // which also calls `reducer` inside its actor to update state and also runs effects.
@@ -96,14 +108,23 @@ open class Store<Action, State, Environment>: ObservableObject
     /// - Note: This is a common sub-store type for SwiftUI-based app.
     public var proxy: Proxy
     {
-        Proxy(state: self.stateBinding, environment: self.environment, send: self.send)
+        Proxy(
+            state: self.stateBinding,
+            environment: self.environment,
+            configuration: self.configuration,
+            send: self.send
+        )
     }
 
     /// Lightweight `Store` proxy that is state-observable and action-sendable.
     /// - Note: This is a common sub-store type for UIKit-Navigation-based app.
     public var observableProxy: ObservableProxy
     {
-        ObservableProxy(state: self.$state, environment: environment, send: { self.send($0) })
+        ObservableProxy(
+            state: self.$state,
+            environment: environment,
+            send: { self.send($0) }
+        )
     }
 }
 

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -122,7 +122,8 @@ open class Store<Action, State, Environment>: ObservableObject
     {
         ObservableProxy(
             state: self.$state,
-            environment: environment,
+            environment: self.environment,
+            configuration: self.configuration,
             send: { self.send($0) }
         )
     }

--- a/Sources/ActomatonStore/UIKit-Support/Store.ObservableProxy.swift
+++ b/Sources/ActomatonStore/UIKit-Support/Store.ObservableProxy.swift
@@ -124,7 +124,12 @@ extension Store.ObservableProxy
     @MainActor
     var unsafeProxy: Store<Action, State?, Environment>.Proxy
     {
-        .init(state: unsafeStateBinding, environment: environment, send: self._send)
+        .init(
+            state: self.unsafeStateBinding,
+            environment: self.environment,
+            configuration: StoreConfiguration(),
+            send: self._send
+        )
     }
 
     /// Unsafe state binding that ignores setter handling.


### PR DESCRIPTION
Successor of:
- #39 

This PR adds `StoreConfiguration` that owns `updatesStateImmediately` flag to conditionally run Reducer twice (introduced in #39 ) only when such configuration is needed.