### PR TITLE
[Store] Improve `Store.Proxy` & `ObservableProxy`'s initializers

### DIFF
--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -21,7 +21,8 @@ extension Store
         private let _send: @MainActor (Action, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Error>
 
         /// Designated initializer with receiving `send` from single-source-of-truth `Store`.
-        public init(
+        /// - Note: This initializer is `internal`, and should only be instantiated via ``Store/proxy-swift.property``.
+        internal init(
             state: Binding<State>,
             environment: Environment,
             configuration: StoreConfiguration = .init(),
@@ -34,22 +35,17 @@ extension Store
             self._send = send
         }
 
-        /// Initializer with simple `send`, mainly for mocking purpose.
-        public init(
+        /// Initializer for mocking purpose, e.g. SwiftUI Preview.
+        public static func mock(
             state: Binding<State>,
-            environment: Environment,
-            configuration: StoreConfiguration = .init(),
-            send: @MainActor @escaping (Action) -> Void
-        )
+            environment: Environment
+        ) -> Store.Proxy
         {
-            self.init(
+            return .init(
                 state: state,
                 environment: environment,
-                configuration: configuration,
-                send: { action, _, _ in
-                    send(action)
-                    return Task {}
-                }
+                configuration: .init(),
+                send: { _, _, _ in Task {} }
             )
         }
 

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -124,7 +124,7 @@ open class Store<Action, State, Environment>: ObservableObject
             state: self.$state,
             environment: self.environment,
             configuration: self.configuration,
-            send: { self.send($0) }
+            send: { action, _, _ in self.send(action) }
         )
     }
 }

--- a/Sources/ActomatonStore/UIKit-Support/Store.ObservableProxy.swift
+++ b/Sources/ActomatonStore/UIKit-Support/Store.ObservableProxy.swift
@@ -28,7 +28,8 @@ extension Store
         }
 
         /// Designated initializer with receiving `send` from single-source-of-truth `Store`.
-        public init<P>(
+        /// - Note: This initializer is `internal`, and should only be instantiated via ``Store/observableProxy-swift.property``.
+        internal init<P>(
             state: P,
             environment: Environment,
             configuration: StoreConfiguration,
@@ -42,23 +43,18 @@ extension Store
             self._send = send
         }
 
-        /// Initializer with simple `send`, mainly for mocking purpose.
-        public convenience init<P>(
+        /// Initializer for mocking purpose, e.g. SwiftUI Preview.
+        public static func mock<P>(
             state: P,
-            environment: Environment,
-            configuration: StoreConfiguration,
-            send: @escaping (Action) -> Void
-        )
+            environment: Environment
+        ) -> ObservableProxy
             where P: Publisher, P.Output == State, P.Failure == Never
         {
-            self.init(
+            return .init(
                 state: state,
                 environment: environment,
-                configuration: configuration,
-                send: { action, _, _ in
-                    send(action)
-                    return Task {}
-                }
+                configuration: .init(),
+                send: { _, _, _ in Task {} }
             )
         }
 


### PR DESCRIPTION
(Subtle) **Breaking change**.

This PR changes `Store.Proxy` & `ObservableProxy`'s initializers as follows:

- Make designated `init` as `internal`, since its instantiation should only take place inside `Store`
- Rename mock-purposed `init` to `static func mock`