### PR TITLE
Add SwiftFormat SPM plugin with CI lint support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,21 @@ on:
   pull_request:
 
 jobs:
+  swiftformat:
+    name: SwiftFormat lint
+    runs-on: ubuntu-latest
+    container: swift:6.2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache SPM build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: swiftformat-${{ hashFiles('Package.resolved') }}
+          restore-keys: swiftformat-
+      - name: Lint
+        run: swift package plugin --allow-writing-to-package-directory swiftformat --lint
+
   xcode26-build:
     name: Xcode ${{ matrix.xcode }} build ${{ matrix.platform }}
     runs-on: macos-26

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,74 @@
+# SwiftFormat configuration for Actomaton
+# https://github.com/nicklockwood/SwiftFormat
+
+# Swift version
+--swiftversion 6.2
+
+# Formatting options
+--indent 4
+--maxwidth 120
+--linebreaks lf
+--semicolons never
+--self insert
+--elseposition next-line
+--guardelse next-line
+--ifdef outdent
+--indentcase false
+--header ignore
+--importgrouping alpha
+--closingparen balanced
+--wraparguments before-first
+--wrapcollections before-first
+--wrapparameters before-first
+--wraptypealiases before-first
+--funcattributes prev-line
+--typeattributes prev-line
+--storedvarattrs prev-line
+--computedvarattrs preserve
+--patternlet hoist
+--stripunusedargs closure-only
+--modifierorder open,public,internal,fileprivate,private,override,final,required,convenience,static,class,dynamic,optional,lazy,weak,unowned,nonisolated,isolated
+--voidtype void
+
+# Disabled rules
+# NOTE: braces rule disabled because codebase uses hybrid style:
+#   - Allman (next-line brace) for function/type/extension/computed property declarations
+#   - K&R (same-line brace) for closures, willSet/didSet, control flow (if/switch/for)
+# SwiftFormat's --allman flag applies to ALL braces, so we preserve existing style instead.
+--disable braces
+--disable wrapMultilineStatementBraces
+--disable extensionAccessControl
+--disable hoistAwait
+--disable hoistTry
+--disable enumNamespaces
+--disable opaqueGenericParameters
+--disable markTypes
+--disable organizeDeclarations
+--disable docComments
+--disable wrapConditionalBodies
+--disable blankLineAfterSwitchCase
+--disable wrapSwitchCases
+--disable wrapEnumCases
+--disable sortSwitchCases
+--disable blockComments
+--disable acronyms
+--disable simplifyGenericConstraints
+--disable redundantSendable
+--disable redundantAsync
+--disable redundantThrows
+--disable redundantInternal
+--disable redundantSelf
+--disable redundantReturn
+--disable trailingClosures
+--disable trailingCommas
+--disable preferKeyPath
+--disable void
+--disable redundantVariable
+# Avoid too aggressive `fileprivate` to `private` conversion that may fail to compile.
+--disable redundantFileprivate
+# Keep `case someCodingKeyName = "..."` raw value to avoid breaking change when case-renaming occurs.
+--disable redundantRawValues
+
+# Exclude
+--exclude .build
+--exclude Package.swift

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ _xcode:
 swift-test:
 	TEST_MAIN_ACTOR=$(TEST_MAIN_ACTOR) swift test
 
+.PHONY: swiftformat
+swiftformat:
+	swift package plugin --allow-writing-to-package-directory swiftformat
+
+.PHONY: swiftformat-lint
+swiftformat-lint:
+	swift package plugin --allow-writing-to-package-directory swiftformat --lint
+
 #--------------------------------------------------
 # DocC
 #--------------------------------------------------

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "4ba779605f3831e1751d0e8cf9da17c29524ae24d73802defe8ad68acbd047b3",
   "pins" : [
     {
       "identity" : "swift-case-paths",
@@ -19,6 +20,15 @@
       }
     },
     {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "c8e50ff2cfc2eab46246c072a9ae25ab656c6ec3",
+        "version" : "0.60.1"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
@@ -28,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0")
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"),
     ] + (
         usesMainActorInTest ? [
             .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0")

--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -44,7 +44,8 @@ public actor Actomaton<Action, State>
     private let executingActor: any Actor
 
     /// State change handler, mainly used for synchronizing with `MainActomaton`'s `@Published state`.
-    /// - Todo: Expose this handler (setter) as `public`, as this handler is useful in Linux which `@Published` is not available.
+    /// - Todo: Expose this handler (setter) as `public`, as this handler is useful in Linux which `@Published` is not
+    /// available.
     private let willChangeState: (_ isolation: isolated Actomaton, _ old: State, _ new: State) -> Void
 
     /// Initializer without `environment`.
@@ -64,7 +65,8 @@ public actor Actomaton<Action, State>
         state: State,
         reducer: Reducer<Action, State, ()>,
         executingActor: any Actor,
-        willChangeState: @escaping (_ isolation: isolated Actomaton, _ old: State, _ new: State) -> Void = { _, _, _ in }
+        willChangeState: @escaping (_ isolation: isolated Actomaton, _ old: State, _ new: State) -> Void = { _, _, _ in
+        }
     )
     {
 #if !DISABLE_COMBINE && canImport(Combine)
@@ -132,7 +134,8 @@ public actor Actomaton<Action, State>
         tracksFeedbacks: Bool = false
     ) -> Task<(), any Error>?
     {
-        Debug.print("[send] \(action), priority = \(String(describing: priority)), tracksFeedbacks = \(tracksFeedbacks)")
+        Debug
+            .print("[send] \(action), priority = \(String(describing: priority)), tracksFeedbacks = \(tracksFeedbacks)")
 
         let effect = reducer.run(action, &state, ())
 
@@ -228,11 +231,14 @@ extension Actomaton
                 for _ in 0 ..< droppingCount {
                     let droppingTask = self.queuedRunningTasks[queue.queue]?.removeFirst()
 
-                    if let droppingTask = droppingTask {
+                    if let droppingTask {
 #if DEBUG
                         let droppingEffectID = self.runningTasks
                             .first(where: { $0.value.contains(droppingTask) })?.key
-                        Debug.print("[checkQueuePolicy] [runNewest] droppingEffectID = \(String(describing: droppingEffectID))")
+                        Debug
+                            .print(
+                                "[checkQueuePolicy] [runNewest] droppingEffectID = \(String(describing: droppingEffectID))"
+                            )
 #endif
                         droppingTask.cancel()
                     }
@@ -274,7 +280,7 @@ extension Actomaton
     private func calculateEffectDelay(queue: AnyEffectQueue?) -> TimeInterval
     {
         // No queue means, immediate task run.
-        guard let queue = queue else { return 0 }
+        guard let queue else { return 0 }
 
         let delayAfterLatestEffect = queue.effectQueueDelay.timeInterval
         let latestEffectDate = self.latestEffectDate[queue.queue, default: Date(timeIntervalSince1970: 0)]
@@ -282,7 +288,10 @@ extension Actomaton
         let targetDelaySinceNow = max(latestEffectDate.timeIntervalSinceNow + delayAfterLatestEffect, 0)
         self.latestEffectDate[queue.queue] = Date(timeIntervalSinceNow: targetDelaySinceNow)
 
-        Debug.print("[calculateEffectDelay] delayAfterLatestExec = \(delayAfterLatestEffect), latestEffectDate = \(latestEffectDate), targetDelaySinceNow = \(targetDelaySinceNow)")
+        Debug
+            .print(
+                "[calculateEffectDelay] delayAfterLatestExec = \(delayAfterLatestEffect), latestEffectDate = \(latestEffectDate), targetDelaySinceNow = \(targetDelaySinceNow)"
+            )
 
         return targetDelaySinceNow
     }
@@ -306,7 +315,7 @@ extension Actomaton
             let nextAction = try await single.run()
 
             // Feed back `nextAction`.
-            if let nextAction = nextAction {
+            if let nextAction {
                 let feedbackTask = await self?.send(nextAction, priority: priority, tracksFeedbacks: tracksFeedbacks)
                 if tracksFeedbacks {
                     try await feedbackTask?.value
@@ -343,7 +352,7 @@ extension Actomaton
                 // Feed back `nextAction`.
                 let feedbackTask = await self?.send(nextAction, priority: priority, tracksFeedbacks: tracksFeedbacks)
 
-                if let feedbackTask = feedbackTask {
+                if let feedbackTask {
                     feedbackTasks.append(feedbackTask)
                 }
             }
@@ -361,7 +370,13 @@ extension Actomaton
             }
         }
 
-        self.enqueueTask(task, id: sequence.id, queue: sequence.queue, priority: priority, tracksFeedbacks: tracksFeedbacks)
+        self.enqueueTask(
+            task,
+            id: sequence.id,
+            queue: sequence.queue,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks
+        )
 
         return task
     }
@@ -381,7 +396,7 @@ extension Actomaton
         Debug.print("[enqueueTask] Append id-task: \(effectID)")
         self.runningTasks[effectID, default: []].insert(task)
 
-        if let queue = queue {
+        if let queue {
             Debug.print("[enqueueTask] Append queue-task: \(queue)")
             self.queuedRunningTasks[queue.queue, default: []].append(task)
         }
@@ -394,7 +409,7 @@ extension Actomaton
             Debug.print("[enqueueTask] Task completed, removing id-task: \(effectID)")
             await self?.removeTask(id: effectID, task: task)
 
-            if let queue = queue {
+            if let queue {
                 await self?.removeTaskIfNeeded(task: task, in: queue)
 
                 switch queue.effectQueuePolicy {
@@ -402,7 +417,11 @@ extension Actomaton
                     if let pendingEffectKind = await self?.dequeuePendingEffectKindIfPossible(queue: queue) {
                         Debug.print("[enqueueTask] Extracted pending effect")
 
-                        if let _ = await self?.performEffectKind(pendingEffectKind, priority: priority, tracksFeedbacks: tracksFeedbacks) {
+                        if let _ = await self?.performEffectKind(
+                            pendingEffectKind,
+                            priority: priority,
+                            tracksFeedbacks: tracksFeedbacks
+                        ) {
                             Debug.print("[enqueueTask] Pending effect started running")
                         }
                         else {

--- a/Sources/Actomaton/Effect.swift
+++ b/Sources/Actomaton/Effect.swift
@@ -373,7 +373,11 @@ extension Effect
         internal let queue: AnyEffectQueue?
         internal let run: @Sendable () async throws -> Action?
 
-        internal init(id: EffectID? = nil, queue: AnyEffectQueue? = nil, run: @escaping @Sendable () async throws -> Action?)
+        internal init(
+            id: EffectID? = nil,
+            queue: AnyEffectQueue? = nil,
+            run: @escaping @Sendable () async throws -> Action?
+        )
         {
             self.id = id
             self.queue = queue

--- a/Sources/Actomaton/EffectQueue.swift
+++ b/Sources/Actomaton/EffectQueue.swift
@@ -15,7 +15,8 @@ public struct EffectQueue: Hashable, Sendable
     }
 }
 
-/// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of new effects.
+/// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of
+/// new effects.
 public protocol EffectQueueProtocol: Hashable, Sendable
 {
     /// Effect buffering policy.

--- a/Sources/Actomaton/Internal/AnyAsyncSequence.swift
+++ b/Sources/Actomaton/Internal/AnyAsyncSequence.swift
@@ -1,4 +1,5 @@
-// Code from: https://github.com/Apodini/Apodini/blob/develop/Sources/ApodiniExtension/AsyncSequenceHelpers/AnyAsyncSequence.swift
+// Code from:
+// https://github.com/Apodini/Apodini/blob/develop/Sources/ApodiniExtension/AsyncSequenceHelpers/AnyAsyncSequence.swift
 
 /// A type-erased version of a `AsyncSequence` that contains values of type `Element`.
 struct AnyAsyncSequence<Element>: AsyncSequence

--- a/Sources/Actomaton/MainActomaton.swift
+++ b/Sources/Actomaton/MainActomaton.swift
@@ -50,7 +50,7 @@ package final class MainActomaton<Action, State>
         self.state = state
 
         // Update `MainActomaton`'s `@Published` state.
-        willChangeState = { [weak self] old, new in
+        willChangeState = { [weak self] _, new in
             self?.state = new
         }
 #endif

--- a/Sources/Actomaton/UncheckedSendable.swift
+++ b/Sources/Actomaton/UncheckedSendable.swift
@@ -5,6 +5,7 @@ extension CasePath: @retroactive @unchecked Sendable {}
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
+
 extension Published.Publisher: @retroactive @unchecked Sendable {}
 
 extension AsyncPublisher: @retroactive @unchecked Sendable {}

--- a/Sources/ActomatonDebugging/Reducer+Debugging.swift
+++ b/Sources/ActomatonDebugging/Reducer+Debugging.swift
@@ -68,7 +68,7 @@ extension Reducer
         where Action: Sendable, State: Sendable
     {
         // Return normal reducer without logging.
-        guard let format = format else {
+        guard let format else {
             return Reducer(nextRun)
         }
 
@@ -125,7 +125,8 @@ extension Reducer
                         let name = format.name.map { "\($0) " } ?? ""
 
                         if let diffString = diff(currentState, nextState) {
-                            print("\(name)state diff = ") // NOTE: Adds linebreak because `diffString` contains +- symbols.
+                            print("\(name)state diff = ") // NOTE: Adds linebreak because `diffString` contains +-
+                            // symbols.
                             print(diffString)
                         }
                         else {

--- a/Sources/ActomatonUI/Extensions/MutableCollection+Helper.swift
+++ b/Sources/ActomatonUI/Extensions/MutableCollection+Helper.swift
@@ -2,9 +2,10 @@ extension MutableCollection
 {
     /// Safe get / set element for `MutableCollection`.
     ///
-    /// - Note: When working with SwiftUI, safe array access is often needed to avoid `ContiguousArrayBuffer` index out of range error.
+    /// - Note: When working with SwiftUI, safe array access is often needed to avoid `ContiguousArrayBuffer` index out
+    /// of range error.
     ///   https://stackoverflow.com/questions/59295206/how-do-you-use-enumerated-with-foreach-in-swiftui/63145650
-    public subscript (safe index: Index) -> Iterator.Element?
+    public subscript(safe index: Index) -> Iterator.Element?
     {
         get {
             self.startIndex <= index && index < self.endIndex
@@ -12,7 +13,7 @@ extension MutableCollection
                 : nil
         }
         set {
-            guard let newValue = newValue, self.startIndex <= index && index < self.endIndex else { return }
+            guard let newValue, self.startIndex <= index, index < self.endIndex else { return }
             self[index] = newValue
         }
     }

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -4,7 +4,8 @@
 ///
 /// - Important: ``Store`` is NOT `ObservableObject` thus its state can't be observed by SwiftUI views.
 ///
-/// To make it observable in SwiftUI, use ``WithViewStore`` (SwiftUI View) to create ``ViewStore`` which is `ObservableObject`.
+/// To make it observable in SwiftUI, use ``WithViewStore`` (SwiftUI View) to create ``ViewStore`` which is
+/// `ObservableObject`.
 /// Note that ``Store/map(state:)`` can narrow down ``Store``'s scope before passing to ``WithViewStore``
 /// so that only the subset of state changes can be observed by SwiftUI, allowing optimized rendering.
 ///
@@ -57,7 +58,10 @@ public class Store<Action, State, Environment>
     /// For example, `AVPlayer` may be needed in both `Reducer` and `AVKit.VideoPlayer`.
     public let environment: Environment
 
-    private let _send: @MainActor (BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), any Error>?
+    private let _send: @MainActor (BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<
+        (),
+        any Error
+    >?
 
     /// Initializer with `environment`.
     public convenience init(
@@ -100,7 +104,10 @@ public class Store<Action, State, Environment>
     internal init(
         state: CurrentValuePublisher<State>,
         environment: Environment,
-        send: @escaping @MainActor (BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), any Error>?
+        send: @escaping @MainActor (BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<
+            (),
+            any Error
+        >?
     )
     {
         self._state = state
@@ -201,7 +208,7 @@ extension Store
             state: (
                 get: { $0.map { $0[keyPath: keyPath] } },
                 set: { state, substate in
-                    if let substate = substate {
+                    if let substate {
                         state?[keyPath: keyPath] = substate
                     }
                 }
@@ -304,7 +311,9 @@ extension Store
 
                 case .state:
                     // `SubState` is immutable, so should not reach here.
-                    assertionFailure("Detected the calls of `ViewStore.directBinding` after `Store.indirectMap` which is illegal. Always use `ViewStore.binding(get:onChange:)` whenever using `indirectMap`. Otherwise, direct-binding will be discarded in Release build.")
+                    assertionFailure(
+                        "Detected the calls of `ViewStore.directBinding` after `Store.indirectMap` which is illegal. Always use `ViewStore.binding(get:onChange:)` whenever using `indirectMap`. Otherwise, direct-binding will be discarded in Release build."
+                    )
                     return nil
                 }
             }
@@ -327,7 +336,7 @@ extension Store
                     return self._send(.action(action), priority: priority, tracksFeedbacks: tracksFeedback)
 
                 case let .state(substate):
-                    guard let substate = substate else { return nil }
+                    guard let substate else { return nil }
 
                     let state = casePath.embed(substate)
                     return self._send(.state(state), priority: priority, tracksFeedbacks: tracksFeedback)

--- a/Sources/ActomatonUI/Store/StoreConfiguration.swift
+++ b/Sources/ActomatonUI/Store/StoreConfiguration.swift
@@ -7,7 +7,8 @@ public struct StoreConfiguration
     let logFormat: LogFormat?
 
     /// - Parameter logFormat:
-    ///   Debug-logging format for ``Store``, including detection of direct-state-binding changes. Default value is `nil` (no logging).
+    ///   Debug-logging format for ``Store``, including detection of direct-state-binding changes. Default value is
+    /// `nil` (no logging).
     public init(logFormat: LogFormat? = nil)
     {
         self.logFormat = logFormat

--- a/Sources/ActomatonUI/SwiftUI/Binding+Helper.swift
+++ b/Sources/ActomatonUI/SwiftUI/Binding+Helper.swift
@@ -1,6 +1,6 @@
 #if canImport(SwiftUI)
-import SwiftUI
 import CasePaths
+import SwiftUI
 
 // MARK: - Functor
 
@@ -45,7 +45,7 @@ extension Binding
                 casePath.extract(from: self.wrappedValue)
             },
             set: { value, transaction in
-                if let value = value {
+                if let value {
                     self.transaction(transaction).wrappedValue = casePath.embed(value)
                 }
             }

--- a/Sources/ActomatonUI/SwiftUI/ForEach+Store.swift
+++ b/Sources/ActomatonUI/SwiftUI/ForEach+Store.swift
@@ -27,13 +27,13 @@ extension ForEach
         self.init(
             Array(zip(state.indices, state)),
             id: firstKeyPath.appending(path: id)
-        ) { index, child in
+        ) { index, _ in
             // IMPORTANT:
             // Safe array access is needed to avoid `ContiguousArrayBuffer` index out of range error.
             // https://stackoverflow.com/questions/59295206/how-do-you-use-enumerated-with-foreach-in-swiftui/63145650
             let substore = store.map(state: \.[safe: index]).optionalize()
 
-            if let substore = substore {
+            if let substore {
                 content(substore)
             }
         }

--- a/Sources/ActomatonUI/SwiftUI/ViewStore.swift
+++ b/Sources/ActomatonUI/SwiftUI/ViewStore.swift
@@ -2,13 +2,15 @@
 import Combine
 import SwiftUI
 
-/// ``Store``'s `ObservableObject` proxy type that can create direct (state-to-state) & indirect (state-to-action) `Binding`s.
+/// ``Store``'s `ObservableObject` proxy type that can create direct (state-to-state) & indirect (state-to-action)
+/// `Binding`s.
 ///
 /// 1. Indirectly mutate `state` by ``binding(get:onChange:)`` and providing action "onChange"
 /// 2. Directly mutate `state` by ``directBinding``
 ///     - Updated state that passes through this `Binding` will NOT pass user-defined `Reducer`.
 ///
-/// Since ``Store`` is not capable of observing its state in SwiftUI, ``ViewStore`` is needed to be attached to SwiftUI view instead, either by:
+/// Since ``Store`` is not capable of observing its state in SwiftUI, ``ViewStore`` is needed to be attached to SwiftUI
+/// view instead, either by:
 ///
 /// 1. Create via ``Store/viewStore`` and attach to `SwiftUI.View` by writing
 ///   `@ObservedObject var viewStore: ViewStore<Action, State>`
@@ -126,7 +128,8 @@ extension ViewStore
         )
     }
 
-    /// Creates indirect `Binding<Bool>` as SwiftUI presentation binding from optional `State`, and sends `Action` on dismissal.
+    /// Creates indirect `Binding<Bool>` as SwiftUI presentation binding from optional `State`, and sends `Action` on
+    /// dismissal.
     public func isPresented<Wrapped>(onDismiss: @autoclosure @escaping () -> Action) -> Binding<Bool>
         where State == Wrapped?
     {

--- a/Sources/ActomatonUI/UIKit/HostingViewController.swift
+++ b/Sources/ActomatonUI/UIKit/HostingViewController.swift
@@ -1,8 +1,8 @@
 #if canImport(UIKit) && canImport(SwiftUI) && !os(watchOS) && !DISABLE_COMBINE && canImport(Combine)
 
-import UIKit
 import Combine
 import SwiftUI
+import UIKit
 
 /// SwiftUI `View` & ``Store`` wrapper view controller that holds `UIHostingController`.
 @MainActor
@@ -23,7 +23,8 @@ open class HostingViewController<Action, State, Environment, Content: SwiftUI.Vi
         super.init(nibName: nil, bundle: nil)
     }
 
-    /// Initializer for ``RouteStore`` as argument, with forgetting ``SendRouteEnvironment/sendRoute`` capability when making `content`.
+    /// Initializer for ``RouteStore`` as argument, with forgetting ``SendRouteEnvironment/sendRoute`` capability when
+    /// making `content`.
     public init<Route>(
         store routeStore: RouteStore<Action, State, Environment, Route>,
         @ViewBuilder content: @escaping @MainActor (Store<Action, State, Environment>) -> Content
@@ -37,6 +38,7 @@ open class HostingViewController<Action, State, Environment, Content: SwiftUI.Vi
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     public required init?(coder: NSCoder)
     {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -1,12 +1,12 @@
 #if !DISABLE_COMBINE && canImport(Combine)
 
-import Dispatch
 import Combine
+import Dispatch
 
 /// `Store` wrapper that also outputs `routes`, mainly used for UIKit's navigation handling.
 @MainActor
-public final class RouteStore<Action, State, Environment, Route>
-    : Store<Action, State, SendRouteEnvironment<Environment, Route>>
+public final class RouteStore<Action, State, Environment, Route>:
+    Store<Action, State, SendRouteEnvironment<Environment, Route>>
     where Action: Sendable, State: Sendable, Environment: Sendable
 {
     private let core: StoreCore<Action, State, SendRouteEnvironment<Environment, Route>>

--- a/Tests/ActomatonTests/CounterTests.swift
+++ b/Tests/ActomatonTests/CounterTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 final class CounterTests: MainTestCase
 {

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
 final class DeinitTests: MainTestCase
@@ -10,7 +10,7 @@ final class DeinitTests: MainTestCase
 
         var actomaton: Actomaton? = Actomaton<Action, State>(
             state: State(),
-            reducer: Reducer { [resultsCollector] action, state, _ in
+            reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
                 case .run:
                     return Effect { [resultsCollector] in

--- a/Tests/ActomatonTests/EffectCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectCancellationTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -22,10 +22,10 @@ final class EffectCancellationTests: MainTestCase
             is2To3Cancelled: Bool? = nil
         )
         {
-            if let is1To2Cancelled = is1To2Cancelled {
+            if let is1To2Cancelled {
                 self.is1To2Cancelled = is1To2Cancelled
             }
-            if let is2To3Cancelled = is2To3Cancelled {
+            if let is2To3Cancelled {
                 self.is2To3Cancelled = is2To3Cancelled
             }
         }
@@ -90,7 +90,6 @@ final class EffectCancellationTests: MainTestCase
                         return nil
                     } + Effect.cancel(id: EffectID2To3())
                 }
-
             }
         )
         self.actomaton = actomaton
@@ -134,16 +133,22 @@ final class EffectCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._2)
 
         try await tick(0.1)
-        assertEqual(await actomaton.state, ._2,
-                    "Only delta time has passed, so state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._2,
+            "Only delta time has passed, so state should not change"
+        )
 
         // Cancel 1To2.
         await actomaton.send(._cancel1To2)
         assertEqual(await actomaton.state, .cancelled)
 
         try await tick(5)
-        assertEqual(await actomaton.state, .cancelled,
-                    "Waited for enough time, and state should not change")
+        assertEqual(
+            await actomaton.state,
+            .cancelled,
+            "Waited for enough time, and state should not change"
+        )
 
         let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertTrue(is1To2Cancelled, "Should cancel.")
@@ -164,16 +169,22 @@ final class EffectCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._3)
 
         try await tick(0.1)
-        assertEqual(await actomaton.state, ._3,
-                    "Only delta time has passed, so state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._3,
+            "Only delta time has passed, so state should not change"
+        )
 
         // Cancel 1To2.
         await actomaton.send(._cancel1To2)
         assertEqual(await actomaton.state, .cancelled)
 
         try await tick(5)
-        assertEqual(await actomaton.state, .cancelled,
-                    "Waited for enough time, and state should not change")
+        assertEqual(
+            await actomaton.state,
+            .cancelled,
+            "Waited for enough time, and state should not change"
+        )
 
         let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertFalse(is1To2Cancelled, "Should not cancel because send is too late.")
@@ -190,16 +201,22 @@ final class EffectCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._2)
 
         try await tick(0.1)
-        assertEqual(await actomaton.state, ._2,
-                    "Only delta time has passed, so state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._2,
+            "Only delta time has passed, so state should not change"
+        )
 
         // Cancel 2To3.
         await actomaton.send(._cancel2To3)
         assertEqual(await actomaton.state, .cancelled)
 
         try await tick(5)
-        assertEqual(await actomaton.state, .cancelled,
-                    "Waited for enough time, and state should not change")
+        assertEqual(
+            await actomaton.state,
+            .cancelled,
+            "Waited for enough time, and state should not change"
+        )
 
         let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertFalse(is1To2Cancelled, "Should not cancel because send is too early.")
@@ -220,16 +237,22 @@ final class EffectCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._3)
 
         try await tick(0.1)
-        assertEqual(await actomaton.state, ._3,
-                    "Only delta time has passed, so state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._3,
+            "Only delta time has passed, so state should not change"
+        )
 
         // Cancel 2To3.
         await actomaton.send(._cancel2To3)
         assertEqual(await actomaton.state, .cancelled)
 
         try await tick(5)
-        assertEqual(await actomaton.state, .cancelled,
-                    "Waited for enough time, and state should not change")
+        assertEqual(
+            await actomaton.state,
+            .cancelled,
+            "Waited for enough time, and state should not change"
+        )
 
         let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertFalse(is1To2Cancelled)

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -22,10 +22,10 @@ final class EffectIDAutoCancellationTests: MainTestCase
             is2To3Cancelled: Bool? = nil
         )
         {
-            if let is1To2Cancelled = is1To2Cancelled {
+            if let is1To2Cancelled {
                 self.is1To2Cancelled = is1To2Cancelled
             }
-            if let is2To3Cancelled = is2To3Cancelled {
+            if let is2To3Cancelled {
                 self.is2To3Cancelled = is2To3Cancelled
             }
         }
@@ -82,7 +82,6 @@ final class EffectIDAutoCancellationTests: MainTestCase
                         return nil
                     }
                 }
-
             }
         )
         self.actomaton = actomaton
@@ -126,15 +125,21 @@ final class EffectIDAutoCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._2)
 
         try await tick(0.1)
-        assertEqual(await actomaton.state, ._2,
-                    "Only delta time has passed, so state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._2,
+            "Only delta time has passed, so state should not change"
+        )
 
         await actomaton.send(._toEnd)
         assertEqual(await actomaton.state, ._end)
 
         try await tick(5)
-        assertEqual(await actomaton.state, ._end,
-                    "Waited for enough time, and state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._end,
+            "Waited for enough time, and state should not change"
+        )
 
         let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertTrue(is1To2Cancelled)
@@ -155,15 +160,21 @@ final class EffectIDAutoCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._3)
 
         try await tick(0.1)
-        assertEqual(await actomaton.state, ._3,
-                    "Only delta time has passed, so state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._3,
+            "Only delta time has passed, so state should not change"
+        )
 
         await actomaton.send(._toEnd)
         assertEqual(await actomaton.state, ._end)
 
         try await tick(5)
-        assertEqual(await actomaton.state, ._end,
-                    "Waited for enough time, and state should not change")
+        assertEqual(
+            await actomaton.state,
+            ._end,
+            "Waited for enough time, and state should not change"
+        )
 
         let is1To2Cancelled = await flags.is1To2Cancelled
         XCTAssertFalse(is1To2Cancelled)

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -107,8 +107,11 @@ final class EffectQueueDelayTests: MainTestCase
         assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3", "4"])
 
         // ResultCollector
-        assertEqual(await startedIDs.results, ["1", "2", "3", "4"],
-                    "Should run all effects.")
+        assertEqual(
+            await startedIDs.results,
+            ["1", "2", "3", "4"],
+            "Should run all effects."
+        )
         assertEqual(await cancelledIDs.results, [])
     }
 
@@ -143,8 +146,11 @@ final class EffectQueueDelayTests: MainTestCase
         assertEqual(await actomaton.state.finishedIDs, ["3", "4"])
 
         // ResultCollector
-        assertEqual(await startedIDs.results, ["3", "4"],
-                    "Only last 2 should run effects.")
+        assertEqual(
+            await startedIDs.results,
+            ["3", "4"],
+            "Only last 2 should run effects."
+        )
 
         // NOTE: In Swift 6, cancellation arrival is indeterminate, so requires `sorted()`.
         assertEqual(await cancelledIDs.results.sorted(), ["1", "2"])
@@ -183,8 +189,11 @@ final class EffectQueueDelayTests: MainTestCase
         assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3", "4"])
 
         // ResultCollector
-        assertEqual(await startedIDs.results, ["1", "2", "3", "4"],
-                    "Should run all effects.")
+        assertEqual(
+            await startedIDs.results,
+            ["1", "2", "3", "4"],
+            "Should run all effects."
+        )
         assertEqual(await cancelledIDs.results, [])
     }
 
@@ -215,8 +224,11 @@ final class EffectQueueDelayTests: MainTestCase
         assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
 
         // ResultCollector
-        assertEqual(await startedIDs.results.sorted(), ["1", "2"],
-                    "Only first 2 should run effects.")
+        assertEqual(
+            await startedIDs.results.sorted(),
+            ["1", "2"],
+            "Only first 2 should run effects."
+        )
         assertEqual(await cancelledIDs.results.sorted(), ["3", "4"])
     }
 }
@@ -242,29 +254,49 @@ private struct EffectID: EffectIDProtocol
 private struct DelayedEffectQueue: EffectQueueProtocol
 {
     let delay: TimeInterval
-    var effectQueuePolicy: EffectQueuePolicy { .runNewest(maxCount: .max) }
-    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+    var effectQueuePolicy: EffectQueuePolicy {
+        .runNewest(maxCount: .max)
+    }
+
+    var effectQueueDelay: EffectQueueDelay {
+        .constant(delay * timescale)
+    }
 }
 
 private struct DelayedNewest2EffectQueue: EffectQueueProtocol
 {
     let delay: TimeInterval
-    var effectQueuePolicy: EffectQueuePolicy { .runNewest(maxCount: 2) }
-    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+    var effectQueuePolicy: EffectQueuePolicy {
+        .runNewest(maxCount: 2)
+    }
+
+    var effectQueueDelay: EffectQueueDelay {
+        .constant(delay * timescale)
+    }
 }
 
 private struct DelayedOldest2SuspendNewEffectQueue: EffectQueueProtocol
 {
     let delay: TimeInterval
-    var effectQueuePolicy: EffectQueuePolicy { .runOldest(maxCount: 2, .suspendNew) }
-    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+    var effectQueuePolicy: EffectQueuePolicy {
+        .runOldest(maxCount: 2, .suspendNew)
+    }
+
+    var effectQueueDelay: EffectQueueDelay {
+        .constant(delay * timescale)
+    }
 }
 
 private struct DelayedOldest2DiscardNewEffectQueue: EffectQueueProtocol
 {
     let delay: TimeInterval
-    var effectQueuePolicy: EffectQueuePolicy { .runOldest(maxCount: 2, .discardNew) }
-    var effectQueueDelay: EffectQueueDelay { .constant(delay * timescale) }
+    var effectQueuePolicy: EffectQueuePolicy {
+        .runOldest(maxCount: 2, .discardNew)
+    }
+
+    var effectQueueDelay: EffectQueueDelay {
+        .constant(delay * timescale)
+    }
 }
 
-private let timescale: TimeInterval = TimeInterval(tickTimeInterval) / 1_000_000_000
+private let timescale: TimeInterval = .init(tickTimeInterval) / 1_000_000_000

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -99,7 +99,6 @@ final class FeedbackTrackingTaskTests: MainTestCase
                         return nil
                     }
                 }
-
             }
         )
         self.actomaton = actomaton
@@ -126,11 +125,14 @@ final class FeedbackTrackingTaskTests: MainTestCase
         // Wait for `._1To2`'s effect only (upto `_2To3`'s next state-transition without its effect)
         try await task?.value
 
-        assertEqual(await actomaton.state, ._3,
-                    """
-                    "State should be `_3` because `._2To3` (next action and state change) will also be triggered
-                    as part of `._1To2`'s effect. (NOTE: `._2To3`'s effect won't be awaited)
-                    """)
+        assertEqual(
+            await actomaton.state,
+            ._3,
+            """
+            "State should be `_3` because `._2To3` (next action and state change) will also be triggered
+            as part of `._1To2`'s effect. (NOTE: `._2To3`'s effect won't be awaited)
+            """
+        )
 
         try await tick(1.3)
         assertEqual(await actomaton.state, ._4(count: 0))
@@ -142,8 +144,8 @@ final class FeedbackTrackingTaskTests: MainTestCase
         assertEqual(await actomaton.state, ._4(count: 2))
 
         // Comment-Out: A bit flaky to check this intermediate state, so ignore it.
-        //try await tick(1.3)
-        //assertEqual(await actomaton.state, ._5)
+        // try await tick(1.3)
+        // assertEqual(await actomaton.state, ._5)
 
         try await tick(2)
         assertEqual(await actomaton.state, ._6)
@@ -162,8 +164,11 @@ final class FeedbackTrackingTaskTests: MainTestCase
         // Wait for all: `._1To2`, `._2To3`, `._3To4`, `._increment`, `._4To5`, `._5To6`.
         try await task?.value
 
-        assertEqual(await actomaton.state, ._6,
-                    "Should wait for final result `._6` because `tracksFeedbacks = true`")
+        assertEqual(
+            await actomaton.state,
+            ._6,
+            "Should wait for final result `._6` because `tracksFeedbacks = true`"
+        )
     }
 
     func test_tracksFeedbacks_sequence() async throws
@@ -179,8 +184,11 @@ final class FeedbackTrackingTaskTests: MainTestCase
         // Wait for all: `._3To4`, `._increment`, `._4To5`, `._5To6`.
         try await task?.value
 
-        assertEqual(await actomaton.state, ._6,
-                    "Should wait for final result `._5` because `tracksFeedbacks = true`")
+        assertEqual(
+            await actomaton.state,
+            ._6,
+            "Should wait for final result `._5` because `tracksFeedbacks = true`"
+        )
     }
 }
 

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -19,7 +19,7 @@ final class LoginLogoutTests: MainTestCase
             isLoginCancelled: Bool? = nil
         )
         {
-            if let isLoginCancelled = isLoginCancelled {
+            if let isLoginCancelled {
                 self.isLoginCancelled = isLoginCancelled
             }
         }
@@ -56,8 +56,8 @@ final class LoginLogoutTests: MainTestCase
                     return .empty
 
                 case (.logout, .loggedIn),
-                    (.forceLogout, .loggingIn),
-                    (.forceLogout, .loggedIn):
+                     (.forceLogout, .loggingIn),
+                     (.forceLogout, .loggedIn):
                     state = .loggingOut
                     return Effect(queue: LoginFlowEffectQueue()) {
                         try await tick(1)
@@ -140,8 +140,10 @@ final class LoginLogoutTests: MainTestCase
         assertEqual(await actomaton.state, .loggedOut)
 
         let isLoginCancelled = await flags.isLoginCancelled
-        XCTAssertTrue(isLoginCancelled,
-                      "login's effect should be cancelled")
+        XCTAssertTrue(
+            isLoginCancelled,
+            "login's effect should be cancelled"
+        )
     }
 }
 

--- a/Tests/ActomatonTests/MainActomaton/MainActomatonCounterTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonCounterTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine

--- a/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 /// Tests for `MainActomaton.deinit` to run successfully with cancelling running tasks.
 @MainActor
@@ -12,7 +12,7 @@ final class MainActomatonDeinitTests: MainTestCase
 
         var actomaton: MainActomaton? = MainActomaton<Action, State>(
             state: State(),
-            reducer: Reducer { [resultsCollector] action, state, _ in
+            reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
                 case .run:
                     return Effect { [resultsCollector] in

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -22,10 +22,10 @@ final class PendingEffectCancellationTests: MainTestCase
             result2: Result? = nil
         )
         {
-            if let result1 = result1 {
+            if let result1 {
                 self.result1 = result1
             }
-            if let result2 = result2 {
+            if let result2 {
                 self.result2 = result2
             }
         }
@@ -51,7 +51,7 @@ final class PendingEffectCancellationTests: MainTestCase
 
         let actomaton = Actomaton<Action, State>(
             state: .init(),
-            reducer: Reducer { [flags] action, state, _ in
+            reducer: Reducer { [flags] action, _, _ in
                 switch action {
                 case .fetch1:
                     return Effect(id: EffectID(name: "1"), queue: Oldest1SuspendNewEffectQueue()) {
@@ -87,7 +87,6 @@ final class PendingEffectCancellationTests: MainTestCase
                 case .cancelAll:
                     return Effect.cancel(ids: { $0.value is EffectID })
                 }
-
             }
         )
         self.actomaton = actomaton

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -69,8 +69,11 @@ final class RunNewestDiscardOldTests: MainTestCase
 
         try await tick(3)
 
-        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 1),
-                    "`effectCompletedCount` should increment by 1 (not 2) because of `NewestEffectQueue`")
+        assertEqual(
+            await actomaton.state,
+            State(count: 2, effectCompletedCount: 1),
+            "`effectCompletedCount` should increment by 1 (not 2) because of `NewestEffectQueue`"
+        )
 
         // 3rd `increment`.
         await actomaton.send(.increment)
@@ -108,8 +111,11 @@ final class RunNewestDiscardOldTests: MainTestCase
 
         try await tick(5)
 
-        assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 2),
-                    "`effectCompletedCount` will increment by 2 because of `NewestEffectQueue`")
+        assertEqual(
+            await actomaton.state,
+            State(count: 4, effectCompletedCount: 2),
+            "`effectCompletedCount` will increment by 2 because of `NewestEffectQueue`"
+        )
 
         // 4th `increment`.
         await actomaton.send(.increment)

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -69,8 +69,11 @@ final class RunOldestDiscardNewTests: MainTestCase
 
         try await tick(3)
 
-        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 1),
-                    "`effectCompletedCount` should increment by 1 (not 2) because of `OldestDiscardNewEffectQueue`")
+        assertEqual(
+            await actomaton.state,
+            State(count: 2, effectCompletedCount: 1),
+            "`effectCompletedCount` should increment by 1 (not 2) because of `OldestDiscardNewEffectQueue`"
+        )
 
         // 3rd `increment`.
         await actomaton.send(.increment)
@@ -81,8 +84,11 @@ final class RunOldestDiscardNewTests: MainTestCase
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
 
         let results = await resultsCollector.results.sorted()
-        XCTAssertEqual(results, [2],
-                       "2nd increment's effect should be cancelled by discard.")
+        XCTAssertEqual(
+            results,
+            [2],
+            "2nd increment's effect should be cancelled by discard."
+        )
     }
 
     func test_maxCount2() async throws
@@ -105,8 +111,11 @@ final class RunOldestDiscardNewTests: MainTestCase
 
         try await tick(4)
 
-        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2),
-                    "`effectCompletedCount` will increment by 2 (not 3) because of `OldestDiscardNewEffectQueue`")
+        assertEqual(
+            await actomaton.state,
+            State(count: 3, effectCompletedCount: 2),
+            "`effectCompletedCount` will increment by 2 (not 3) because of `OldestDiscardNewEffectQueue`"
+        )
 
         // 4th `increment`.
         await actomaton.send(.increment)
@@ -117,8 +126,11 @@ final class RunOldestDiscardNewTests: MainTestCase
         assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 3))
 
         let results = await resultsCollector.results.sorted()
-        XCTAssertEqual(results, [3],
-                       "3rd increment's effect should be cancelled by discard.")
+        XCTAssertEqual(
+            results,
+            [3],
+            "3rd increment's effect should be cancelled by discard."
+        )
     }
 }
 

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -70,14 +70,20 @@ final class RunOldestSuspendNewTests: MainTestCase
         // Wait until 1st effect is finished.
         try await tick(1.5)
 
-        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 1),
-                    "`effectCompletedCount` should increment by 1 because of `OldestSuspendNewEffectQueue`.")
+        assertEqual(
+            await actomaton.state,
+            State(count: 2, effectCompletedCount: 1),
+            "`effectCompletedCount` should increment by 1 because of `OldestSuspendNewEffectQueue`."
+        )
 
         // Wait until 2nd effect is finished.
         try await tick(1.5)
 
-        assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 2),
-                    "`effectCompletedCount` should increment by 2 because of `OldestSuspendNewEffectQueue`.")
+        assertEqual(
+            await actomaton.state,
+            State(count: 2, effectCompletedCount: 2),
+            "`effectCompletedCount` should increment by 2 because of `OldestSuspendNewEffectQueue`."
+        )
 
         // 3rd `increment`.
         await actomaton.send(.increment)
@@ -112,14 +118,20 @@ final class RunOldestSuspendNewTests: MainTestCase
         // Wait until 1st & 2nd effect is finished.
         try await tick(1.5)
 
-        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2),
-                    "`effectCompletedCount` should increment by 2 because of `OldestSuspendNewEffectQueue`.")
+        assertEqual(
+            await actomaton.state,
+            State(count: 3, effectCompletedCount: 2),
+            "`effectCompletedCount` should increment by 2 because of `OldestSuspendNewEffectQueue`."
+        )
 
         // Wait until 3rd effect is finished.
         try await tick(1.5)
 
-        assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 3),
-                    "`effectCompletedCount` should increment by 3 because of `OldestSuspendNewEffectQueue`.")
+        assertEqual(
+            await actomaton.state,
+            State(count: 3, effectCompletedCount: 3),
+            "`effectCompletedCount` should increment by 3 because of `OldestSuspendNewEffectQueue`."
+        )
 
         // 4th `increment`.
         await actomaton.send(.increment)

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Actomaton
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -77,8 +77,11 @@ final class TimerTests: MainTestCase
         await actomaton.send(.stop)
 
         try await tick(3)
-        assertEqual(await actomaton.state, 3,
-                    "Should not increment because timer is stopped.")
+        assertEqual(
+            await actomaton.state,
+            3,
+            "Should not increment because timer is stopped."
+        )
     }
 }
 

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -1,7 +1,7 @@
 #if !DISABLE_COMBINE && canImport(Combine)
 
-import XCTest
 @testable import ActomatonUI
+import XCTest
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
 final class DeinitTests: MainTestCase
@@ -13,7 +13,7 @@ final class DeinitTests: MainTestCase
 
         var actomaton: Store? = Store<Action, State, Environment>(
             state: State(),
-            reducer: Reducer { [resultsCollector] action, state, _ in
+            reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
                 case .run:
                     return Effect { [resultsCollector] in

--- a/Tests/ReadMeTests/ReadMeTests.swift
+++ b/Tests/ReadMeTests/ReadMeTests.swift
@@ -1,6 +1,6 @@
-import XCTest
-import Foundation
 @testable import Actomaton
+import Foundation
+import XCTest
 
 #if !DISABLE_COMBINE && canImport(Combine)
 import Combine
@@ -32,7 +32,7 @@ private func readMe1_4() async throws
         }
     }
 
-    let reducer = Reducer<Action, State, Environment> { action, state, environment in
+    let reducer = Reducer<Action, State, Environment> { action, _, environment in
         switch action {
         case let .fetch(id):
             return Effect(queue: DelayedEffectQueue()) {

--- a/Tests/TestFixtures/Fixtures.swift
+++ b/Tests/TestFixtures/Fixtures.swift
@@ -2,7 +2,8 @@ import XCTest
 
 // MARK: - Tick
 
-/// - Note: For safe async testing, leeway should have at least 50 millisec (30 millsec isn't enough for MacBook Pro (15-inch, 2018)).
+/// - Note: For safe async testing, leeway should have at least 50 millisec (30 millsec isn't enough for MacBook Pro
+/// (15-inch, 2018)).
 public func tick(_ n: Double) async throws
 {
     try await Task.sleep(nanoseconds: UInt64(Double(tickTimeInterval) * n))
@@ -33,7 +34,7 @@ public func assertEqual<T>(
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
-) where T : Equatable
+) where T: Equatable
 {
     XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
 }


### PR DESCRIPTION
## Summary

- Add [nicklockwood/SwiftFormat](https://github.com/nicklockwood/SwiftFormat) as an SPM command plugin (v0.60.1)
- Add `.swiftformat` config tuned to preserve the codebase's hybrid brace style (Allman for declarations, K&R for closures/control flow)
- Add `make swiftformat` / `make swiftformat-lint` Makefile targets
- Add CI lint job on `ubuntu-latest` (Swift 6.2 container) with SPM build caching
- Apply initial formatting to all Sources/ and Tests/ files

## Details

The `.swiftformat` config preserves existing code style by disabling rules that conflict with the codebase conventions (e.g. hybrid Allman/K&R braces, explicit `internal`, `where` clause style). Active rules handle whitespace normalization: line wrapping at 120 chars, import sorting, indent fixes, and `if let` shorthand modernization.

SwiftFormat is added as a top-level SPM dependency but only used as a plugin — downstream projects depending on Actomaton will **not** pull SwiftFormat transitively.
