### PR TITLE
Fix some Swift 6 strict-concurrency errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
             dependencies: ["ActomatonStore", "ActomatonDebugging"]
         )
     ]
+//    swiftLanguageVersions: [.version("6")]
 )
 
 // Comment-Out: Enable this `unsafeFlags` in local development.

--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -52,7 +52,7 @@ public actor Actomaton<Action, State>
         executingActor: any Actor
     )
     {
-        self.state = state
+        self._state = Published(initialValue: state)
         self.reducer = reducer
         self.executingActor = executingActor
     }

--- a/Sources/Actomaton/UncheckedSendable.swift
+++ b/Sources/Actomaton/UncheckedSendable.swift
@@ -1,7 +1,22 @@
 import CasePaths
 
+#if swift(>=6.0)
+
+extension WritableKeyPath: @retroactive @unchecked Sendable {}
+extension CasePath: @retroactive @unchecked Sendable {}
+
+#if canImport(Combine)
+import Combine
+extension Published.Publisher: @retroactive @unchecked Sendable {}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension AsyncPublisher: @retroactive @unchecked Sendable {}
+#endif
+
+#else
+
 // TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-
 extension WritableKeyPath: @unchecked Sendable {}
-
 extension CasePath: @unchecked Sendable {}
+
+#endif

--- a/Sources/ActomatonUI/SwiftUI/Binding+Helper.swift
+++ b/Sources/ActomatonUI/SwiftUI/Binding+Helper.swift
@@ -7,8 +7,8 @@ extension Binding
 {
     /// Transforms `<Value>` to `<SubValue>` using `get` and `set`.
     public func transform<SubValue>(
-        get: @escaping (Value) -> SubValue,
-        set: @escaping (Value, SubValue) -> Value
+        get: @escaping @Sendable (Value) -> SubValue,
+        set: @escaping @Sendable (Value, SubValue) -> Value
     ) -> Binding<SubValue>
     {
         Binding<SubValue>(
@@ -60,6 +60,7 @@ extension Binding
     ///   which turns `Binding<Value?>` into `Binding<Value>?`.
     public func traverse<SubValue>(_ keyPath: WritableKeyPath<Value, SubValue?>)
         -> Binding<SubValue>?
+        where SubValue: Sendable
     {
         guard let subValue = self.wrappedValue[keyPath: keyPath] else {
             return nil
@@ -77,7 +78,7 @@ extension Binding
 extension Binding
 {
     /// Adds setter hook.
-    public func onSet(_ hook: @escaping (_ old: Value, _ new: Value) -> Void) -> Binding<Value>
+    public func onSet(_ hook: @escaping @Sendable (_ old: Value, _ new: Value) -> Void) -> Binding<Value>
     {
         self.transform(
             get: { $0 },

--- a/Tests/ActomatonStoreTests/DeinitTests.swift
+++ b/Tests/ActomatonStoreTests/DeinitTests.swift
@@ -3,9 +3,9 @@ import XCTest
 @testable import ActomatonStore
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
-@MainActor
 final class DeinitTests: XCTestCase
 {
+    @MainActor
     func test_deinit() async throws
     {
         let resultsCollector = ResultsCollector<String>()

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -4,7 +4,6 @@ import XCTest
 import Combine
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runNewest(maxCount: n)`.
-@MainActor
 final class RunNewestDiscardOldTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -27,7 +26,7 @@ final class RunNewestDiscardOldTests: XCTestCase
 
         let actomaton = Actomaton<Action, State>(
             state: State(),
-            reducer: Reducer { action, state, _ in
+            reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {
                 case .increment:
                     state.count += 1
@@ -36,8 +35,8 @@ final class RunNewestDiscardOldTests: XCTestCase
                         try await tick(1) {
                             Debug.print("Effect success")
                             return .effectCompleted
-                        } ifCancelled: {
-                            await self.resultsCollector.append(state.count)
+                        } ifCancelled: { [resultsCollector] in
+                            await resultsCollector.append(state.count)
                             Debug.print("Effect cancelled: \(state.count)")
                             return nil
                         }

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -4,7 +4,6 @@ import XCTest
 import Combine
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
-@MainActor
 final class RunOldestDiscardNewTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -27,7 +26,7 @@ final class RunOldestDiscardNewTests: XCTestCase
 
         let actomaton = Actomaton<Action, State>(
             state: State(),
-            reducer: Reducer { action, state, _ in
+            reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {
                 case .increment:
                     state.count += 1
@@ -36,8 +35,8 @@ final class RunOldestDiscardNewTests: XCTestCase
                         try await tick(1) {
                             Debug.print("Effect success")
                             return .effectCompleted
-                        } ifCancelled: {
-                            await self.resultsCollector.append(state.count)
+                        } ifCancelled: { [resultsCollector] in
+                            await resultsCollector.append(state.count)
                             Debug.print("Effect cancelled")
                             return nil
                         }

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -4,7 +4,6 @@ import XCTest
 import Combine
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
-@MainActor
 final class RunOldestSuspendNewTests: XCTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -27,7 +26,7 @@ final class RunOldestSuspendNewTests: XCTestCase
 
         let actomaton = Actomaton<Action, State>(
             state: State(),
-            reducer: Reducer { action, state, _ in
+            reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {
                 case .increment:
                     state.count += 1
@@ -36,8 +35,8 @@ final class RunOldestSuspendNewTests: XCTestCase
                         try await tick(1) {
                             Debug.print("Effect success")
                             return .effectCompleted
-                        } ifCancelled: {
-                            await self.resultsCollector.append(state.count)
+                        } ifCancelled: { [resultsCollector] in
+                            await resultsCollector.append(state.count)
                             Debug.print("Effect cancelled")
                             return nil
                         }

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import ActomatonUI
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
-@MainActor
 final class DeinitTests: XCTestCase
 {
+    @MainActor
     func test_deinit() async throws
     {
         let resultsCollector = ResultsCollector<String>()


### PR DESCRIPTION
This PR fixes some of Swift 6 strict-concurrency warnings and errors in Xcode 16 Beta 1 to make more concurrency-safe.
This PR change should be **non-breaking** (unless user enables Swift 6 mode for strict `Sendable` check).

NOTE: `deinit` isolation issue hasn't been resolved, so this library itself cannot activate Swift 6 mode yet.
See also discussion in [Isolated synchronous deinit - Evolution / Pitches - Swift Forums](https://forums.swift.org/t/isolated-synchronous-deinit/58177) .