### PR TITLE
Collect tasks from recursive .next action sends

### DIFF
--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -153,16 +153,18 @@ public actor Actomaton<Action, State>
             }
         }
 
-        // Send `.next` actions synchronously.
+        // Send `.next` actions synchronously, collecting their tasks.
         for syncAction in syncActions {
-            send(syncAction, priority: priority)
+            if let task = send(syncAction, priority: priority, tracksFeedbacks: tracksFeedbacks) {
+                tasks.append(task)
+            }
         }
 
         if tasks.isEmpty { return nil }
 
         let tasks_ = tasks
 
-        // Unifies `tasks`.
+        // Make a detached task that waits for all `tasks`.
         return Task.detached {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 for task in tasks_ {


### PR DESCRIPTION
## Summary
- Fix `send()` to collect effect tasks returned by synchronous recursive `.next` action dispatches, so they are included in the unified task
- Propagate `tracksFeedbacks` parameter to recursive `send()` calls

## Problem
Previously, when `.next(Action)` triggered a recursive `send()`, the returned `Task` was discarded (`@discardableResult`). This meant:
- `await send(A).value` would not wait for effects spawned by the recursively sent action
- `send(A)?.cancel()` would not cancel those effects
- `tracksFeedbacks` was not propagated (always defaulted to `false`)

## Fix
Capture the returned task from each recursive `send()` call and append it to the `tasks` array, so the unified detached task includes all effects from the `.next` chain.
