### PR TITLE
[Store] Add `Store.Proxy.noEnvironment`

### DIFF
--- a/Sources/ActomatonStore/Store.Proxy.swift
+++ b/Sources/ActomatonStore/Store.Proxy.swift
@@ -222,3 +222,14 @@ extension Store.Proxy
         )
     }
 }
+
+// MARK: - noEnvironment
+
+extension Store.Proxy
+{
+    /// Converts `Environment` to `Void` so that `SwiftUI.View` doesn't need to know about `Environment`.
+    public var noEnvironment: Store<Action, State, Void>.Proxy
+    {
+        self.map(environment: { _ in () })
+    }
+}


### PR DESCRIPTION
Improvement for:
- #36 

Due to #36 , `Store.Proxy` now exposes `Environment` as public member variable.
But in many scenarios, only Store-level needs to know about it and can hide its information to `SwiftUI.View`.

In such cases, `Store.Proxy.noEnvironment` can be used to convert `Environment` into `Void`.