### PR TITLE
Fix `MainActomaton.state` using `willChangeState` handler

### DIFF
--- a/Tests/ActomatonTests/MainActomaton/MainActomatonCounterTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonCounterTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Actomaton
 
-#if USE_COMBINE && canImport(Combine)
+#if canImport(Combine)
 import Combine
 #endif
 

--- a/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import Actomaton
+
+/// Tests for `MainActomaton.deinit` to run successfully with cancelling running tasks.
+@MainActor
+@available(macOS 14.0, iOS 17.0, macCatalyst 17.0, watchOS 10.0, tvOS 17.0, *)
+final class MainActomatonDeinitTests: MainTestCase
+{
+    func test_deinit() async throws
+    {
+        let resultsCollector = ResultsCollector<String>()
+
+        var actomaton: MainActomaton2? = MainActomaton2<Action, State>(
+            state: State(),
+            reducer: Reducer { [resultsCollector] action, state, _ in
+                switch action {
+                case .run:
+                    return Effect { [resultsCollector] in
+                        return try await tick(5) {
+                            await resultsCollector.append("Effect succeeded")
+                            return nil
+                        } ifCancelled: {
+                            Debug.print("Effect cancelled")
+                            await resultsCollector.append("Effect cancelled")
+                            return nil
+                        }
+                    }
+                }
+            },
+            environment: Environment(resultsCollector: resultsCollector)
+        )
+
+        weak var weakActomaton = actomaton
+
+        let task = actomaton?.send(.run)
+        try await tick(1)
+
+        // Deinit `actomaton`.
+        actomaton = nil
+        XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
+
+        // Wait until deinit fully completes.
+        try? await task?.value
+
+        // Wait another 10ms for reliable deinit completion.
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        // Check results.
+        //
+        // NOTE:
+        // Arrival timing of 2 results are almost simultaneous thus isn't guaranteed in order,
+        // so will use `Set` here.
+        let results = await resultsCollector.results
+        XCTAssertEqual(
+            Set(results), ["Effect cancelled", "DeinitChecker deinit"],
+            "Running effect should be cancelled, and `DeinitChecker` should deinit."
+        )
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case run
+}
+
+private struct State
+{
+    init() {}
+}
+
+private struct Environment: Sendable
+{
+    let deinitChecker: DeinitChecker
+
+    init(resultsCollector: ResultsCollector<String>)
+    {
+        self.deinitChecker = DeinitChecker(resultsCollector: resultsCollector)
+    }
+}
+
+private actor DeinitChecker
+{
+    let resultsCollector: ResultsCollector<String>
+
+    init(resultsCollector: ResultsCollector<String>)
+    {
+        self.resultsCollector = resultsCollector
+    }
+
+    deinit
+    {
+        Task { [resultsCollector] in
+            await resultsCollector.append("DeinitChecker deinit")
+        }
+    }
+}

--- a/Tests/ActomatonTests/MainActomatonTests.swift
+++ b/Tests/ActomatonTests/MainActomatonTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Actomaton
+
+#if USE_COMBINE && canImport(Combine)
+import Combine
+#endif
+
+@MainActor
+@available(macOS 14.0, iOS 17.0, macCatalyst 17.0, watchOS 10.0, tvOS 17.0, *)
+final class MainActomatonCounterTests: MainTestCase
+{
+    fileprivate var actomaton: MainActomaton2<Action, State>!
+
+    override func setUp() async throws
+    {
+        let actomaton = MainActomaton2<Action, State>(
+            state: State(),
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+                    return Effect.fireAndForget {
+                        print("increment")
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return Effect.fireAndForget {
+                        print("decrement")
+                    }
+                }
+            }
+        )
+        self.actomaton = actomaton
+    }
+
+    func test_increment_decrement() async throws
+    {
+        assertEqual(actomaton.state.count, 0)
+
+        actomaton.send(.increment)
+        assertEqual(actomaton.state.count, 1)
+
+        actomaton.send(.increment)
+        assertEqual(actomaton.state.count, 2)
+
+        actomaton.send(.decrement)
+        assertEqual(actomaton.state.count, 1)
+
+        actomaton.send(.decrement)
+        assertEqual(actomaton.state.count, 0)
+
+        actomaton.send(.decrement)
+        assertEqual(actomaton.state.count, -1)
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case increment
+    case decrement
+}
+
+private struct State
+{
+    var count: Int = 0
+}


### PR DESCRIPTION
This PR fixes `MainActomaton.state` that wasn't updated properly after `send`, which is caused by:
- https://github.com/Actomaton/Actomaton/pull/94#discussion_r1835442339

This PR also adds `MainActomaton` test cases as well as improving `Actomaton`-`MainActomaton` state forwarding by using `willChangeState` handler.