### PR TITLE
Rename `#if CI` to `#if TEST_CLOCK` for explicit test clock control

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: apt-get update && apt-get install -y make
 
       - name: Build Ubuntu package
-        run: CI=1 make swift-test
+        run: TEST_CLOCK=1 make swift-test
 
   required:
     name: Required

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PLATFORM_TVOS = tvOS Simulator,id=$(call udid_for,tvOS,TV)
 PLATFORM_VISIONOS = visionOS Simulator,id=$(call udid_for,visionOS,Vision)
 PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,watchOS,Watch)
 
-SWIFT_TEST_FLAGS = $(if $(CI),-Xswiftc -DCI,)
+SWIFT_TEST_FLAGS = $(if $(filter 1,$(TEST_CLOCK)),-Xswiftc -DTEST_CLOCK,)
 
 # Base path after host name, required for GitHub Pages.
 # Note that `documentation/{module_name}` is automatically added to the end of this path in Swift-DocC,

--- a/Tests/TestFixtures/MainTestCase.swift
+++ b/Tests/TestFixtures/MainTestCase.swift
@@ -13,7 +13,7 @@ import ConcurrencyExtras
 /// [More information](https://www.pointfree.co/blog/posts/110-reliably-testing-async-code-in-swift)
 open class MainTestCase: XCTestCase
 {
-#if CI
+#if TEST_CLOCK
     public let clock = TestClock<Duration>()
 #else
     public let clock = ContinuousClock()


### PR DESCRIPTION
Rename `#if CI` compilation condition to `#if TEST_CLOCK` to make the intent explicit — it controls whether `TestClock` is used, not whether we're running in CI.

- `Makefile`: Use `$(filter 1,$(TEST_CLOCK))` instead of `$(if $(CI),...)` so `TEST_CLOCK=0` correctly disables the flag
- `.github/workflows/main.yml`: Use `TEST_CLOCK=1` instead of `CI=1`
- `Tests/TestFixtures/MainTestCase.swift`: `#if CI` → `#if TEST_CLOCK`
