### PR TITLE
Improve test clock infrastructure and enable extensionAccessControl

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # NOTE: `make` command not available in the container.
+      - name: Install make
+        run: apt-get update && apt-get install -y make
+
       - name: Build Ubuntu package
-        run: TEST_MAIN_ACTOR=1 swift test
+        run: CI=1 make swift-test

--- a/.swiftformat
+++ b/.swiftformat
@@ -29,6 +29,7 @@
 --stripunusedargs closure-only
 --modifierorder open,public,internal,fileprivate,private,override,final,required,convenience,static,class,dynamic,optional,lazy,weak,unowned,nonisolated,isolated
 --voidtype void
+--extensionacl on-declarations
 
 # Disabled rules
 # NOTE: braces rule disabled because codebase uses hybrid style:
@@ -37,7 +38,6 @@
 # SwiftFormat's --allman flag applies to ALL braces, so we preserve existing style instead.
 --disable braces
 --disable wrapMultilineStatementBraces
---disable extensionAccessControl
 --disable hoistAwait
 --disable hoistTry
 --disable enumNamespaces

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PLATFORM_TVOS = tvOS Simulator,id=$(call udid_for,tvOS,TV)
 PLATFORM_VISIONOS = visionOS Simulator,id=$(call udid_for,visionOS,Vision)
 PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,watchOS,Watch)
 
-TEST_MAIN_ACTOR = 1
+SWIFT_TEST_FLAGS = $(if $(CI),-Xswiftc -DCI,)
 
 # Base path after host name, required for GitHub Pages.
 # Note that `documentation/{module_name}` is automatically added to the end of this path in Swift-DocC,
@@ -29,11 +29,11 @@ xcode-test:
 
 .PHONY: _xcode
 _xcode:
-	set -o pipefail && TEST_MAIN_ACTOR=$(TEST_MAIN_ACTOR) xcodebuild $(ACTION) -scheme Actomaton-Package -destination 'platform=$(PLATFORM_$(shell echo $(OS) | tr '[:lower:]' '[:upper:]'))' | xcpretty
+	set -o pipefail && xcodebuild $(ACTION) -scheme Actomaton-Package -destination 'platform=$(PLATFORM_$(shell echo $(OS) | tr '[:lower:]' '[:upper:]'))' | xcpretty
 
 .PHONY: swift-test
 swift-test:
-	TEST_MAIN_ACTOR=$(TEST_MAIN_ACTOR) swift test
+	swift test $(SWIFT_TEST_FLAGS)
 
 .PHONY: swiftformat
 swiftformat:

--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,7 @@ let package = Package(
             name: "TestFixtures",
             dependencies: [
                 "Actomaton",
+                .product(name: "Clocks", package: "swift-clocks"),
                 .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras")
             ],
             path: "./Tests/TestFixtures"

--- a/Tests/ActomatonTests/CounterTests.swift
+++ b/Tests/ActomatonTests/CounterTests.swift
@@ -22,7 +22,8 @@ final class CounterTests: MainTestCase
                         print("decrement")
                     }
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
     }

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -55,7 +55,7 @@ final class DeinitTests: MainTestCase
             "Running effect should be cancelled, and `DeinitChecker` should deinit."
         )
 
-        _ = weakActomaton
+        weakActomaton = nil // For suppressing `WeakMutability` warning.
     }
 }
 

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -7,14 +7,15 @@ final class DeinitTests: MainTestCase
     func test_deinit() async throws
     {
         let resultsCollector = ResultsCollector<String>()
+        let clock = self.clock
 
         var actomaton: Actomaton? = Actomaton<Action, State>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
                 case .run:
-                    return Effect { [resultsCollector] in
-                        return try await tick(5) {
+                    return Effect { [resultsCollector] context in
+                        return try await context.clock.sleep(for: .ticks(5)) {
                             await resultsCollector.append("Effect succeeded")
                             return nil
                         } ifCancelled: {
@@ -25,13 +26,14 @@ final class DeinitTests: MainTestCase
                     }
                 }
             },
-            environment: Environment(resultsCollector: resultsCollector)
+            environment: Environment(resultsCollector: resultsCollector),
+            effectContext: effectContext
         )
 
         weak var weakActomaton = actomaton
 
         let task = await actomaton?.send(.run)
-        try await tick(1)
+        await clock.advance(by: .ticks(1))
 
         // Deinit `actomaton`.
         actomaton = nil
@@ -40,8 +42,7 @@ final class DeinitTests: MainTestCase
         // Wait until deinit fully completes.
         try? await task?.value
 
-        // Wait another 10ms for reliable deinit completion.
-        try await Task.sleep(nanoseconds: 10_000_000)
+        await settle()
 
         // Check results.
         //
@@ -53,6 +54,8 @@ final class DeinitTests: MainTestCase
             Set(results), ["Effect cancelled", "DeinitChecker deinit"],
             "Running effect should be cancelled, and `DeinitChecker` should deinit."
         )
+
+        _ = weakActomaton
     }
 }
 

--- a/Tests/ActomatonTests/EffectCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectCancellationTests.swift
@@ -46,8 +46,8 @@ final class EffectCancellationTests: MainTestCase
                     guard state == ._1 else { return .empty }
 
                     state = ._2
-                    return Effect(id: EffectID1To2()) {
-                        try await tick(1) {
+                    return Effect(id: EffectID1To2()) { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._2To3
                         } ifCancelled: {
                             Debug.print("_1To2 cancelled")
@@ -60,8 +60,8 @@ final class EffectCancellationTests: MainTestCase
                     guard state == ._2 else { return .empty }
 
                     state = ._3
-                    return Effect(id: EffectID2To3()) {
-                        try await tick(1) {
+                    return Effect(id: EffectID2To3()) { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._3To4
                         } ifCancelled: {
                             Debug.print("_2To3 cancelled")
@@ -78,19 +78,20 @@ final class EffectCancellationTests: MainTestCase
 
                 case ._cancel1To2:
                     state = .cancelled
-                    return Effect {
-                        try await tick(1)
+                    return Effect { context in
+                        try await context.clock.sleep(for: .ticks(1))
                         return nil
                     } + Effect.cancel(id: EffectID1To2())
 
                 case ._cancel2To3:
                     state = .cancelled
-                    return Effect {
-                        try await tick(1)
+                    return Effect { context in
+                        try await context.clock.sleep(for: .ticks(1))
                         return nil
                     } + Effect.cancel(id: EffectID2To3())
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
 
@@ -112,10 +113,10 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._1To2)
         assertEqual(await actomaton.state, ._2)
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
         assertEqual(await actomaton.state, ._3)
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
         assertEqual(await actomaton.state, ._4)
 
         let is1To2Cancelled = await flags.is1To2Cancelled
@@ -132,7 +133,7 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._1To2)
         assertEqual(await actomaton.state, ._2)
 
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         assertEqual(
             await actomaton.state,
             ._2,
@@ -143,7 +144,7 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._cancel1To2)
         assertEqual(await actomaton.state, .cancelled)
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
         assertEqual(
             await actomaton.state,
             .cancelled,
@@ -165,10 +166,10 @@ final class EffectCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._2)
 
         // Wait until `state = _3`.
-        try await tick(1.3)
+        await clock.advance(by: .ticks(1.3))
         assertEqual(await actomaton.state, ._3)
 
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         assertEqual(
             await actomaton.state,
             ._3,
@@ -179,7 +180,7 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._cancel1To2)
         assertEqual(await actomaton.state, .cancelled)
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
         assertEqual(
             await actomaton.state,
             .cancelled,
@@ -200,7 +201,7 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._1To2)
         assertEqual(await actomaton.state, ._2)
 
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         assertEqual(
             await actomaton.state,
             ._2,
@@ -211,7 +212,7 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._cancel2To3)
         assertEqual(await actomaton.state, .cancelled)
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
         assertEqual(
             await actomaton.state,
             .cancelled,
@@ -233,10 +234,10 @@ final class EffectCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._2)
 
         // Wait until `state = _3`.
-        try await tick(1.3)
+        await clock.advance(by: .ticks(1.3))
         assertEqual(await actomaton.state, ._3)
 
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         assertEqual(
             await actomaton.state,
             ._3,
@@ -247,7 +248,7 @@ final class EffectCancellationTests: MainTestCase
         await actomaton.send(._cancel2To3)
         assertEqual(await actomaton.state, .cancelled)
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
         assertEqual(
             await actomaton.state,
             .cancelled,

--- a/Tests/ActomatonTests/EffectContextClockTests.swift
+++ b/Tests/ActomatonTests/EffectContextClockTests.swift
@@ -1,12 +1,12 @@
 @testable import Actomaton
+import Clocks
 import XCTest
 
 final class EffectContextClockTests: XCTestCase
 {
     func test_sleep_for_uses_injected_clock() async throws
     {
-        let recorder = Recorder()
-        let clock = RecordingClock(recorder: recorder)
+        let clock = TestClock<Duration>()
 
         let actomaton = Actomaton<Action, State>(
             state: .idle,
@@ -15,7 +15,7 @@ final class EffectContextClockTests: XCTestCase
                 case .start:
                     state = .running
                     return Effect { context in
-                        try await context.clock.sleep(for: .seconds(1))
+                        try await context.clock.sleep(for: .ticks(1))
                         return .finished
                     }
 
@@ -28,16 +28,17 @@ final class EffectContextClockTests: XCTestCase
         )
 
         let task = await actomaton.send(.start)
+        assertEqual(await actomaton.state, .running)
+
+        await clock.advance(by: .ticks(1))
         try await task?.value
 
         assertEqual(await actomaton.state, .finished)
-        assertEqual(await recorder.durations, [.seconds(1)])
     }
 
     func test_sleep_until_uses_injected_clock() async throws
     {
-        let recorder = Recorder()
-        let clock = RecordingClock(recorder: recorder)
+        let clock = TestClock<Duration>()
 
         let actomaton = Actomaton<Action, State>(
             state: .idle,
@@ -46,8 +47,7 @@ final class EffectContextClockTests: XCTestCase
                 case .start:
                     state = .running
                     return Effect { context in
-                        let deadline = context.clock.now.advanced(by: .seconds(2))
-                        try await context.clock.sleep(until: deadline, tolerance: nil)
+                        try await context.clock.sleep(until: .ticks(2))
                         return .finished
                     }
 
@@ -60,10 +60,12 @@ final class EffectContextClockTests: XCTestCase
         )
 
         let task = await actomaton.send(.start)
+        assertEqual(await actomaton.state, .running)
+
+        await clock.advance(by: .ticks(2))
         try await task?.value
 
         assertEqual(await actomaton.state, .finished)
-        assertEqual(await recorder.durations, [.seconds(2)])
     }
 }
 
@@ -80,54 +82,4 @@ private enum State
     case idle
     case running
     case finished
-}
-
-private actor Recorder
-{
-    var durations: [Duration] = []
-
-    func append(_ duration: Duration)
-    {
-        self.durations.append(duration)
-    }
-}
-
-private struct RecordingClock: Clock
-{
-    struct Instant: InstantProtocol
-    {
-        var offset: Duration
-
-        func advanced(by duration: Duration) -> Instant
-        {
-            Instant(offset: self.offset + duration)
-        }
-
-        func duration(to other: Instant) -> Duration
-        {
-            other.offset - self.offset
-        }
-
-        static func < (l: Instant, r: Instant) -> Bool
-        {
-            l.offset < r.offset
-        }
-    }
-
-    let recorder: Recorder
-
-    var now: Instant
-    {
-        Instant(offset: .zero)
-    }
-
-    var minimumResolution: Duration
-    {
-        .zero
-    }
-
-    func sleep(until deadline: Instant, tolerance: Duration?) async throws
-    {
-        await self.recorder.append(self.now.duration(to: deadline))
-    }
 }

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -45,8 +45,8 @@ final class EffectIDAutoCancellationTests: MainTestCase
                     guard state == ._1 else { return .empty }
 
                     state = ._2
-                    return Effect(queue: Newest1EffectQueue()) {
-                        try await tick(1) {
+                    return Effect(queue: Newest1EffectQueue()) { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._2To3
                         } ifCancelled: {
                             Debug.print("_1To2 cancelled")
@@ -59,8 +59,8 @@ final class EffectIDAutoCancellationTests: MainTestCase
                     guard state == ._2 else { return .empty }
 
                     state = ._3
-                    return Effect(queue: Newest1EffectQueue()) {
-                        try await tick(1) {
+                    return Effect(queue: Newest1EffectQueue()) { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._3To4
                         } ifCancelled: {
                             Debug.print("_2To3 cancelled")
@@ -77,12 +77,13 @@ final class EffectIDAutoCancellationTests: MainTestCase
 
                 case ._toEnd:
                     state = ._end
-                    return Effect(queue: Newest1EffectQueue()) {
-                        try await tick(1)
+                    return Effect(queue: Newest1EffectQueue()) { context in
+                        try await context.clock.sleep(for: .ticks(1))
                         return nil
                     }
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
 
@@ -104,10 +105,10 @@ final class EffectIDAutoCancellationTests: MainTestCase
         await actomaton.send(._1To2)
         assertEqual(await actomaton.state, ._2)
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
         assertEqual(await actomaton.state, ._3)
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
         assertEqual(await actomaton.state, ._4)
 
         let is1To2Cancelled = await flags.is1To2Cancelled
@@ -124,7 +125,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
         await actomaton.send(._1To2)
         assertEqual(await actomaton.state, ._2)
 
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         assertEqual(
             await actomaton.state,
             ._2,
@@ -134,7 +135,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
         await actomaton.send(._toEnd)
         assertEqual(await actomaton.state, ._end)
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
         assertEqual(
             await actomaton.state,
             ._end,
@@ -156,10 +157,10 @@ final class EffectIDAutoCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._2)
 
         // Wait until `state = _3`.
-        try await tick(1.3)
+        await clock.advance(by: .ticks(1.3))
         assertEqual(await actomaton.state, ._3)
 
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         assertEqual(
             await actomaton.state,
             ._3,
@@ -169,7 +170,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
         await actomaton.send(._toEnd)
         assertEqual(await actomaton.state, ._end)
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
         assertEqual(
             await actomaton.state,
             ._end,

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -10,7 +10,7 @@ final class EffectQueueDelayTests: MainTestCase
 {
     private func makeActomaton<Queue: EffectQueueProtocol>(
         queue: Queue,
-        effectTime: TimeInterval
+        effectTime: TestDuration
     ) -> (Actomaton<Action, State>, startedIDs: ResultsCollector<String>, cancelledIDs: ResultsCollector<String>)
     {
         let startedIDs: ResultsCollector<String> = .init()
@@ -21,7 +21,7 @@ final class EffectQueueDelayTests: MainTestCase
             reducer: Reducer { action, state, _ in
                 switch action {
                 case let .fetch(id):
-                    return Effect(id: EffectID(name: "running \(id)"), queue: queue) {
+                    return Effect(id: EffectID(name: "running \(id)"), queue: queue) { context in
                         // NOTE: Due to `queue`'s delay, this scope may run at delayed schedule time.
 
                         print("Start: \(id), Task.isCancelled = \(Task.isCancelled)")
@@ -35,10 +35,10 @@ final class EffectQueueDelayTests: MainTestCase
                         // Swift 6 requirement:
                         // Swift 5.7 worked with 1 ms delay, but Swift 6 will need 10 ms.
                         do {
-                            try await Task.sleep(nanoseconds: 10_000_000)
+                            try await context.clock.sleep(for: .ticks(0.2))
                         }
                         catch {
-                            // Ignore cancellation handling during `Task.sleep`.
+                            // Ignore cancellation handling during `clock.sleep`.
                         }
 
                         print("Start (recheck): \(id), Task.isCancelled = \(Task.isCancelled)")
@@ -50,7 +50,7 @@ final class EffectQueueDelayTests: MainTestCase
                             await startedIDs.append(id)
                         }
 
-                        return try await tick(effectTime) {
+                        return try await context.clock.sleep(for: effectTime) {
                             return ._didFetch(id: id)
                         } ifCancelled: { () -> Action? in
                             print("Effect \(id) cancelled")
@@ -66,7 +66,8 @@ final class EffectQueueDelayTests: MainTestCase
                         print("Finished: \(id)")
                     }
                 }
-            }
+            },
+            effectContext: effectContext
         )
 
         return (actomaton, startedIDs, cancelledIDs)
@@ -74,8 +75,8 @@ final class EffectQueueDelayTests: MainTestCase
 
     func test_DelayedEffectQueue() async throws
     {
-        let delay: TimeInterval = 3
-        let effectTime: TimeInterval = 2
+        let delay = TestDuration.ticks(3)
+        let effectTime = TestDuration.ticks(2)
 
         // `.runNewest(maxCount: .max)`.
         let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
@@ -94,16 +95,16 @@ final class EffectQueueDelayTests: MainTestCase
 
         assertEqual(await actomaton.state.finishedIDs, [])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3", "4"])
 
         // ResultCollector
@@ -118,8 +119,8 @@ final class EffectQueueDelayTests: MainTestCase
     // NOTE: Behaves similar to debounce, but up to `.runNewest(N)` effects.
     func test_DelayedNewest2EffectQueue() async throws
     {
-        let delay: TimeInterval = 2
-        let effectTime: TimeInterval = 1
+        let delay = TestDuration.ticks(2)
+        let effectTime = TestDuration.ticks(1)
 
         // `.runNewest(2)`
         let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
@@ -139,10 +140,10 @@ final class EffectQueueDelayTests: MainTestCase
         // NOTE:
         // `delay * 2` for waiting from "1" to "3", then `effectTime + 0.75` for waiting "3"
         // to be safely completed but before fetching "4".
-        try await tick(delay * 2 + effectTime + 0.75)
+        await clock.advance(by: delay * 2.0 + effectTime + .ticks(0.75))
         assertEqual(await actomaton.state.finishedIDs, ["3"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["3", "4"])
 
         // ResultCollector
@@ -158,8 +159,8 @@ final class EffectQueueDelayTests: MainTestCase
 
     func test_DelayedOldest2SuspendNewEffectQueue() async throws
     {
-        let delay: TimeInterval = 2
-        let effectTime: TimeInterval = 3
+        let delay = TestDuration.ticks(2)
+        let effectTime = TestDuration.ticks(3)
 
         // `.runOldest(2, .suspendNew)`
         let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
@@ -176,16 +177,16 @@ final class EffectQueueDelayTests: MainTestCase
 
         assertEqual(await actomaton.state.finishedIDs, [])
 
-        try await tick(effectTime + 0.5)
+        await clock.advance(by: effectTime + .ticks(0.5))
         assertEqual(await actomaton.state.finishedIDs, ["1"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2", "3", "4"])
 
         // ResultCollector
@@ -199,8 +200,8 @@ final class EffectQueueDelayTests: MainTestCase
 
     func test_DelayedOldest2DiscardNewEffectQueue() async throws
     {
-        let delay: TimeInterval = 2
-        let effectTime: TimeInterval = 3
+        let delay = TestDuration.ticks(2)
+        let effectTime = TestDuration.ticks(3)
 
         // `.runOldest(2, .discardNew)`
         let (actomaton, startedIDs, cancelledIDs) = makeActomaton(
@@ -217,10 +218,10 @@ final class EffectQueueDelayTests: MainTestCase
 
         assertEqual(await actomaton.state.finishedIDs, [])
 
-        try await tick(effectTime + 0.5)
+        await clock.advance(by: effectTime + .ticks(0.5))
         assertEqual(await actomaton.state.finishedIDs, ["1"])
 
-        try await tick(delay)
+        await clock.advance(by: delay)
         assertEqual(await actomaton.state.finishedIDs, ["1", "2"])
 
         // ResultCollector
@@ -253,50 +254,48 @@ private struct EffectID: EffectIDProtocol
 
 private struct DelayedEffectQueue: EffectQueueProtocol
 {
-    let delay: TimeInterval
+    let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
         .runNewest(maxCount: .max)
     }
 
     var effectQueueDelay: EffectQueueDelay {
-        .constant(delay * timescale)
+        .constant(delay.timeInterval)
     }
 }
 
 private struct DelayedNewest2EffectQueue: EffectQueueProtocol
 {
-    let delay: TimeInterval
+    let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
         .runNewest(maxCount: 2)
     }
 
     var effectQueueDelay: EffectQueueDelay {
-        .constant(delay * timescale)
+        .constant(delay.timeInterval)
     }
 }
 
 private struct DelayedOldest2SuspendNewEffectQueue: EffectQueueProtocol
 {
-    let delay: TimeInterval
+    let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
         .runOldest(maxCount: 2, .suspendNew)
     }
 
     var effectQueueDelay: EffectQueueDelay {
-        .constant(delay * timescale)
+        .constant(delay.timeInterval)
     }
 }
 
 private struct DelayedOldest2DiscardNewEffectQueue: EffectQueueProtocol
 {
-    let delay: TimeInterval
+    let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
         .runOldest(maxCount: 2, .discardNew)
     }
 
     var effectQueueDelay: EffectQueueDelay {
-        .constant(delay * timescale)
+        .constant(delay.timeInterval)
     }
 }
-
-private let timescale: TimeInterval = .init(tickTimeInterval) / 1_000_000_000

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -20,8 +20,8 @@ final class FeedbackTrackingTaskTests: MainTestCase
                     guard state == ._1 else { return .empty }
 
                     state = ._2
-                    return Effect {
-                        try await tick(1) {
+                    return Effect { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._2To3
                         } ifCancelled: {
                             Debug.print("_1To2 cancelled")
@@ -33,8 +33,8 @@ final class FeedbackTrackingTaskTests: MainTestCase
                     guard state == ._2 else { return .empty }
 
                     state = ._3
-                    return Effect {
-                        try await tick(1) {
+                    return Effect { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._3To4
                         } ifCancelled: {
                             Debug.print("_2To3 cancelled")
@@ -46,18 +46,18 @@ final class FeedbackTrackingTaskTests: MainTestCase
                     guard state == ._3 else { return .empty }
 
                     state = ._4(count: 0)
-                    return Effect(sequence: {
+                    return Effect(sequence: { context in
                         AsyncStream<Action> { continuation in
                             let task = Task<(), any Error> {
                                 for _ in 1 ... 2 {
-                                    try await tick(1) {
+                                    try await context.clock.sleep(for: .ticks(1)) {
                                         continuation.yield(._increment)
                                     } ifCancelled: {
                                         Debug.print("_3To4 cancelled")
                                     }
                                 }
 
-                                try await tick(1)
+                                try await context.clock.sleep(for: .ticks(1))
                                 continuation.yield(._4To5)
                                 continuation.finish()
                             }
@@ -77,8 +77,8 @@ final class FeedbackTrackingTaskTests: MainTestCase
                     guard case ._4 = state else { return .empty }
 
                     state = ._5
-                    return Effect {
-                        try await tick(1) {
+                    return Effect { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._5To6
                         } ifCancelled: {
                             Debug.print("_4To5 cancelled")
@@ -94,12 +94,13 @@ final class FeedbackTrackingTaskTests: MainTestCase
 
                 case ._toEnd:
                     state = ._end
-                    return Effect {
-                        try await tick(1)
+                    return Effect { context in
+                        try await context.clock.sleep(for: .ticks(1))
                         return nil
                     }
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
 
@@ -123,6 +124,7 @@ final class FeedbackTrackingTaskTests: MainTestCase
         let task = await actomaton.send(._1To2, tracksFeedbacks: false)
 
         // Wait for `._1To2`'s effect only (upto `_2To3`'s next state-transition without its effect)
+        await clock.advance(by: .ticks(1))
         try await task?.value
 
         assertEqual(
@@ -134,20 +136,20 @@ final class FeedbackTrackingTaskTests: MainTestCase
             """
         )
 
-        try await tick(1.3)
+        await clock.advance(by: .ticks(1.3))
         assertEqual(await actomaton.state, ._4(count: 0))
 
-        try await tick(1.3)
+        await clock.advance(by: .ticks(1.3))
         assertEqual(await actomaton.state, ._4(count: 1))
 
-        try await tick(1.3)
+        await clock.advance(by: .ticks(1.3))
         assertEqual(await actomaton.state, ._4(count: 2))
 
         // Comment-Out: A bit flaky to check this intermediate state, so ignore it.
         // try await tick(1.3)
         // assertEqual(await actomaton.state, ._5)
 
-        try await tick(2)
+        await clock.advance(by: .ticks(2))
         assertEqual(await actomaton.state, ._6)
     }
 
@@ -162,6 +164,7 @@ final class FeedbackTrackingTaskTests: MainTestCase
         let task = await actomaton.send(._1To2, tracksFeedbacks: true)
 
         // Wait for all: `._1To2`, `._2To3`, `._3To4`, `._increment`, `._4To5`, `._5To6`.
+        await clock.advance(by: .ticks(6))
         try await task?.value
 
         assertEqual(
@@ -182,6 +185,7 @@ final class FeedbackTrackingTaskTests: MainTestCase
         let task = await actomaton.send(._3To4, tracksFeedbacks: true)
 
         // Wait for all: `._3To4`, `._increment`, `._4To5`, `._5To6`.
+        await clock.advance(by: .ticks(4))
         try await task?.value
 
         assertEqual(

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -37,14 +37,14 @@ final class LoginLogoutTests: MainTestCase
                 switch (action, state) {
                 case (.login, .loggedOut):
                     state = .loggingIn
-                    return Effect(queue: LoginFlowEffectQueue()) {
+                    return Effect(queue: LoginFlowEffectQueue()) { context in
                         do {
-                            try await tick(1)
-                            return .loginOK
-                        }
-                        catch is CancellationError {
-                            await flags.mark(isLoginCancelled: true)
-                            return nil
+                            return try await context.clock.sleep(for: .ticks(1)) {
+                                return .loginOK
+                            } ifCancelled: {
+                                await flags.mark(isLoginCancelled: true)
+                                return nil
+                            }
                         }
                         catch {
                             return nil
@@ -59,8 +59,8 @@ final class LoginLogoutTests: MainTestCase
                      (.forceLogout, .loggingIn),
                      (.forceLogout, .loggedIn):
                     state = .loggingOut
-                    return Effect(queue: LoginFlowEffectQueue()) {
-                        try await tick(1)
+                    return Effect(queue: LoginFlowEffectQueue()) { context in
+                        try await context.clock.sleep(for: .ticks(1))
                         return .logoutOK
                     }
 
@@ -71,7 +71,8 @@ final class LoginLogoutTests: MainTestCase
                 default:
                     return .empty
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
 
@@ -107,12 +108,14 @@ final class LoginLogoutTests: MainTestCase
         t = await actomaton.send(.login)
         assertEqual(await actomaton.state, .loggingIn)
 
+        await clock.advance(by: .ticks(1))
         try await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedIn)
 
         t = await actomaton.send(.logout)
         assertEqual(await actomaton.state, .loggingOut)
 
+        await clock.advance(by: .ticks(1))
         try await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
 
@@ -131,11 +134,12 @@ final class LoginLogoutTests: MainTestCase
         assertEqual(await actomaton.state, .loggingIn)
 
         // Wait for a while and interrupt by `forceLogout`.
-        try await tick(0.1)
+        await clock.advance(by: .ticks(0.1))
         t = await actomaton.send(.forceLogout)
 
         assertEqual(await actomaton.state, .loggingOut)
 
+        await clock.advance(by: .ticks(1))
         try await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
 

--- a/Tests/ActomatonTests/MainActomaton/MainActomatonCounterTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonCounterTests.swift
@@ -28,7 +28,8 @@ final class MainActomatonCounterTests: MainTestCase
                         print("decrement")
                     }
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
     }

--- a/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
@@ -9,14 +9,15 @@ final class MainActomatonDeinitTests: MainTestCase
     func test_deinit() async throws
     {
         let resultsCollector = ResultsCollector<String>()
+        let clock = self.clock
 
         var actomaton: MainActomaton? = MainActomaton<Action, State>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
                 case .run:
-                    return Effect { [resultsCollector] in
-                        return try await tick(5) {
+                    return Effect { [resultsCollector] context in
+                        return try await context.clock.sleep(for: .ticks(5)) {
                             await resultsCollector.append("Effect succeeded")
                             return nil
                         } ifCancelled: {
@@ -27,13 +28,14 @@ final class MainActomatonDeinitTests: MainTestCase
                     }
                 }
             },
-            environment: Environment(resultsCollector: resultsCollector)
+            environment: Environment(resultsCollector: resultsCollector),
+            effectContext: effectContext
         )
 
         weak var weakActomaton = actomaton
 
         let task = actomaton?.send(.run)
-        try await tick(1)
+        await clock.advance(by: .ticks(1))
 
         // Deinit `actomaton`.
         actomaton = nil
@@ -42,8 +44,7 @@ final class MainActomatonDeinitTests: MainTestCase
         // Wait until deinit fully completes.
         try? await task?.value
 
-        // Wait another 10ms for reliable deinit completion.
-        try await Task.sleep(nanoseconds: 10_000_000)
+        await settle()
 
         // Check results.
         //
@@ -55,6 +56,8 @@ final class MainActomatonDeinitTests: MainTestCase
             Set(results), ["Effect cancelled", "DeinitChecker deinit"],
             "Running effect should be cancelled, and `DeinitChecker` should deinit."
         )
+
+        _ = weakActomaton
     }
 }
 

--- a/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
+++ b/Tests/ActomatonTests/MainActomaton/MainActomatonDeinitTests.swift
@@ -57,7 +57,7 @@ final class MainActomatonDeinitTests: MainTestCase
             "Running effect should be cancelled, and `DeinitChecker` should deinit."
         )
 
-        _ = weakActomaton
+        weakActomaton = nil // For suppressing `WeakMutability` warning.
     }
 }
 

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -54,8 +54,8 @@ final class PendingEffectCancellationTests: MainTestCase
             reducer: Reducer { [flags] action, _, _ in
                 switch action {
                 case .fetch1:
-                    return Effect(id: EffectID(name: "1"), queue: Oldest1SuspendNewEffectQueue()) {
-                        try await tick(1) {
+                    return Effect(id: EffectID(name: "1"), queue: Oldest1SuspendNewEffectQueue()) { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._didFetch1
                         } ifCancelled: {
                             Debug.print("Effect 1 cancelled")
@@ -65,8 +65,8 @@ final class PendingEffectCancellationTests: MainTestCase
                     }
 
                 case .fetch2:
-                    return Effect(id: EffectID(name: "2"), queue: Oldest1SuspendNewEffectQueue()) {
-                        try await tick(1) {
+                    return Effect(id: EffectID(name: "2"), queue: Oldest1SuspendNewEffectQueue()) { context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             return ._didFetch2
                         } ifCancelled: {
                             // NOTE: When Effect 2 is suspended and cancelled before execution,
@@ -87,7 +87,8 @@ final class PendingEffectCancellationTests: MainTestCase
                 case .cancelAll:
                     return Effect.cancel(ids: { $0.value is EffectID })
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
 
@@ -110,12 +111,12 @@ final class PendingEffectCancellationTests: MainTestCase
         await actomaton.send(.fetch1)
         await actomaton.send(.fetch2) // NOTE: This fetch will be suspended by `Oldest1SuspendNewEffectQueue`.
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(await flags.result1, .completed)
         assertEqual(await flags.result2, .initial, "Should not complete yet.")
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(await flags.result1, .completed)
         assertEqual(await flags.result2, .completed)
@@ -131,7 +132,7 @@ final class PendingEffectCancellationTests: MainTestCase
 
         await actomaton.send(.cancelAll)
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(await flags.result1, .cancelled)
         assertEqual(await flags.result2, .cancelled)

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -33,11 +33,11 @@ final class RunNewestDiscardOldTests: MainTestCase
                 case .increment:
                     state.count += 1
 
-                    return Effect(queue: NewestEffectQueue(maxCount: maxCount)) { [state] in
-                        try await tick(1) {
+                    return Effect(queue: NewestEffectQueue(maxCount: maxCount)) { [state] context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             Debug.print("Effect success")
                             return .effectCompleted
-                        } ifCancelled: { [resultsCollector] in
+                        } ifCancelled: {
                             await resultsCollector.append(state.count)
                             Debug.print("Effect cancelled: \(state.count)")
                             return nil
@@ -48,7 +48,8 @@ final class RunNewestDiscardOldTests: MainTestCase
                     state.effectCompletedCount += 1
                     return .empty
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
     }
@@ -67,7 +68,7 @@ final class RunNewestDiscardOldTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
 
         assertEqual(
             await actomaton.state,
@@ -79,7 +80,7 @@ final class RunNewestDiscardOldTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 1))
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
 
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
 
@@ -109,7 +110,7 @@ final class RunNewestDiscardOldTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 0))
 
-        try await tick(5)
+        await clock.advance(by: .ticks(5))
 
         assertEqual(
             await actomaton.state,
@@ -121,7 +122,7 @@ final class RunNewestDiscardOldTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 5, effectCompletedCount: 2))
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
 
         assertEqual(await actomaton.state, State(count: 5, effectCompletedCount: 3))
 

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -33,11 +33,11 @@ final class RunOldestDiscardNewTests: MainTestCase
                 case .increment:
                     state.count += 1
 
-                    return Effect(queue: OldestDiscardNewEffectQueue(maxCount: maxCount)) { [state] in
-                        try await tick(1) {
+                    return Effect(queue: OldestDiscardNewEffectQueue(maxCount: maxCount)) { [state] context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             Debug.print("Effect success")
                             return .effectCompleted
-                        } ifCancelled: { [resultsCollector] in
+                        } ifCancelled: {
                             await resultsCollector.append(state.count)
                             Debug.print("Effect cancelled")
                             return nil
@@ -48,7 +48,8 @@ final class RunOldestDiscardNewTests: MainTestCase
                     state.effectCompletedCount += 1
                     return .empty
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
     }
@@ -67,7 +68,7 @@ final class RunOldestDiscardNewTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
 
         assertEqual(
             await actomaton.state,
@@ -79,7 +80,7 @@ final class RunOldestDiscardNewTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 1))
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
 
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
 
@@ -109,7 +110,7 @@ final class RunOldestDiscardNewTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 0))
 
-        try await tick(4)
+        await clock.advance(by: .ticks(4))
 
         assertEqual(
             await actomaton.state,
@@ -121,7 +122,7 @@ final class RunOldestDiscardNewTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 2))
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
 
         assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 3))
 

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -33,11 +33,11 @@ final class RunOldestSuspendNewTests: MainTestCase
                 case .increment:
                     state.count += 1
 
-                    return Effect(queue: OldestSuspendNewEffectQueue(maxCount: maxCount)) { [state] in
-                        try await tick(1) {
+                    return Effect(queue: OldestSuspendNewEffectQueue(maxCount: maxCount)) { [state] context in
+                        return try await context.clock.sleep(for: .ticks(1)) {
                             Debug.print("Effect success")
                             return .effectCompleted
-                        } ifCancelled: { [resultsCollector] in
+                        } ifCancelled: {
                             await resultsCollector.append(state.count)
                             Debug.print("Effect cancelled")
                             return nil
@@ -48,7 +48,8 @@ final class RunOldestSuspendNewTests: MainTestCase
                     state.effectCompletedCount += 1
                     return .empty
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
     }
@@ -68,7 +69,7 @@ final class RunOldestSuspendNewTests: MainTestCase
         assertEqual(await actomaton.state, State(count: 2, effectCompletedCount: 0))
 
         // Wait until 1st effect is finished.
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(
             await actomaton.state,
@@ -77,7 +78,7 @@ final class RunOldestSuspendNewTests: MainTestCase
         )
 
         // Wait until 2nd effect is finished.
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(
             await actomaton.state,
@@ -89,7 +90,7 @@ final class RunOldestSuspendNewTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 2))
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 3))
 
@@ -116,7 +117,7 @@ final class RunOldestSuspendNewTests: MainTestCase
         assertEqual(await actomaton.state, State(count: 3, effectCompletedCount: 0))
 
         // Wait until 1st & 2nd effect is finished.
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(
             await actomaton.state,
@@ -125,7 +126,7 @@ final class RunOldestSuspendNewTests: MainTestCase
         )
 
         // Wait until 3rd effect is finished.
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(
             await actomaton.state,
@@ -137,7 +138,7 @@ final class RunOldestSuspendNewTests: MainTestCase
         await actomaton.send(.increment)
         assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 3))
 
-        try await tick(1.5)
+        await clock.advance(by: .ticks(1.5))
 
         assertEqual(await actomaton.state, State(count: 4, effectCompletedCount: 4))
 

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -14,11 +14,11 @@ final class TimerTests: MainTestCase
     {
         struct TimerID: EffectIDProtocol {}
 
-        let timerEffect = Effect(id: TimerID(), sequence: {
+        let timerEffect = Effect(id: TimerID(), sequence: { context in
             AsyncStream<()> { continuation in
                 let task = Task {
                     while true {
-                        try await tick(2)
+                        try await context.clock.sleep(for: .ticks(2))
                         continuation.yield(())
                     }
                 }
@@ -42,7 +42,8 @@ final class TimerTests: MainTestCase
                 case .stop:
                     return .cancel(id: TimerID())
                 }
-            }
+            },
+            effectContext: effectContext
         )
         self.actomaton = actomaton
 
@@ -65,18 +66,18 @@ final class TimerTests: MainTestCase
 
         assertEqual(await actomaton.state, 0)
 
-        try await tick(2.3)
+        await clock.advance(by: .ticks(2.3))
         assertEqual(await actomaton.state, 1)
 
-        try await tick(2.3)
+        await clock.advance(by: .ticks(2.3))
         assertEqual(await actomaton.state, 2)
 
-        try await tick(2.3)
+        await clock.advance(by: .ticks(2.3))
         assertEqual(await actomaton.state, 3)
 
         await actomaton.send(.stop)
 
-        try await tick(3)
+        await clock.advance(by: .ticks(3))
         assertEqual(
             await actomaton.state,
             3,

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -56,7 +56,7 @@ final class DeinitTests: MainTestCase
             "Running effect should be cancelled, and `DeinitChecker` should deinit."
         )
 
-        _ = weakActomaton
+        weakActomaton = nil // For suppressing `WeakMutability` warning.
     }
 }
 

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -10,14 +10,15 @@ final class DeinitTests: MainTestCase
     func test_deinit() async throws
     {
         let resultsCollector = ResultsCollector<String>()
+        let clock = self.clock
 
         var actomaton: Store? = Store<Action, State, Environment>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
                 case .run:
-                    return Effect { [resultsCollector] in
-                        return try await tick(5) {
+                    return Effect { [resultsCollector] context in
+                        return try await context.clock.sleep(for: .ticks(5)) {
                             await resultsCollector.append("Effect succeeded")
                             return nil
                         } ifCancelled: {
@@ -28,13 +29,14 @@ final class DeinitTests: MainTestCase
                     }
                 }
             },
-            environment: Environment(resultsCollector: resultsCollector)
+            environment: Environment(resultsCollector: resultsCollector),
+            effectContext: effectContext
         )
 
         weak var weakActomaton = actomaton
 
         let task = actomaton?.send(.run)
-        try await tick(1)
+        await clock.advance(by: .ticks(1))
 
         // Deinit `actomaton`.
         actomaton = nil
@@ -53,6 +55,8 @@ final class DeinitTests: MainTestCase
             Set(results), ["Effect cancelled", "DeinitChecker deinit"],
             "Running effect should be cancelled, and `DeinitChecker` should deinit."
         )
+
+        _ = weakActomaton
     }
 }
 

--- a/Tests/TestFixtures/Fixtures.swift
+++ b/Tests/TestFixtures/Fixtures.swift
@@ -1,28 +1,77 @@
+import Clocks
 import XCTest
 
-// MARK: - Tick
+// MARK: - Clock.advance(by: TestDuration)
 
-/// - Note: For safe async testing, leeway should have at least 50 millisec (30 millsec isn't enough for MacBook Pro
-/// (15-inch, 2018)).
-public func tick(_ n: Double) async throws
+extension TestClock where Duration == Swift.Duration
 {
-    try await Task.sleep(nanoseconds: UInt64(Double(tickTimeInterval) * n))
+    public func advance(
+        by duration: TestDuration
+    ) async
+    {
+        await self.advance(by: duration.duration)
+    }
 }
 
-public let tickTimeInterval: UInt64 = 50_000_000 // 50 ms
-
-public func tick<T>(
-    _ n: Double,
-    ifSucceeded: () async throws -> T,
-    ifCancelled: () async throws -> T
-) async throws -> T
+extension ContinuousClock
 {
-    do {
-        try await tick(n)
-        return try await ifSucceeded()
+    public func advance(
+        by duration: TestDuration
+    ) async
+    {
+        try? await self.sleep(for: duration.duration)
     }
-    catch is CancellationError {
-        return try await ifCancelled()
+}
+
+// MARK: - Clock.sleep(for: TestDuration)
+
+extension Clock where Duration == Swift.Duration
+{
+    public func sleep(
+        for duration: TestDuration
+    ) async throws
+    {
+        try await self.sleep(for: duration.duration)
+    }
+
+    public func sleep<T>(
+        for duration: TestDuration,
+        ifSucceeded: () async throws -> T,
+        ifCancelled: () async throws -> T
+    ) async throws -> T
+    {
+        do {
+            try await self.sleep(for: duration.duration)
+            return try await ifSucceeded()
+        }
+        catch is CancellationError {
+            return try await ifCancelled()
+        }
+    }
+}
+
+// MARK: - Clock.sleep(until: TestDuration)
+
+extension Clock where Duration == Swift.Duration
+{
+    public func sleep(
+        until duration: TestDuration,
+        tolerance: Duration? = nil
+    ) async throws
+    {
+        let deadline = self.now.advanced(by: duration.duration)
+        try await self.sleep(until: deadline, tolerance: tolerance)
+    }
+}
+
+// MARK: - settle
+
+public func settle(
+    yields: Int = 10
+) async
+{
+    for _ in 0 ..< yields {
+        await Task.yield()
     }
 }
 

--- a/Tests/TestFixtures/MainTestCase.swift
+++ b/Tests/TestFixtures/MainTestCase.swift
@@ -1,3 +1,5 @@
+import Actomaton
+import Clocks
 import Foundation
 import XCTest
 
@@ -5,18 +7,31 @@ import XCTest
 
 import ConcurrencyExtras
 
+#endif
+
 /// This XCTestCase subclass ensures that all async code is executed in the same order that is enqueued.
 /// [More information](https://www.pointfree.co/blog/posts/110-reliably-testing-async-code-in-swift)
-open class MainTestCase: XCTestCase {
-    open override func invokeTest() {
+open class MainTestCase: XCTestCase
+{
+#if CI
+    public let clock = TestClock<Duration>()
+#else
+    public let clock = ContinuousClock()
+#endif
+
+    public var effectContext: EffectContext
+    {
+        EffectContext(clock: self.clock)
+    }
+
+    open override func invokeTest()
+    {
+#if canImport(ConcurrencyExtras)
         withMainSerialExecutor {
             super.invokeTest()
         }
+#else
+        super.invokeTest()
+#endif
     }
 }
-
-#else
-
-public typealias MainTestCase = XCTestCase
-
-#endif

--- a/Tests/TestFixtures/TestDuration.swift
+++ b/Tests/TestFixtures/TestDuration.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Test-only duration unit backed by "ticks".
+///
+/// One tick is currently 50 ms.
+public struct TestDuration: Sendable, Hashable
+{
+    public let ticks: TimeInterval
+
+    private init(
+        ticks: TimeInterval
+    )
+    {
+        self.ticks = ticks
+    }
+
+    public static func ticks(
+        _ ticks: TimeInterval
+    ) -> Self
+    {
+        Self(ticks: ticks)
+    }
+
+    public var timeInterval: TimeInterval
+    {
+        self.ticks * oneTickTimeInterval
+    }
+
+    internal var duration: Duration
+    {
+        .nanoseconds(Int64((Double(oneTickNanoseconds) * self.ticks).rounded()))
+    }
+}
+
+public func + (
+    lhs: TestDuration,
+    rhs: TestDuration
+) -> TestDuration
+{
+    .ticks(lhs.ticks + rhs.ticks)
+}
+
+public func * (
+    lhs: TestDuration,
+    rhs: TimeInterval
+) -> TestDuration
+{
+    .ticks(lhs.ticks * rhs)
+}
+
+public func * (
+    lhs: TimeInterval,
+    rhs: TestDuration
+) -> TestDuration
+{
+    rhs * lhs
+}
+
+private let oneTickNanoseconds: UInt64 = 50_000_000 // 50 ms
+private let oneTickTimeInterval: TimeInterval = .init(oneTickNanoseconds) / 1_000_000_000

--- a/Tests/TestFixtures/UncheckedSendable.swift
+++ b/Tests/TestFixtures/UncheckedSendable.swift
@@ -1,6 +1,0 @@
-#if !DISABLE_COMBINE && canImport(Combine)
-import Combine
-
-extension Published.Publisher: @retroactive @unchecked Sendable {}
-
-#endif


### PR DESCRIPTION
## Summary

- Add `TestDuration` type and `Clock`-based helpers replacing raw `tick()` functions
- Use `TestClock` in CI and `ContinuousClock` locally via `MainTestCase`
- Update all tests to use clock-based `sleep`/`advance` instead of `tick()`
- Enable SwiftFormat `extensionAccessControl` rule with `onDeclarations`
- Update CI to use `make swift-test` with `-DCI` flag for Ubuntu
