### PR TITLE
Add visionOS CI build support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         xcode: ["26.0"]
-        platform: ["iOS", "macOS", "watchOS", "tvOS"]
+        platform: ["iOS", "macOS", "watchOS", "tvOS", "visionOS"]
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode ${{ matrix.xcode }}

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let usesMainActorInTest = ProcessInfo.processInfo.environment["TEST_MAIN_ACTOR"]
 
 let package = Package(
     name: "Actomaton",
-    platforms: [.macOS("15.4"), .iOS("18.4"), .watchOS("11.4"), .tvOS("18.4")],
+    // Xcode 16.4 / Swift 6.2
+    platforms: [.macOS("15.4"), .iOS("18.4"), .watchOS("11.4"), .tvOS("18.4"), .visionOS("2.4")],
     products: [
         .library(
             name: "Actomaton",


### PR DESCRIPTION
## Summary
- Add `visionOS` to the Xcode build matrix in CI workflow
- Add `.visionOS("2.4")` platform declaration to Package.swift
