### PR TITLE
Fix Swift 6.2 SendableMetatype warning in MealyMachine

### DIFF
--- a/Sources/ActomatonCore/EffectManagerProtocol.swift
+++ b/Sources/ActomatonCore/EffectManagerProtocol.swift
@@ -17,24 +17,16 @@ public protocol EffectManagerProtocol<Action, State, Output>: AnyObject
     /// Called once by ``MealyMachine`` after initialization.
     ///
     /// - Parameters:
-    ///   - isolatedPerform:
+    ///   - performIsolated:
     ///     Closure to run a block within the owning actor's isolation.
     ///     This method is a proof that `self` (EffectManager) is owned and protected by `isolated any Actor`,
     ///     which guarantees e.g. safe clean up work inside `Task` closure while `self` is usually a non-`Sendable`
     /// class.
     ///   - sendAction:
     ///     Closure to send feedback actions back to the owning actor.
-    ///
-    /// - Warning:
-    ///   Technically, `performIsolated` closure's second parameter should be typed as `Self`
-    ///   rather than `any EffectManagerProtocol`.
-    ///   However, Swift 6.2 compiler complains about this due to `SendableMetatype` check
-    ///   that shows a warning message: "Capture of non-Sendable type 'EffM.Type' in an isolated closure".
-    ///   Thus, as a workaround, we loosen the closure parameter type from `Self` to `any EffectManagerProtocol`,
-    ///   and let `EffectManager` implementation side call `as! Self` cast instead, which will be a safe operation.
     func setUp(
         performIsolated: @escaping @Sendable (
-            @escaping @Sendable (isolated any Actor, any EffectManagerProtocol<Action, State, Output>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, Self) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )

--- a/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
@@ -13,7 +13,7 @@ public final class ActionEffectManager<Action, State>: EffectManagerProtocol
 
     public func setUp(
         performIsolated: @escaping @Sendable (
-            @escaping @Sendable (isolated any Actor, any EffectManagerProtocol<Action, State, Output>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, ActionEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )

--- a/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
@@ -12,7 +12,7 @@ public final class NoOpEffectManager<Action, State>: EffectManagerProtocol
 
     public func setUp(
         performIsolated: @escaping @Sendable (
-            @escaping @Sendable (isolated any Actor, any EffectManagerProtocol<Action, State, Output>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, NoOpEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -69,15 +69,15 @@ public actor MealyMachine<Action, State, Output>
 
     /// Initializer with custom `executingActor`.
     /// Used for ``MainActomaton`` construction.
-    package init(
+    package init<EffM>(
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
-        effectManager: some EffectManagerProtocol<Action, State, Output>,
+        effectManager: EffM,
         executingActor: any Actor,
         willChangeState: @escaping (
             _ isolation: isolated MealyMachine, _ old: State, _ new: State
         ) -> Void = { _, _, _ in }
-    ) where Action: Sendable
+    ) where Action: Sendable, EffM: EffectManagerProtocol<Action, State, Output>
     {
 #if !DISABLE_COMBINE && canImport(Combine)
         self._state = Published(initialValue: state)
@@ -89,10 +89,26 @@ public actor MealyMachine<Action, State, Output>
         self.executingActor = executingActor
         self.willChangeState = willChangeState
 
-        effectManager.setUp(
-            performIsolated: { [weak self] f in
+        typealias NonSendablePerformIsolated = (
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffM) -> Void
+        ) async -> Void
+
+        typealias SendablePerformIsolated = @Sendable (
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffM) -> Void
+        ) async -> Void
+
+        // Create as non-`@Sendable` closure to avoid too conservative `SendableMetatype` check of `EffM`,
+        // then `unsafeBitCast` to `@Sendable` for passing to `effectManager.setUp()`.
+        // This is considered as a safe operation because the only capture is `[weak self]` which is `Sendable`.
+        let performIsolated: SendablePerformIsolated = unsafeBitCast(
+            { [weak self] f in
                 await self?.performIsolated(f)
-            },
+            } as NonSendablePerformIsolated,
+            to: SendablePerformIsolated.self
+        )
+
+        effectManager.setUp(
+            performIsolated: performIsolated,
             sendAction: { [weak self] action, priority, tracksFeedbacks in
                 await self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
             }
@@ -130,15 +146,15 @@ public actor MealyMachine<Action, State, Output>
         return effectManager.processOutput(output_, priority: priority, tracksFeedbacks: tracksFeedbacks)
     }
 
-    /// Runs a block within `self`'s isolation.
+    /// Runs a block within `self`'s isolation with `EffM` force-casting.
     /// This method is a proof that `effectManager` is owned and protected by `self`.
     ///
     /// Used by ``EffectManagerProtocol`` conformers to re-enter actor isolation from detached tasks.
-    private func performIsolated(
-        _ f: @Sendable (isolated any Actor, any EffectManagerProtocol<Action, State, Output>) -> Void
-    )
+    private func performIsolated<EffM>(
+        _ f: @Sendable (isolated any Actor, EffM) -> Void
+    ) where EffM: EffectManagerProtocol<Action, State, Output>
     {
-        f(self, self.effectManager)
+        f(self, self.effectManager as! EffM)
     }
 }
 

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -93,6 +93,7 @@ public actor MealyMachine<Action, State, Output>
             _ runEffM: @escaping @Sendable (isolated any Actor, EffM) -> Void
         ) async -> Void
 
+        // swiftformat:disable:next wrapAttributes
         typealias SendablePerformIsolated = @Sendable (
             _ runEffM: @escaping @Sendable (isolated any Actor, EffM) -> Void
         ) async -> Void

--- a/Sources/ActomatonEffect/Internal/EffectManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectManager.swift
@@ -30,11 +30,9 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     private var sendAction: (@Sendable (Action, TaskPriority?, Bool) async -> Task<(), any Error>?)?
 
     /// Closure to run a block within the owning actor's isolation for safe bookkeeping updates.
-    /// Wraps the protocol's `performIsolated` with a safe downcast from `any EffectManagerProtocol` to `EffectManager`,
-    /// so that call sites (e.g. `enqueueTask`) receive the concrete type directly without casting.
     private var performIsolated: (
         @Sendable (
-            @escaping @Sendable (isolated any Actor, EffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffectManager<Action, State>) -> Void
         ) async -> Void
     )?
 
@@ -44,19 +42,12 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
 
     package func setUp(
         performIsolated: @escaping @Sendable (
-            @escaping @Sendable (isolated any Actor, any EffectManagerProtocol<Action, State, Output>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
     {
-        // Wrap with downcast so call sites receive the concrete type directly.
-        self.performIsolated = { f in
-            await performIsolated { actor, anyEffectManager in
-                // NOTE: `anyEffectManager` is a typing workaround to suppress Swift compiler warning, which is safe to
-                // downcast.
-                f(actor, anyEffectManager as! Self)
-            }
-        }
+        self.performIsolated = performIsolated
         self.sendAction = sendAction
     }
 

--- a/Tests/ActomatonCoreTests/MealyReducerTests.swift
+++ b/Tests/ActomatonCoreTests/MealyReducerTests.swift
@@ -146,7 +146,7 @@ private final class StringEffectManager<Action: Sendable, State>: EffectManagerP
 
     func setUp(
         performIsolated: @escaping @Sendable (
-            @escaping @Sendable (isolated any Actor, any EffectManagerProtocol<Action, State, Output>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, StringEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )


### PR DESCRIPTION
## Summary

- Change `EffectManagerProtocol.setUp` to use `Self` instead of `any EffectManagerProtocol` for the `performIsolated` callback parameter
- In `MealyMachine.init`, create the `performIsolated` closure as non-`@Sendable` and `unsafeBitCast` to `@Sendable` to avoid the Swift 6.2 `SendableMetatype` warning ("Capture of non-Sendable type 'EffM.Type' in an isolated closure")
- Add generic `performIsolated<EffM>` on `MealyMachine` that performs `as! EffM` inside actor-isolated context
- Simplify `EffectManager.setUp` to direct assignment (no wrapper closure with `as! Self` cast)
