### PR TITLE
[Docs] Update Actomaton.docc & README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ inspired by [Elm](http://elm-lang.org/) and [swift-composable-architecture](http
 This repository consists of 3 frameworks:
 
 1. `Actomaton`: Actor-based effect-handling state-machine at its core. Linux ready.
+    - [Documentation](https://inamiy.github.io/Actomaton/documentation/actomaton/)
 2. `ActomatonStore`: SwiftUI & Combine support
+    - [Documentation (Currently in Japanese only)](https://inamiy.github.io/Actomaton/documentation/actomatonstore/)
 3. `ActomatonDebugging`: Helper module to print `Action` and `State` (with diffing) per `Reducer` call.
+    - [Documentation](https://inamiy.github.io/Actomaton/documentation/actomatondebugging/)
 
 These frameworks depend on [swift-case-paths](https://github.com/pointfreeco/swift-case-paths) as Functional Prism library, which is a powerful tool to construct an App-level Mega-Reducer from each screen's Reducers.
 
@@ -25,11 +28,6 @@ This framework is a successor of the following projects:
 ## Demo App
 
 - [Actomaton-Gallery](https://github.com/inamiy/Actomaton-Gallery)
-
-## Documentation
-
-- Actomaton: https://actomaton.web.app/documentation/actomaton
-- ActomatonStore: https://actomaton.web.app/documentation/actomatonstore (Currently in Japanese only)
 
 ## 1. Actomaton (Core)
 

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples.md
@@ -7,4 +7,5 @@ Quick example code to grasp how Actomaton architecture works.
 - <doc:01-Counter>
 - <doc:02-LoginLogout>
 - <doc:03-Timer>
-- <doc:04-ReducerComposition>
+- <doc:04-EffectQueue>
+- <doc:05-ReducerComposition>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-Timer.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-Timer.md
@@ -85,4 +85,4 @@ enum Main {
 
 ## Next Step
 
-<doc:04-ReducerComposition>
+<doc:04-EffectQueue>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/04-EffectQueue.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/04-EffectQueue.md
@@ -1,0 +1,106 @@
+# Example 4: EffectQueue
+
+``EffectQueue`` example.
+
+## Overview
+
+``EffectQueue`` provides an easy-to-use effect queueing management system in Actomaton which allows:
+
+- Suspending newly arrived effects
+- Discard old / new effects
+- Delays next executing effect
+
+For example:
+
+```swift
+enum Action: Sendable {
+    case fetch(id: String)
+    case _didFetch(Data)
+}
+
+struct State: Sendable {} // no state
+
+struct Environment: Sendable {
+    let fetch: @Sendable (_ id: String) async throws -> Data
+}
+
+struct DelayedEffectQueue: EffectQueueProtocol {
+    // First 3 effects will run concurrently, and other sent effects will be suspended.
+    var effectQueuePolicy: EffectQueuePolicy {
+        .runOldest(maxCount: 3, .suspendNew)
+    }
+
+    // Adds delay between effect start. (This is useful for throttling / deboucing)
+    var effectQueueDelay: EffectQueueDelay {
+        .random(0.1 ... 0.3)
+    }
+}
+
+let reducer = Reducer<Action, State, Environment> { action, state, environment in
+    switch action {
+    case let .fetch(id):
+        return Effect(queue: DelayedEffectQueue()) {
+            let data = try await environment.fetch(id)
+            return ._didFetch(data)
+        }
+    case let ._didFetch(data):
+        // Do something with `data`.
+        return .empty
+    }
+}
+
+let actomaton = Actomaton<Action, State>(
+    state: State(),
+    reducer: reducer,
+        environment: Environment(fetch: { /* ... */ })
+)
+
+await actomaton.send(.fetch(id: "item1"))
+await actomaton.send(.fetch(id: "item2")) // min delay of 0.1
+await actomaton.send(.fetch(id: "item3")) // min delay of 0.1 (after item2 actually starts)
+await actomaton.send(.fetch(id: "item4")) // starts when item1 or 2 or 3 finishes
+```
+
+Above code uses a custom `DelayedEffectQueue` that conforms to ``EffectQueueProtocol`` with suspendable ``EffectQueuePolicy`` and delays between each effect by ``EffectQueueDelay``.
+
+See [EffectQueuePolicy](https://github.com/inamiy/Actomaton/blob/main/Sources/Actomaton/EffectQueuePolicy.swift) for how each policy takes different queueing strategy for effects.
+
+```swift
+/// `EffectQueueProtocol`'s buffering policy.
+public enum EffectQueuePolicy: Hashable, Sendable
+{
+    /// Runs `maxCount` newest effects, cancelling old running effects.
+    case runNewest(maxCount: Int)
+
+    /// Runs `maxCount` old effects with either suspending or discarding new effects.
+    case runOldest(maxCount: Int, OverflowPolicy)
+
+    public enum OverflowPolicy: Sendable
+    {
+        /// Suspends new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
+        case suspendNew
+
+        /// Discards new effects when `.runOldest` `maxCount` of old effects is reached until one of them is completed.
+        case discardNew
+    }
+}
+```
+
+For convenient ``EffectQueueProtocol`` protocol conformance, there are built-in sub-protocols:
+
+```swift
+/// A helper protocol where `effectQueuePolicy` is set to `.runNewest(maxCount: 1)`.
+public protocol Newest1EffectQueueProtocol: EffectQueueProtocol {}
+
+/// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .discardNew)`.
+public protocol Oldest1DiscardNewEffectQueueProtocol: EffectQueueProtocol {}
+
+/// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .suspendNew)`.
+public protocol Oldest1SuspendNewEffectQueueProtocol: EffectQueueProtocol {}
+```
+
+so that we can write in one-liner: `struct MyEffectQueue: Newest1EffectQueueProtocol {}`
+
+## Next Step
+
+<doc:05-ReducerComposition>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/05-ReducerComposition.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/05-ReducerComposition.md
@@ -1,4 +1,4 @@
-# Example 4: Making a large app (Reducer Composition)
+# Example 5: Making a large app (Reducer Composition)
 
 Reducer composition example.
 


### PR DESCRIPTION
Documentation for:
- #9 
- #49 

Related:
- #50 

## Overview

This PR adds documentation for `EffectQueue` and `EffectQueueDelay`.

- [Example 4: EffectQueue | Documentation](https://inamiy.github.io/Actomaton/documentation/actomaton/04-effectqueue) 