### PR TITLE
Support Swift 6 language mode (Strict Concurrency)

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 import PackageDescription
 
@@ -51,5 +51,6 @@ let package = Package(
             name: "ReadMeTests",
             dependencies: ["Actomaton", "ActomatonDebugging"]
         )
-    ]
+    ],
+    swiftLanguageVersions: [.version("6")]
 )

--- a/Sources/ActomatonUI/UncheckedSendable.swift
+++ b/Sources/ActomatonUI/UncheckedSendable.swift
@@ -2,10 +2,18 @@ import Combine
 
 // TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
 
+#if swift(>=6.0)
+
+extension PassthroughSubject: @retroactive @unchecked Sendable {}
+extension Published.Publisher: @retroactive @unchecked Sendable {}
+extension AnyPublisher: @retroactive @unchecked Sendable {}
+extension AnyCancellable: @retroactive @unchecked Sendable {}
+
+#else
+
 extension PassthroughSubject: @unchecked Sendable {}
-
 extension Published.Publisher: @unchecked Sendable {}
-
 extension AnyPublisher: @unchecked Sendable {}
-
 extension AnyCancellable: @unchecked Sendable {}
+
+#endif

--- a/Tests/TestFixtures/UncheckedSendable.swift
+++ b/Tests/TestFixtures/UncheckedSendable.swift
@@ -2,4 +2,12 @@ import Combine
 
 // TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
 
+#if swift(>=6.0)
+
+extension Published.Publisher: @retroactive @unchecked Sendable {}
+
+#else
+
 extension Published.Publisher: @unchecked Sendable {}
+
+#endif


### PR DESCRIPTION
Successor of:
- #83 

This PR completes [Swift 6 language mode migration](https://www.swift.org/migration/documentation/migrationguide/) to support strict concurrency check.

Also note that this PR still supports from Swift 5.9 as is.

### P.S.

There was [Isolated synchronous deinit](https://forums.swift.org/t/isolated-synchronous-deinit/58177) issue that was hanging for a long time in Swift Forum, but unfortunately won't make it complete by Swift 6 official released.
So I added an ugly copy-paste clean up code in `deinit` as a workaround. 