### PR TITLE
Include SwiftFormat plugin only when SWIFTFORMAT env var is set

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
           restore-keys: swiftformat-
       - name: Lint
         run: swift package plugin --allow-writing-to-package-directory swiftformat --lint
+        env:
+          SWIFTFORMAT: 1
 
   xcode-build:
     name: Xcode build ${{ matrix.platform }}

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ swift-test:
 
 .PHONY: swiftformat
 swiftformat:
-	swift package plugin --allow-writing-to-package-directory swiftformat
+	SWIFTFORMAT=1 swift package plugin --allow-writing-to-package-directory swiftformat
 
 .PHONY: swiftformat-lint
 swiftformat-lint:
-	swift package plugin --allow-writing-to-package-directory swiftformat --lint
+	SWIFTFORMAT=1 swift package plugin --allow-writing-to-package-directory swiftformat --lint
 
 #--------------------------------------------------
 # DocC

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf209feae64d9c9a887d9ee61e77e6227c06d91de6db0be66613f5e5509195cc",
+  "originHash" : "e2e92d9750f7f484319d47bd888e13be127692834f6d412a020cccc35de8f6a8",
   "pins" : [
     {
       "identity" : "swift-case-paths",
@@ -35,15 +35,6 @@
       "state" : {
         "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swiftformat",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nicklockwood/SwiftFormat",
-      "state" : {
-        "revision" : "c8e50ff2cfc2eab46246c072a9ae25ab656c6ec3",
-        "version" : "0.60.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,13 +25,18 @@ let package = Package(
             targets: ["ActomatonEffect"]
         ),
     ],
-    dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
-        .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.6"),
-        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"),
-    ],
+    dependencies: {
+        var deps: [Package.Dependency] = [
+            .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),
+            .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.6"),
+            .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
+            .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
+        ]
+        if ProcessInfo.processInfo.environment["SWIFTFORMAT"] != nil {
+            deps.append(.package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"))
+        }
+        return deps
+    }(),
     targets: [
         .target(
             name: "ActomatonCore",


### PR DESCRIPTION
Conditionally include SwiftFormat package dependency only when `SWIFTFORMAT` environment variable is set, to avoid slow builds (especially on CI).

- `Package.swift`: Use closure-based `dependencies` that checks `ProcessInfo.processInfo.environment["SWIFTFORMAT"]`
- `Makefile`: `swiftformat` / `swiftformat-lint` targets now prefix with `SWIFTFORMAT=1`
- `Package.resolved`: SwiftFormat entry removed (resolved on-demand only)
