### PR TITLE
[Makefile] Add `make docs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+.docbuild
+docbuild

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # NOTE: Async tests are currently disabled due to its indeterminacy nature of effectful computation.
 
+DOC_HOSTING_BASE_PATH := /Actomaton
+DOCBUILD_BUILD_DIR := .docbuild
+DOCBUILD_PRODUCT_DIR := $(DOCBUILD_BUILD_DIR)/Build/Products/Debug-iphonesimulator
+DOCBUILD_OUTPUT_DIR := docbuild
+
 .PHONY: build-macOS
 build-macOS:
 	$(MAKE) build DESTINATION='platform=OS X'
@@ -20,3 +25,36 @@ build-tvOS:
 build:
 	set -o pipefail && \
 		xcodebuild build -scheme Actomaton-Package -destination '${DESTINATION}' | xcpretty
+
+# NOTE:
+# `xcodebuild docbuild` allows spcifying iOS platform and generates dependency's doccarchives.
+# https://forums.swift.org/t/generate-documentation-failing-on-import-uikit/55202/7
+#
+# NOTE: This task may fail once (Error 65), so in such case, retry.
+.PHONY: docs
+docs:
+	xcodebuild docbuild \
+		-scheme ActomatonStore \
+		-destination 'platform=iOS Simulator,name=iPhone 13 Pro' \
+		-derivedDataPath $(DOCBUILD_BUILD_DIR) \
+		OTHER_DOCC_FLAGS="--transform-for-static-hosting --hosting-base-path $(DOC_HOSTING_BASE_PATH)"
+
+	#--------------------------------------------------
+	# (Immaturely) gathering multiple doccarchives
+	#--------------------------------------------------
+	# Gather `./data/documentation` from other packages into ActomatonStore.
+	cp -rf $(DOCBUILD_PRODUCT_DIR)/Actomaton.doccarchive/data/documentation/* $(DOCBUILD_PRODUCT_DIR)/ActomatonStore.doccarchive/data/documentation/
+	cp -rf $(DOCBUILD_PRODUCT_DIR)/ActomatonDebugging.doccarchive/data/documentation/* $(DOCBUILD_PRODUCT_DIR)/ActomatonStore.doccarchive/data/documentation/
+
+	# Gather `./documentation` from other packages into ActomatonStore.
+	cp -rf $(DOCBUILD_PRODUCT_DIR)/Actomaton.doccarchive/documentation/* $(DOCBUILD_PRODUCT_DIR)/ActomatonStore.doccarchive/documentation/
+	cp -rf $(DOCBUILD_PRODUCT_DIR)/ActomatonDebugging.doccarchive/documentation/* $(DOCBUILD_PRODUCT_DIR)/ActomatonStore.doccarchive/documentation/
+
+	# Delete unnecessary DB files.
+	rm -rf $(DOCBUILD_PRODUCT_DIR)/ActomatonStore.doccarchive/index/
+
+	# Move `ActomatonStore.doccarchive` to `$(DOCBUILD_OUTPUT_DIR)`.
+	mv -f $(DOCBUILD_PRODUCT_DIR)/ActomatonStore.doccarchive $(DOCBUILD_OUTPUT_DIR)
+
+	# Clean up `$(DOCBUILD_BUILD_DIR)`.
+	rm -rf $(DOCBUILD_BUILD_DIR)


### PR DESCRIPTION
This PR adds `make docs` task to generate multiple doccarchives and (naively) combine together as 1 static-hosting bundle.

See gh-pages example:
- https://inamiy.github.io/Actomaton/documentation/actomaton/
- https://inamiy.github.io/Actomaton/documentation/actomatonstore/
- https://inamiy.github.io/Actomaton/documentation/actomatondebugging/