### PR TITLE
Add EffectContext with replaceable Clock for testable effect scheduling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-26
     strategy:
       matrix:
-        xcode: ["26.0"]
+        xcode: ["26.4"]
         platform: ["iOS", "macOS", "watchOS", "tvOS", "visionOS"]
     steps:
     - uses: actions/checkout@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4ba779605f3831e1751d0e8cf9da17c29524ae24d73802defe8ad68acbd047b3",
+  "originHash" : "f27a03d73774c7476051211e273a414b9af4841bc7b1cae660d36121291e0626",
   "pins" : [
     {
       "identity" : "swift-case-paths",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "d226d167bd4a68b51e352af5655c92bce8ee0463",
         "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -33,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f27a03d73774c7476051211e273a414b9af4841bc7b1cae660d36121291e0626",
+  "originHash" : "bf209feae64d9c9a887d9ee61e77e6227c06d91de6db0be66613f5e5509195cc",
   "pins" : [
     {
       "identity" : "swift-case-paths",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,6 @@
 import Foundation
 import PackageDescription
 
-// `$ TEST_MAIN_ACTOR=1 swift test`
-let usesMainActorInTest = ProcessInfo.processInfo.environment["TEST_MAIN_ACTOR"] == "1"
-
 let package = Package(
     name: "Actomaton",
     // Xcode 16.4 / Swift 6.2
@@ -30,13 +27,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
+        .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.6"),
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"),
-    ] + (
-        usesMainActorInTest ? [
-            .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0")
-        ] : []
-    ),
+    ],
     targets: [
         .target(
             name: "ActomatonCore",
@@ -46,6 +41,7 @@ let package = Package(
             name: "ActomatonEffect",
             dependencies: [
                 "ActomatonCore",
+                .product(name: "Clocks", package: "swift-clocks"),
             ]
         ),
         .target(
@@ -70,11 +66,10 @@ let package = Package(
             ]),
         .target(
             name: "TestFixtures",
-            dependencies: ["Actomaton"] + (
-                usesMainActorInTest ? [
-                    .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras")
-                ] : []
-            ),
+            dependencies: [
+                "Actomaton",
+                .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras")
+            ],
             path: "./Tests/TestFixtures"
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ reducer = Reducer { action, state, environment in
         }
     case .decrement:
         state.count -= 1
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { context in
             print("decrement and sleep...")
-            try await Task.sleep(...) // NOTE: We can use `await`!
+            try await context.clock.sleep(for: .seconds(1))
             print("I'm awake!")
         }
     }

--- a/Sources/Actomaton/Actomaton+Init.swift
+++ b/Sources/Actomaton/Actomaton+Init.swift
@@ -7,13 +7,14 @@ extension MealyMachine where Output == Effect<Action>
     /// Initializer without `environment`.
     public init(
         state: State,
-        reducer: Reducer<Action, State, ()>
+        reducer: Reducer<Action, State, ()>,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
     ) where Action: Sendable
     {
         self.init(
             state: state,
             reducer: reducer,
-            effectManager: EffectManager<Action, State>()
+            effectManager: EffectManager<Action, State>(effectContext: effectContext)
         )
     }
 
@@ -21,12 +22,17 @@ extension MealyMachine where Output == Effect<Action>
     public init<Environment>(
         state: State,
         reducer: Reducer<Action, State, Environment>,
-        environment: Environment
+        environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
     ) where Action: Sendable, Environment: Sendable
     {
-        self.init(state: state, reducer: Reducer { action, state, _ in
-            reducer.run(action, &state, environment)
-        })
+        self.init(
+            state: state,
+            reducer: Reducer<Action, State, ()> { action, state, _ in
+                reducer.run(action, &state, environment)
+            },
+            effectManager: EffectManager<Action, State>(effectContext: effectContext)
+        )
     }
 
     /// Initializer with `environment` and custom `executingActor`.
@@ -35,6 +41,7 @@ extension MealyMachine where Output == Effect<Action>
         state: State,
         reducer: Reducer<Action, State, Environment>,
         environment: Environment,
+        effectContext: EffectContext,
         executingActor: any Actor
     ) where Action: Sendable, Environment: Sendable
     {
@@ -43,7 +50,7 @@ extension MealyMachine where Output == Effect<Action>
             reducer: Reducer<Action, State, ()> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectManager<Action, State>(),
+            effectManager: EffectManager<Action, State>(effectContext: effectContext),
             executingActor: executingActor
         )
     }

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/01-Counter.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/01-Counter.md
@@ -65,14 +65,17 @@ reducer = Reducer { action, state, environment in
         }
     case .decrement:
         state.count -= 1
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { context in
             print("decrement and sleep...")
-            try await Task.sleep(...) // NOTE: We can use `await`!
+            try await context.clock.sleep(for: .seconds(1))
             print("I'm awake!")
         }
     }
 }
 ```
+
+`EffectContext` is for runtime-owned capabilities such as clock-based sleeping and cancellation checks.
+Keep API clients and other business dependencies in `Environment`.
 
 NOTE: There are 5 ways of creating ``Effect`` in Actomaton:
 

--- a/Sources/Actomaton/MainActomaton.swift
+++ b/Sources/Actomaton/MainActomaton.swift
@@ -29,7 +29,8 @@ package final class MainActomaton<Action, State>
     /// Initializer without `environment`.
     package init(
         state: State,
-        reducer: Reducer<Action, State, ()>
+        reducer: Reducer<Action, State, ()>,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
     )
     {
         var willChangeState: (@MainActor (_ old: State, _ new: State) -> Void)?
@@ -37,7 +38,7 @@ package final class MainActomaton<Action, State>
         self.actomaton = Actomaton(
             state: state,
             reducer: reducer,
-            effectManager: EffectManager<Action, State>(),
+            effectManager: EffectManager<Action, State>(effectContext: effectContext),
             executingActor: MainActor.shared,
             willChangeState: { @Sendable _, old, new in
                 MainActor.assumeIsolated {
@@ -61,12 +62,17 @@ package final class MainActomaton<Action, State>
     package convenience init<Environment>(
         state: State,
         reducer: Reducer<Action, State, Environment>,
-        environment: Environment
+        environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
     ) where Environment: Sendable
     {
-        self.init(state: state, reducer: Reducer { action, state, _ in
-            reducer.run(action, &state, environment)
-        })
+        self.init(
+            state: state,
+            reducer: Reducer { action, state, _ in
+                reducer.run(action, &state, environment)
+            },
+            effectContext: effectContext
+        )
     }
 
     /// Sends `action` to `Actomaton`.

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -15,119 +15,239 @@ extension Effect
 {
     // MARK: - Single async
 
-    /// Single-`async` side-effect.
-    public init(run: @escaping @Sendable () async throws -> Action?)
+    /// Single-`async` side-effect with `EffectContext`.
+    public init(
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    )
     {
         self.init(kinds: [.single(Single(id: nil, queue: nil, run: run))])
     }
 
-    /// Single-`async` side-effect.
+    /// Single-`async` side-effect without `EffectContext`.
+    public init(run: @escaping @Sendable () async throws -> Action?)
+    {
+        self.init(run: { _ in
+            try await run()
+        })
+    }
+
+    /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
-    public init<ID>(id: ID? = nil, run: @escaping @Sendable () async throws -> Action?)
+    public init<ID>(
+        id: ID? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    )
         where ID: EffectIDProtocol
     {
         self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: nil, run: run))])
     }
 
-    /// Single-`async` side-effect.
+    /// Single-`async` side-effect without `EffectContext`.
+    /// - Parameter id: Cancellation identifier.
+    public init<ID>(id: ID? = nil, run: @escaping @Sendable () async throws -> Action?)
+        where ID: EffectIDProtocol
+    {
+        self.init(id: id, run: { _ in
+            try await run()
+        })
+    }
+
+    /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<Queue>(queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where Queue: EffectQueueProtocol
+    public init<Queue>(
+        queue: Queue? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    ) where Queue: EffectQueueProtocol
     {
         self.init(kinds: [.single(Single(id: nil, queue: queue.map(AnyEffectQueue.init), run: run))])
     }
 
-    /// Single-`async` side-effect.
+    /// Single-`async` side-effect without `EffectContext`.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    public init<Queue>(queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
+        where Queue: EffectQueueProtocol
+    {
+        self.init(queue: queue, run: { _ in
+            try await run()
+        })
+    }
+
+    /// Single-`async` side-effect with `EffectContext`.
+    /// - Parameter id: Cancellation identifier.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    public init<ID, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    ) where ID: EffectIDProtocol, Queue: EffectQueueProtocol
+    {
+        self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: queue.map(AnyEffectQueue.init), run: run))])
+    }
+
+    /// Single-`async` side-effect without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
-        self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: queue.map(AnyEffectQueue.init), run: run))])
+        self.init(id: id, queue: queue, run: { _ in
+            try await run()
+        })
     }
 
     // MARK: - AsyncSequence
 
-    /// `AsyncSequence` side-effect.
-    public init<S>(sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence & Sendable, S.Element == Action
+    /// `AsyncSequence` side-effect with `EffectContext`.
+    public init<S>(
+        sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) where S: AsyncSequence & Sendable, S.Element == Action
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: nil,
                     queue: nil,
-                    sequence: { try await sequence()?.typeErased }
+                    sequence: { context in try await sequence(context)?.typeErased }
                 )
             )]
         )
     }
 
-    /// `AsyncSequence` side-effect.
+    /// `AsyncSequence` side-effect without `EffectContext`.
+    public init<S>(sequence: @escaping @Sendable () async throws -> S?)
+        where S: AsyncSequence & Sendable, S.Element == Action
+    {
+        self.init(sequence: { _ in
+            try await sequence()
+        })
+    }
+
+    /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
-    public init<ID, S>(id: ID? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where ID: EffectIDProtocol, S: AsyncSequence & Sendable, S.Element == Action
+    public init<ID, S>(
+        id: ID? = nil,
+        sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) where ID: EffectIDProtocol, S: AsyncSequence & Sendable, S.Element == Action
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: id.map(EffectID.init),
                     queue: nil,
-                    sequence: { try await sequence()?.typeErased }
+                    sequence: { context in try await sequence(context)?.typeErased }
                 )
             )]
         )
     }
 
-    /// `AsyncSequence` side-effect.
+    /// `AsyncSequence` side-effect without `EffectContext`.
+    /// - Parameter id: Cancellation identifier.
+    public init<ID, S>(id: ID? = nil, sequence: @escaping @Sendable () async throws -> S?)
+        where ID: EffectIDProtocol, S: AsyncSequence & Sendable, S.Element == Action
+    {
+        self.init(id: id, sequence: { _ in
+            try await sequence()
+        })
+    }
+
+    /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<S, Queue>(queue: Queue? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence & Sendable, S.Element == Action, Queue: EffectQueueProtocol
+    public init<S, Queue>(
+        queue: Queue? = nil,
+        sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) where S: AsyncSequence & Sendable, S.Element == Action, Queue: EffectQueueProtocol
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: nil,
                     queue: queue.map(AnyEffectQueue.init),
-                    sequence: { try await sequence()?.typeErased }
+                    sequence: { context in try await sequence(context)?.typeErased }
                 )
             )]
         )
     }
 
-    /// `AsyncSequence` side-effect.
+    /// `AsyncSequence` side-effect without `EffectContext`.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    public init<S, Queue>(queue: Queue? = nil, sequence: @escaping @Sendable () async throws -> S?)
+        where S: AsyncSequence & Sendable, S.Element == Action, Queue: EffectQueueProtocol
+    {
+        self.init(queue: queue, sequence: { _ in
+            try await sequence()
+        })
+    }
+
+    /// `AsyncSequence` side-effect with `EffectContext`.
+    /// - Parameter id: Cancellation identifier.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    public init<ID, S, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) where ID: EffectIDProtocol, S: AsyncSequence & Sendable, S.Element == Action, Queue: EffectQueueProtocol
+    {
+        self.init(
+            kinds: [.sequence(
+                _Sequence(
+                    id: id.map(EffectID.init),
+                    queue: queue.map(AnyEffectQueue.init),
+                    sequence: { context in try await sequence(context)?.typeErased }
+                )
+            )]
+        )
+    }
+
+    /// `AsyncSequence` side-effect without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<ID, S, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
         sequence: @escaping @Sendable () async throws -> S?
-    )
-        where ID: EffectIDProtocol, S: AsyncSequence & Sendable, S.Element == Action, Queue: EffectQueueProtocol
+    ) where ID: EffectIDProtocol, S: AsyncSequence & Sendable, S.Element == Action, Queue: EffectQueueProtocol
     {
-        self.init(
-            kinds: [.sequence(
-                _Sequence(
-                    id: id.map(EffectID.init),
-                    queue: queue.map(AnyEffectQueue.init),
-                    sequence: { try await sequence()?.typeErased }
-                )
-            )]
-        )
+        self.init(id: id, queue: queue, sequence: { _ in
+            try await sequence()
+        })
     }
 
     // MARK: - fireAndForget
 
-    /// Single-`async` side-effect without returning next action.
-    public static func fireAndForget(run: @escaping @Sendable () async throws -> ()) -> Effect<Action>
+    /// Single-`async` side-effect without returning next action, with `EffectContext`.
+    public static func fireAndForget(
+        run: @escaping @Sendable (EffectContext) async throws -> ()
+    ) -> Effect<Action>
     {
-        self.init(run: {
-            try await run()
+        self.init(run: { context in
+            try await run(context)
             return nil
         })
     }
 
-    /// Single-`async` side-effect without returning next action.
+    /// Single-`async` side-effect without returning next action, without `EffectContext`.
+    public static func fireAndForget(run: @escaping @Sendable () async throws -> ()) -> Effect<Action>
+    {
+        self.fireAndForget(run: { _ in
+            try await run()
+        })
+    }
+
+    /// Single-`async` side-effect without returning next action, with `EffectContext`.
+    /// - Parameter id: Cancellation identifier.
+    public static func fireAndForget<ID>(
+        id: ID? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> ()
+    ) -> Effect<Action>
+        where ID: EffectIDProtocol
+    {
+        self.init(id: id, run: { context in
+            try await run(context)
+            return nil
+        })
+    }
+
+    /// Single-`async` side-effect without returning next action, without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     public static func fireAndForget<ID>(
         id: ID? = nil,
@@ -135,13 +255,26 @@ extension Effect
     ) -> Effect<Action>
         where ID: EffectIDProtocol
     {
-        self.init(id: id, run: {
+        self.fireAndForget(id: id, run: { _ in
             try await run()
+        })
+    }
+
+    /// Single-`async` side-effect without returning next action, with `EffectContext`.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    public static func fireAndForget<Queue>(
+        queue: Queue? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> ()
+    ) -> Effect<Action>
+        where Queue: EffectQueueProtocol
+    {
+        self.init(queue: queue, run: { context in
+            try await run(context)
             return nil
         })
     }
 
-    /// Single-`async` side-effect without returning next action.
+    /// Single-`async` side-effect without returning next action, without `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func fireAndForget<Queue>(
         queue: Queue? = nil,
@@ -149,13 +282,28 @@ extension Effect
     ) -> Effect<Action>
         where Queue: EffectQueueProtocol
     {
-        self.init(queue: queue, run: {
+        self.fireAndForget(queue: queue, run: { _ in
             try await run()
+        })
+    }
+
+    /// Single-`async` side-effect without returning next action, with `EffectContext`.
+    /// - Parameter id: Cancellation identifier.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    public static func fireAndForget<ID, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> ()
+    ) -> Effect<Action>
+        where ID: EffectIDProtocol, Queue: EffectQueueProtocol
+    {
+        self.init(id: id, queue: queue, run: { context in
+            try await run(context)
             return nil
         })
     }
 
-    /// Single-`async` side-effect without returning next action.
+    /// Single-`async` side-effect without returning next action, without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func fireAndForget<ID, Queue>(
@@ -165,9 +313,8 @@ extension Effect
     ) -> Effect<Action>
         where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
-        self.init(id: id, queue: queue, run: {
+        self.fireAndForget(id: id, queue: queue, run: { _ in
             try await run()
-            return nil
         })
     }
 
@@ -376,12 +523,12 @@ extension Effect
     {
         internal let id: EffectID?
         internal let queue: AnyEffectQueue?
-        internal let run: @Sendable () async throws -> Action?
+        internal let run: @Sendable (EffectContext) async throws -> Action?
 
         internal init(
             id: EffectID? = nil,
             queue: AnyEffectQueue? = nil,
-            run: @escaping @Sendable () async throws -> Action?
+            run: @escaping @Sendable (EffectContext) async throws -> Action?
         )
         {
             self.id = id
@@ -391,8 +538,8 @@ extension Effect
 
         internal func map<Action2>(action f: @escaping @Sendable (Action) -> Action2) -> Effect<Action2>.Single
         {
-            .init(id: id, queue: queue) {
-                (try await run()).map(f)
+            .init(id: id, queue: queue) { context in
+                (try await run(context)).map(f)
             }
         }
 
@@ -414,12 +561,12 @@ extension Effect
     {
         internal let id: EffectID?
         internal let queue: AnyEffectQueue?
-        internal let sequence: @Sendable () async throws -> AnyAsyncSequence<Action>?
+        internal let sequence: @Sendable (EffectContext) async throws -> AnyAsyncSequence<Action>?
 
         internal init(
             id: EffectID? = nil,
             queue: AnyEffectQueue? = nil,
-            sequence: @escaping @Sendable () async throws -> AnyAsyncSequence<Action>?
+            sequence: @escaping @Sendable (EffectContext) async throws -> AnyAsyncSequence<Action>?
         )
         {
             self.id = id
@@ -429,7 +576,9 @@ extension Effect
 
         internal func map<Action2>(action f: @escaping @Sendable (Action) -> Action2) -> Effect<Action2>._Sequence
         {
-            .init(id: id, queue: queue, sequence: { try await sequence()?.map(f).typeErased })
+            .init(id: id, queue: queue, sequence: { context in
+                try await sequence(context)?.map(f).typeErased
+            })
         }
 
         internal func map<ID>(id f: @escaping (EffectID?) -> ID?) -> Effect._Sequence

--- a/Sources/ActomatonEffect/EffectContext.swift
+++ b/Sources/ActomatonEffect/EffectContext.swift
@@ -1,0 +1,20 @@
+import Clocks
+import Foundation
+
+/// Runtime-owned effect execution context.
+///
+/// `EffectContext` complements reducer `Environment` instead of replacing it.
+/// - Use `Environment` for domain dependencies such as API clients and repositories.
+/// - Use `EffectContext` for runtime capabilities such as sleeping with a replaceable clock and cancellation checks.
+public struct EffectContext: Sendable
+{
+    public let clock: AnyClock<Duration>
+
+    public init<C>(
+        clock: C
+    )
+        where C: Clock, C.Duration == Duration
+    {
+        self.clock = AnyClock(clock)
+    }
+}

--- a/Sources/ActomatonEffect/EffectQueueDelay.swift
+++ b/Sources/ActomatonEffect/EffectQueueDelay.swift
@@ -15,4 +15,11 @@ public enum EffectQueueDelay: Hashable, Sendable
             return TimeInterval.random(in: timeRange)
         }
     }
+
+    var duration: Duration
+    {
+        .nanoseconds(
+            Int64(self.timeInterval * 1_000_000_000)
+        )
+    }
 }

--- a/Sources/ActomatonEffect/Internal/EffectManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectManager.swift
@@ -1,4 +1,5 @@
 import ActomatonCore
+import Clocks
 import Foundation
 
 /// Default ``EffectManagerProtocol`` implementation that manages ``Effect<Action>`` with queue-based task lifecycle.
@@ -9,6 +10,8 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     where Action: Sendable
 {
     package typealias Output = Effect<Action>
+
+    private let effectContext: EffectContext
 
     // MARK: - Task tracking
 
@@ -22,8 +25,8 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Suspended effects.
     private var pendingEffectKinds: [EffectQueue: [Effect<Action>.Kind]] = [:]
 
-    /// Tracked latest effect start date for delayed effects calculation.
-    private var latestEffectDate: [EffectQueue: Date] = [:]
+    /// Tracked latest effect start time for delayed effects calculation.
+    private var latestEffectTime: [EffectQueue: AnyClock<Duration>.Instant] = [:]
 
     // MARK: - Callbacks (set via setUp)
 
@@ -36,7 +39,12 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         ) async -> Void
     )?
 
-    package init() {}
+    package init(
+        effectContext: EffectContext
+    )
+    {
+        self.effectContext = effectContext
+    }
 
     // MARK: - EffectManagerProtocol
 
@@ -171,10 +179,10 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         case .single, .sequence:
             let shouldExecute = checkQueuePolicy(effectKind: kind)
             if shouldExecute {
-                let delay = calculateEffectDelay(queue: kind.queue)
+                let time = calculateEffectTime(queue: kind.queue)
                 if let task = makeTask(
                     effectKind: kind,
-                    delay: delay,
+                    time: time,
                     priority: priority,
                     tracksFeedbacks: tracksFeedbacks
                 )
@@ -247,20 +255,21 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Creates a detached task for the given effect kind.
     private func makeTask(
         effectKind: Effect<Action>.Kind,
-        delay: TimeInterval,
+        time: AnyClock<Duration>.Instant?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?
     {
         let sendAction = self.sendAction
+        let context = self.effectContext
 
         switch effectKind {
         case let .single(single):
             let task = Task.detached(priority: priority) {
-                if delay > 0 {
-                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                if let time {
+                    try? await context.clock.sleep(until: time, tolerance: nil)
                 }
-                let nextAction = try await single.run()
+                let nextAction = try await single.run(context)
                 if let nextAction {
                     let feedbackTask = await sendAction?(nextAction, priority, tracksFeedbacks)
                     if tracksFeedbacks {
@@ -279,10 +288,10 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
 
         case let .sequence(sequence):
             let task = Task<(), any Error>.detached(priority: priority) {
-                if delay > 0 {
-                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                if let time {
+                    try? await context.clock.sleep(until: time, tolerance: nil)
                 }
-                guard let seq = try await sequence.sequence() else { return }
+                guard let seq = try await sequence.sequence(context) else { return }
                 var feedbackTasks: [Task<(), any Error>] = []
                 for try await nextAction in seq {
                     let feedbackTask = await sendAction?(nextAction, priority, tracksFeedbacks)
@@ -386,24 +395,32 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         }
     }
 
-    /// Calculates effect delay based on `latestTaskRunningDate` for necessary sleep in `makeTask`.
-    private func calculateEffectDelay(queue: AnyEffectQueue?) -> TimeInterval
+    /// Calculates absolute effect start time for queue-based delay scheduling.
+    ///
+    /// Returns `nil` when the effect should run immediately without additional sleeping.
+    private func calculateEffectTime(queue: AnyEffectQueue?) -> AnyClock<Duration>.Instant?
     {
-        // No queue means, immediate task run.
-        guard let queue else { return 0 }
+        guard let queue else { return nil }
 
-        let delayAfterLatestEffect = queue.effectQueueDelay.timeInterval
-        let latestDate = self.latestEffectDate[queue.queue, default: Date(timeIntervalSince1970: 0)]
+        let now = self.effectContext.clock.now
 
-        let targetDelaySinceNow = max(latestDate.timeIntervalSinceNow + delayAfterLatestEffect, 0)
-        self.latestEffectDate[queue.queue] = Date(timeIntervalSinceNow: targetDelaySinceNow)
+        guard let latestTime = self.latestEffectTime[queue.queue] else {
+            self.latestEffectTime[queue.queue] = now
+            return nil
+        }
 
-        Debug
-            .print(
-                "[calculateEffectDelay] delayAfterLatestExec = \(delayAfterLatestEffect), latestEffectDate = \(latestDate), targetDelaySinceNow = \(targetDelaySinceNow)"
-            )
+        let targetDelay = now.duration(to: latestTime) + queue.effectQueueDelay.duration
 
-        return targetDelaySinceNow
+        if targetDelay <= .zero {
+            self.latestEffectTime[queue.queue] = now
+            return nil
+        }
+
+        let nextTime = now.advanced(by: targetDelay)
+        self.latestEffectTime[queue.queue] = nextTime
+
+        Debug.print("[calculateEffectDelay] scheduled via effectContext.clock")
+        return nextTime
     }
 
     /// Dequeues a pending effect if possible (for `runOldest-suspendNew` policy).
@@ -416,11 +433,11 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     {
         guard pendingEffectKinds[queue.queue]?.isEmpty == false else { return nil }
         let kind = pendingEffectKinds[queue.queue]!.removeFirst()
-        let delay = calculateEffectDelay(queue: queue)
+        let time = calculateEffectTime(queue: queue)
         Debug.print("[dequeuePendingIfPossible] Dequeued pending effect")
         return makeTask(
             effectKind: kind,
-            delay: delay,
+            time: time,
             priority: priority,
             tracksFeedbacks: tracksFeedbacks
         )
@@ -430,15 +447,17 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// so that cancellation can still be delivered to `Effect`'s async scope.
     private func cancelEffectKind(_ effectKind: Effect<Action>.Kind)
     {
+        let context = self.effectContext
+
         switch effectKind {
         case let .single(single):
             Task<Void, any Error>.detached {
-                _ = try await single.run()
+                _ = try await single.run(context)
             }
             .cancel() // Cancel immediately.
         case let .sequence(sequence):
             Task<Void, any Error>.detached {
-                _ = try await sequence.sequence()
+                _ = try await sequence.sequence(context)
             }
             .cancel() // Cancel immediately.
         case .next, .cancel:

--- a/Sources/ActomatonUI/Store/Internal/StoreCore.swift
+++ b/Sources/ActomatonUI/Store/Internal/StoreCore.swift
@@ -20,6 +20,7 @@ internal final class StoreCore<Action, State, Environment>
         state initialState: State,
         reducer: Reducer<Action, State, Environment>,
         environment: Environment,
+        effectContext: EffectContext,
         configuration: StoreConfiguration
     )
     {
@@ -30,7 +31,8 @@ internal final class StoreCore<Action, State, Environment>
             state: initialState,
             reducer: lift(reducer: reducer)
                 .log(format: configuration.logFormat),
-            environment: environment
+            environment: environment,
+            effectContext: effectContext
         )
 
         self.actomaton.statePublisher

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -68,6 +68,7 @@ public class Store<Action, State, Environment>
         state initialState: State,
         reducer: Reducer<Action, State, Environment>,
         environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock()),
         configuration: StoreConfiguration = .init()
     )
     {
@@ -75,6 +76,7 @@ public class Store<Action, State, Environment>
             state: initialState,
             reducer: reducer,
             environment: environment,
+            effectContext: effectContext,
             configuration: configuration
         )
 
@@ -89,6 +91,7 @@ public class Store<Action, State, Environment>
     public convenience init(
         state initialState: State,
         reducer: Reducer<Action, State, Void>,
+        effectContext: EffectContext = .init(clock: ContinuousClock()),
         configuration: StoreConfiguration = .init()
     ) where Environment == Void
     {
@@ -96,6 +99,7 @@ public class Store<Action, State, Environment>
             state: initialState,
             reducer: reducer,
             environment: (),
+            effectContext: effectContext,
             configuration: configuration
         )
     }

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -17,6 +17,7 @@ public final class RouteStore<Action, State, Environment, Route>:
         state: State,
         reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>>,
         environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock()),
         configuration: StoreConfiguration = .init(),
         routeType: Route.Type = Route.self // for quick type-inference
     )
@@ -33,6 +34,7 @@ public final class RouteStore<Action, State, Environment, Route>:
             state: state,
             reducer: reducer,
             environment: sendRouteEnvironment,
+            effectContext: effectContext,
             configuration: configuration
         )
         self.core = core
@@ -48,13 +50,15 @@ public final class RouteStore<Action, State, Environment, Route>:
     public convenience init(
         state: State,
         reducer: Reducer<Action, State, SendRouteEnvironment<Void, Route>>,
-        routeType: Route.Type = Route.self // for quick type-inference
+        effectContext: EffectContext = .init(clock: ContinuousClock()),
+        routeType: Route.Type = Route.self
     ) where Environment == Void
     {
         self.init(
             state: state,
             reducer: reducer,
-            environment: ()
+            environment: (),
+            effectContext: effectContext
         )
     }
 

--- a/Tests/ActomatonTests/EffectContextClockTests.swift
+++ b/Tests/ActomatonTests/EffectContextClockTests.swift
@@ -1,0 +1,133 @@
+@testable import Actomaton
+import XCTest
+
+final class EffectContextClockTests: XCTestCase
+{
+    func test_sleep_for_uses_injected_clock() async throws
+    {
+        let recorder = Recorder()
+        let clock = RecordingClock(recorder: recorder)
+
+        let actomaton = Actomaton<Action, State>(
+            state: .idle,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .start:
+                    state = .running
+                    return Effect { context in
+                        try await context.clock.sleep(for: .seconds(1))
+                        return .finished
+                    }
+
+                case .finished:
+                    state = .finished
+                    return .empty
+                }
+            },
+            effectContext: EffectContext(clock: clock)
+        )
+
+        let task = await actomaton.send(.start)
+        try await task?.value
+
+        assertEqual(await actomaton.state, .finished)
+        assertEqual(await recorder.durations, [.seconds(1)])
+    }
+
+    func test_sleep_until_uses_injected_clock() async throws
+    {
+        let recorder = Recorder()
+        let clock = RecordingClock(recorder: recorder)
+
+        let actomaton = Actomaton<Action, State>(
+            state: .idle,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .start:
+                    state = .running
+                    return Effect { context in
+                        let deadline = context.clock.now.advanced(by: .seconds(2))
+                        try await context.clock.sleep(until: deadline, tolerance: nil)
+                        return .finished
+                    }
+
+                case .finished:
+                    state = .finished
+                    return .empty
+                }
+            },
+            effectContext: EffectContext(clock: clock)
+        )
+
+        let task = await actomaton.send(.start)
+        try await task?.value
+
+        assertEqual(await actomaton.state, .finished)
+        assertEqual(await recorder.durations, [.seconds(2)])
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case start
+    case finished
+}
+
+private enum State
+{
+    case idle
+    case running
+    case finished
+}
+
+private actor Recorder
+{
+    var durations: [Duration] = []
+
+    func append(_ duration: Duration)
+    {
+        self.durations.append(duration)
+    }
+}
+
+private struct RecordingClock: Clock
+{
+    struct Instant: InstantProtocol
+    {
+        var offset: Duration
+
+        func advanced(by duration: Duration) -> Instant
+        {
+            Instant(offset: self.offset + duration)
+        }
+
+        func duration(to other: Instant) -> Duration
+        {
+            other.offset - self.offset
+        }
+
+        static func < (l: Instant, r: Instant) -> Bool
+        {
+            l.offset < r.offset
+        }
+    }
+
+    let recorder: Recorder
+
+    var now: Instant
+    {
+        Instant(offset: .zero)
+    }
+
+    var minimumResolution: Duration
+    {
+        .zero
+    }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws
+    {
+        await self.recorder.append(self.now.duration(to: deadline))
+    }
+}

--- a/Tests/ReadMeTests/ReadMeTests.swift
+++ b/Tests/ReadMeTests/ReadMeTests.swift
@@ -7,6 +7,41 @@ import Combine
 #endif
 
 /// Compile-only test for README.
+private func readMe1_1_effectContext() async throws
+{
+    enum Action: Sendable {
+        case start
+        case finished
+    }
+
+    struct State: Sendable {
+        var isRunning = false
+    }
+
+    let reducer = Reducer<Action, State, Void> { action, state, _ in
+        switch action {
+        case .start:
+            state.isRunning = true
+            return Effect { context in
+                try await context.clock.sleep(for: .seconds(1))
+                return .finished
+            }
+
+        case .finished:
+            state.isRunning = false
+            return .empty
+        }
+    }
+
+    let actomaton = Actomaton<Action, State>(
+        state: State(),
+        reducer: reducer
+    )
+
+    _ = await actomaton.send(.start)
+}
+
+/// Compile-only test for README.
 private func readMe1_4() async throws
 {
     enum Action: Sendable {


### PR DESCRIPTION
## Summary

- Introduce `EffectContext` struct with an `AnyClock<Duration>` that is passed to every `Effect` closure at runtime, enabling testable time-based scheduling without relying on `Task.sleep`
- Add overloaded `Effect` initializers that accept `(EffectContext) async throws -> Action?` alongside backward-compatible `() async throws -> Action?` variants
- Replace `Date`-based delay calculation in `EffectManager` with clock-based `sleep(until:)` for deterministic queue delay handling
- Add `swift-clocks` dependency and `EffectContextClockTests` verifying `TestClock` integration

## Test plan

- [x] `EffectContextClockTests` validates clock-based effect scheduling with `TestClock`
- [x] `ReadMeTests` updated to cover new `EffectContext` API
- [x] Verify existing tests pass with default `ContinuousClock`
