### PR TITLE
[Actomaton] Add `EffectQueueDelay`

### DIFF
--- a/Sources/Actomaton/EffectQueue.swift
+++ b/Sources/Actomaton/EffectQueue.swift
@@ -18,7 +18,19 @@ public struct EffectQueue: Hashable, Sendable
 /// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of new effects.
 public protocol EffectQueueProtocol: Hashable, Sendable
 {
+    /// Effect buffering policy.
     var effectQueuePolicy: EffectQueuePolicy { get }
+
+    /// Effect delaying strategy.
+    var effectQueueDelay: EffectQueueDelay { get }
+}
+
+extension EffectQueueProtocol
+{
+    public var effectQueueDelay: EffectQueueDelay
+    {
+        .constant(0) // Default is "no delay".
+    }
 }
 
 // MARK: - Newest1EffectQueueProtocol
@@ -66,11 +78,13 @@ struct AnyEffectQueue: EffectQueueProtocol, Sendable
 {
     let queue: EffectQueue
     let effectQueuePolicy: EffectQueuePolicy
+    let effectQueueDelay: EffectQueueDelay
 
     init<Queue>(_ queue: Queue)
         where Queue: EffectQueueProtocol
     {
         self.queue = EffectQueue(queue)
         self.effectQueuePolicy = queue.effectQueuePolicy
+        self.effectQueueDelay = queue.effectQueueDelay
     }
 }

--- a/Sources/Actomaton/EffectQueueDelay.swift
+++ b/Sources/Actomaton/EffectQueueDelay.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// ``EffectQueueProtocol``'s  delaying strategy.
+public enum EffectQueueDelay: Hashable, Sendable
+{
+    case constant(TimeInterval)
+    case random(ClosedRange<TimeInterval>)
+
+    var timeInterval: TimeInterval
+    {
+        switch self {
+        case let .constant(timeInterval):
+            return timeInterval
+        case let .random(timeRange):
+            return TimeInterval.random(in: timeRange)
+        }
+    }
+}

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import Actomaton
+
+import Combine
+
+/// Tests for `EffectQueueDelay`.
+final class EffectQueueDelayTests: XCTestCase
+{
+    private func makeActomaton<Queue: EffectQueueProtocol>(
+        queue: Queue,
+        effectTime: TimeInterval
+    ) -> (Actomaton<Action, State>, startedIDs: ResultsCollector<String>, cancelledIDs: ResultsCollector<String>)
+    {
+        let startedIDs: ResultsCollector<String> = .init()
+        let cancelledIDs: ResultsCollector<String> = .init()
+
+        let actomaton = Actomaton<Action, State>(
+            state: .init(),
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case let .fetch(id):
+                    return Effect(id: EffectID(name: "running \(id)"), queue: queue) {
+                        // NOTE: Due to `queue`'s delay, this scope may run at delayed schedule time.
+
+                        print("Start: \(id), Task.isCancelled = \(Task.isCancelled)")
+
+                        // NOTE:
+                        // Because of delayed effect cancellation may occur by `EffectQueue`,
+                        // `Task.isCancelled` may already be `true` at here.
+                        if !Task.isCancelled {
+                            await startedIDs.append(id)
+                        }
+
+                        return try await tick(effectTime) {
+                            return ._didFetch(id: id)
+                        } ifCancelled: { () -> Action? in
+                            print("Effect \(id) cancelled")
+                            await cancelledIDs.append(id)
+                            return nil
+                        }
+                    }
+
+                case let ._didFetch(id):
+                    state.finishedIDs.insert(id)
+
+                    return Effect.fireAndForget {
+                        print("Finished: \(id)")
+                    }
+                }
+            }
+        )
+
+        return (actomaton, startedIDs, cancelledIDs)
+    }
+
+    func test_DelayedEffectQueue() async throws
+    {
+        let delay: TimeInterval = 3
+        let effectTime: TimeInterval = 2
+
+        // `.runNewest(maxCount: .max)`.
+        let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
+            queue: DelayedEffectQueue(delay: delay),
+            effectTime: effectTime
+        )
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+        assertEqual(await startedIDs.results, [])
+        assertEqual(await cancelledIDs.results, [])
+
+        await actomaton.send(.fetch(id: "1")) // fetch at t=0
+        await actomaton.send(.fetch(id: "2")) // delayed fetch at t=3
+        await actomaton.send(.fetch(id: "3")) // delayed fetch at t=6
+        await actomaton.send(.fetch(id: "4")) // delayed fetch at t=9
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3", "4"])
+
+        // ResultCollector
+        assertEqual(await startedIDs.results, ["1", "2", "3", "4"],
+                    "Should run all effects.")
+        assertEqual(await cancelledIDs.results, [])
+    }
+
+    // NOTE: Behaves similar to debounce, but up to `.runNewest(N)` effects.
+    func test_DelayedNewest2EffectQueue() async throws
+    {
+        let delay: TimeInterval = 2
+        let effectTime: TimeInterval = 1
+
+        // `.runNewest(2)`
+        let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
+            queue: DelayedNewest2EffectQueue(delay: delay),
+            effectTime: effectTime
+        )
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        await actomaton.send(.fetch(id: "1")) // fetch at t=0, will be auto-cancelled by queue
+        await actomaton.send(.fetch(id: "2")) // delayed fetch at t=2, will be auto-cancelled by queue
+        await actomaton.send(.fetch(id: "3")) // delayed fetch at t=4
+        await actomaton.send(.fetch(id: "4")) // delayed fetch at t=6
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        try await tick(delay * 2 + effectTime + 0.5)
+        assertEqual(await actomaton.state.finishedIDs, ["3"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["3", "4"])
+
+        // ResultCollector
+        assertEqual(await startedIDs.results, ["3", "4"],
+                    "Only last 2 should run effects.")
+        assertEqual(await cancelledIDs.results, ["1", "2"])
+    }
+
+    func test_DelayedOldest2SuspendNewEffectQueue() async throws
+    {
+        let delay: TimeInterval = 2
+        let effectTime: TimeInterval = 3
+
+        // `.runOldest(2, .suspendNew)`
+        let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
+            queue: DelayedOldest2SuspendNewEffectQueue(delay: delay),
+            effectTime: effectTime
+        )
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        await actomaton.send(.fetch(id: "1")) // fetch at t=0, comples at t=3
+        await actomaton.send(.fetch(id: "2")) // delayed fetch at t=2, comples at t=5
+        await actomaton.send(.fetch(id: "3")) // delayed fetch at t=4, comples at t=7
+        await actomaton.send(.fetch(id: "4")) // delayed fetch at t=6, comples at t=9
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        try await tick(effectTime + 0.5)
+        assertEqual(await actomaton.state.finishedIDs, ["1"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3", "4"])
+
+        // ResultCollector
+        assertEqual(await startedIDs.results, ["1", "2", "3", "4"],
+                    "Should run all effects.")
+        assertEqual(await cancelledIDs.results, [])
+    }
+
+    func test_DelayedOldest2DiscardNewEffectQueue() async throws
+    {
+        let delay: TimeInterval = 2
+        let effectTime: TimeInterval = 3
+
+        // `.runOldest(2, .discardNew)`
+        let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
+            queue: DelayedOldest2DiscardNewEffectQueue(delay: delay),
+            effectTime: effectTime
+        )
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        await actomaton.send(.fetch(id: "1")) // fetch at t=0, comples at t=3
+        await actomaton.send(.fetch(id: "2")) // delayed fetch at t=2, comples at t=5
+        await actomaton.send(.fetch(id: "3")) // delayed fetch at t=4, will be auto-cancelled by queue
+        await actomaton.send(.fetch(id: "4")) // delayed fetch at t=6, will be auto-cancelled by queue
+
+        assertEqual(await actomaton.state.finishedIDs, [])
+
+        try await tick(effectTime + 0.5)
+        assertEqual(await actomaton.state.finishedIDs, ["1"])
+
+        try await tick(delay)
+        assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
+
+        // ResultCollector
+        assertEqual(await startedIDs.results.sorted(), ["1", "2"],
+                    "Only first 2 should run effects.")
+        assertEqual(await cancelledIDs.results.sorted(), ["3", "4"])
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case fetch(id: String)
+    case _didFetch(id: String)
+}
+
+private struct State: Equatable
+{
+    var finishedIDs: Set<String> = []
+}
+
+private struct EffectID: EffectIDProtocol
+{
+    var name: String
+}
+
+private struct DelayedEffectQueue: EffectQueueProtocol
+{
+    let delay: TimeInterval
+    var effectQueuePolicy: EffectQueuePolicy { .runNewest(maxCount: .max) }
+    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+}
+
+private struct DelayedNewest2EffectQueue: EffectQueueProtocol
+{
+    let delay: TimeInterval
+    var effectQueuePolicy: EffectQueuePolicy { .runNewest(maxCount: 2) }
+    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+}
+
+private struct DelayedOldest2SuspendNewEffectQueue: EffectQueueProtocol
+{
+    let delay: TimeInterval
+    var effectQueuePolicy: EffectQueuePolicy { .runOldest(maxCount: 2, .suspendNew) }
+    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+}
+
+private struct DelayedOldest2DiscardNewEffectQueue: EffectQueueProtocol
+{
+    let delay: TimeInterval
+    var effectQueuePolicy: EffectQueuePolicy { .runOldest(maxCount: 2, .discardNew) }
+    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+}
+
+private let timescale: TimeInterval = TimeInterval(tickTimeInterval) / 1_000_000_000

--- a/Tests/ActomatonTests/Fixtures/Fixtures.swift
+++ b/Tests/ActomatonTests/Fixtures/Fixtures.swift
@@ -8,7 +8,7 @@ func tick(_ n: Double) async throws
     try await Task.sleep(nanoseconds: UInt64(Double(tickTimeInterval) * n))
 }
 
-private let tickTimeInterval: UInt64 = 50_000_000 // 50 ms
+let tickTimeInterval: UInt64 = 50_000_000 // 50 ms
 
 func tick<T>(
     _ n: Double,


### PR DESCRIPTION
## Feature: `EffectQueueDelay`

**Additive Change**.

This PR introduces **`EffectQueueDelay`** which associates with `EffectQueue` to **automagically adds `Task.sleep` before actually invoking `Effect`s.**

This feature becomes useful when:

- Throttling multiple waiting effects which ensures minimum time interval between effects
- Debouncing and remove old effects by time interval using `EffectQueuePolicy.runNewest(n)`