### PR TITLE
[Test] [CI] Use `ConcurrencyExtras` to run tests on top of main executor in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   xcodebuild:
+    name: Xcode ${{ matrix.xcode }} build ${{ matrix.platform }}
     runs-on: macos-14
     strategy:
       matrix:
@@ -22,17 +23,19 @@ jobs:
     - name: Select Xcode ${{ matrix.xcode }}
       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
     - name: Build ${{ matrix.platform }} package
-      run: make build-${{ matrix.platform}}
+      run: make xcode-build OS=${{ matrix.platform}}
 
   ubuntu:
+    name: Ubuntu test (Swift ${{ matrix.swift }})
+    runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
     strategy:
       matrix:
         swift:
           - '6.0.2'
-    name: Ubuntu (Swift ${{ matrix.swift }})
-    runs-on: ubuntu-latest
-    container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v4
-      - name: Build Ubuntu upackage
-        run: swift build
+
+      # NOTE: `make` command not available in the container.
+      - name: Build Ubuntu package
+        run: TEST_MAIN_ACTOR=1 swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,10 @@
 // swift-tools-version:5.9
 
+import Foundation
 import PackageDescription
+
+// `$ TEST_MAIN_ACTOR=1 swift test`
+let usesMainActorInTest = ProcessInfo.processInfo.environment["TEST_MAIN_ACTOR"] == "1"
 
 let package = Package(
     name: "Actomaton",
@@ -16,7 +20,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0")
-    ],
+    ] + (
+        usesMainActorInTest ? [
+            .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0")
+        ] : []
+    ),
     targets: [
         .target(
             name: "Actomaton",
@@ -36,7 +44,11 @@ let package = Package(
             ]),
         .target(
             name: "TestFixtures",
-            dependencies: ["Actomaton"],
+            dependencies: ["Actomaton"] + (
+                usesMainActorInTest ? [
+                    .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras")
+                ] : []
+            ),
             path: "./Tests/TestFixtures"
         ),
         .testTarget(

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -1,6 +1,10 @@
 // swift-tools-version:6.0
 
+import Foundation
 import PackageDescription
+
+// `$ TEST_MAIN_ACTOR=1 swift test`
+let usesMainActorInTest = ProcessInfo.processInfo.environment["TEST_MAIN_ACTOR"] == "1"
 
 let package = Package(
     name: "Actomaton",
@@ -16,7 +20,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0")
-    ],
+    ] + (
+        usesMainActorInTest ? [
+            .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0")
+        ] : []
+    ),
     targets: [
         .target(
             name: "Actomaton",
@@ -36,7 +44,11 @@ let package = Package(
             ]),
         .target(
             name: "TestFixtures",
-            dependencies: ["Actomaton"],
+            dependencies: ["Actomaton"] + (
+                usesMainActorInTest ? [
+                    .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras")
+                ] : []
+            ),
             path: "./Tests/TestFixtures"
         ),
         .testTarget(
@@ -52,5 +64,5 @@ let package = Package(
             dependencies: ["Actomaton", "ActomatonDebugging"]
         )
     ],
-    swiftLanguageVersions: [.version("6")]
+    swiftLanguageModes: [.v6]
 )

--- a/Tests/ActomatonTests/CounterTests.swift
+++ b/Tests/ActomatonTests/CounterTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Actomaton
 
-final class CounterTests: XCTestCase
+final class CounterTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -40,6 +40,9 @@ final class DeinitTests: MainTestCase
         // Wait until deinit fully completes.
         try? await task?.value
 
+        // Wait another 10ms for reliable deinit completion.
+        try await Task.sleep(nanoseconds: 10_000_000)
+
         // Check results.
         //
         // NOTE:

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Actomaton
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
-final class DeinitTests: XCTestCase
+final class DeinitTests: MainTestCase
 {
     func test_deinit() async throws
     {

--- a/Tests/ActomatonTests/EffectCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectCancellationTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `Effect.cancel`.
-final class EffectCancellationTests: XCTestCase
+final class EffectCancellationTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `Newest1EffectQueueProtocol` where previous effect will be automatically cancelled by the next effect.
-final class EffectIDAutoCancellationTests: XCTestCase
+final class EffectIDAutoCancellationTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `EffectQueueDelay`.
-final class EffectQueueDelayTests: XCTestCase
+final class EffectQueueDelayTests: MainTestCase
 {
     private func makeActomaton<Queue: EffectQueueProtocol>(
         queue: Queue,

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `actomaton.send`'s returned `Task`.
-final class FeedbackTrackingTaskTests: XCTestCase
+final class FeedbackTrackingTaskTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Combine
 #endif
 
-final class LoginLogoutTests: XCTestCase
+final class LoginLogoutTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `Effect.cancel` to cancel pending effects by `Oldest1SuspendNewEffectQueueProtocol`.
-final class PendingEffectCancellationTests: XCTestCase
+final class PendingEffectCancellationTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runNewest(maxCount: n)`.
-final class RunNewestDiscardOldTests: XCTestCase
+final class RunNewestDiscardOldTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
-final class RunOldestDiscardNewTests: XCTestCase
+final class RunOldestDiscardNewTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
-final class RunOldestSuspendNewTests: XCTestCase
+final class RunOldestSuspendNewTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -18,7 +18,7 @@ final class TimerTests: MainTestCase
             AsyncStream<()> { continuation in
                 let task = Task {
                     while true {
-                        try await tick(1)
+                        try await tick(2)
                         continuation.yield(())
                     }
                 }
@@ -65,13 +65,13 @@ final class TimerTests: MainTestCase
 
         assertEqual(await actomaton.state, 0)
 
-        try await tick(1.3)
+        try await tick(2.3)
         assertEqual(await actomaton.state, 1)
 
-        try await tick(1.3)
+        try await tick(2.3)
         assertEqual(await actomaton.state, 2)
 
-        try await tick(1.3)
+        try await tick(2.3)
         assertEqual(await actomaton.state, 3)
 
         await actomaton.send(.stop)

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 /// Tests for `Effect.cancel`.
-final class TimerTests: XCTestCase
+final class TimerTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
 

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -1,3 +1,5 @@
+#if canImport(Combine)
+
 import XCTest
 @testable import ActomatonUI
 
@@ -92,3 +94,5 @@ private actor DeinitChecker
         }
     }
 }
+
+#endif

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import ActomatonUI
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
-final class DeinitTests: XCTestCase
+final class DeinitTests: MainTestCase
 {
     @MainActor
     func test_deinit() async throws

--- a/Tests/TestFixtures/MainTestCase.swift
+++ b/Tests/TestFixtures/MainTestCase.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+
+#if canImport(ConcurrencyExtras)
+
+import ConcurrencyExtras
+
+/// This XCTestCase subclass ensures that all async code is executed in the same order that is enqueued.
+/// [More information](https://www.pointfree.co/blog/posts/110-reliably-testing-async-code-in-swift)
+open class MainTestCase: XCTestCase {
+    open override func invokeTest() {
+        withMainSerialExecutor {
+            super.invokeTest()
+        }
+    }
+}
+
+#else
+
+public typealias MainTestCase = XCTestCase
+
+#endif


### PR DESCRIPTION
This PR improves test cases and support CI test runs by introducing `ConcurrencyExtras` that enforces MainActor-only run.

Note: GitHub Actions's Mac container is not reliable for Swift Concurrency run, so omitted.