### PR TITLE
Refactor ActionEffectManager Output from Action? to [Action]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Built-in `EffectManagerProtocol` conformers cover common cases:
 |---|---|---|
 | `EffectManager` | `Effect<Action>` | Full async effect lifecycle (in `ActomatonEffect`) |
 | `NoOpEffectManager` | `Void` | Pure state transitions, no side-effects |
-| `ActionEffectManager` | `Action?` | Synchronous action feedback loops |
+| `ActionEffectManager` | `[Action]` | Synchronous action feedback loops |
 
 ## Installation
 

--- a/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
@@ -1,11 +1,15 @@
 import Foundation
 
-/// Simple `Action`-based Effect Manager where `Output` is `Action?` that allows synchronous action feedback loop
+/// Simple `Action`-based Effect Manager where `Output` is `[Action]` that allows synchronous action feedback loop
 /// without side-effects.
+///
+/// Each action in the output array is fed back into the reducer sequentially.
+/// Any further actions produced by those feedback calls are recursively processed
+/// until no more actions remain.
 public final class ActionEffectManager<Action, State>: EffectManagerProtocol
     where Action: Sendable
 {
-    public typealias Output = Action?
+    public typealias Output = [Action]
 
     public init() {}
 
@@ -24,12 +28,12 @@ public final class ActionEffectManager<Action, State>: EffectManagerProtocol
         sendReducer: (Action) -> Output
     ) -> Output
     {
-        if let output {
-            return preprocessOutput(sendReducer(output), sendReducer: sendReducer)
+        var remaining: [Action] = []
+        for action in output {
+            let nested = preprocessOutput(sendReducer(action), sendReducer: sendReducer)
+            remaining.append(contentsOf: nested)
         }
-        else {
-            return nil
-        }
+        return remaining
     }
 
     public func processOutput(

--- a/Tests/ActomatonCoreTests/DoubleLoopDoubleMealyMachineTests.swift
+++ b/Tests/ActomatonCoreTests/DoubleLoopDoubleMealyMachineTests.swift
@@ -85,16 +85,16 @@ private struct Pair: Equatable, Sendable
 /// using `makePairsForRow` (a pure computation), and action feedback drives the `i` loop.
 /// Each `.innerDone(results)` action appends results, increments `i`, and feeds back
 /// the next iteration — or returns `nil` when all rows are complete.
-private func makeOuterMachine(n: Int, m: Int) -> MealyMachine<OuterAction, OuterState, OuterAction?>
+private func makeOuterMachine(n: Int, m: Int) -> MealyMachine<OuterAction, OuterState, [OuterAction]>
 {
     MealyMachine(
         state: OuterState(),
         reducer: MealyReducer { action, state, _ in
             switch action {
             case .start:
-                guard n > 0, m > 0 else { return nil }
+                guard n > 0, m > 0 else { return [] }
                 let results = makePairsForRow(i: 0, m: m)
-                return .innerDone(results: results)
+                return [.innerDone(results: results)]
 
             case let .innerDone(results):
                 state.results.append(contentsOf: results)
@@ -102,10 +102,10 @@ private func makeOuterMachine(n: Int, m: Int) -> MealyMachine<OuterAction, Outer
 
                 if state.i < n {
                     let innerResults = makePairsForRow(i: state.i, m: m)
-                    return .innerDone(results: innerResults)
+                    return [.innerDone(results: innerResults)]
                 }
                 else {
-                    return nil
+                    return []
                 }
             }
         },

--- a/Tests/ActomatonCoreTests/DoubleLoopSingleMealyMachineTests.swift
+++ b/Tests/ActomatonCoreTests/DoubleLoopSingleMealyMachineTests.swift
@@ -84,27 +84,27 @@ private struct LoopState: Equatable, Sendable
 ///
 /// Each iteration maps to a `.doSomething(i, j)` action whose reducer returns
 /// the next `(i, j)` as feedback, or `nil` when done.
-private func makeDoubleLoopMachine(n: Int, m: Int) -> MealyMachine<LoopAction, LoopState, LoopAction?>
+private func makeDoubleLoopMachine(n: Int, m: Int) -> MealyMachine<LoopAction, LoopState, [LoopAction]>
 {
     MealyMachine(
         state: LoopState(),
         reducer: MealyReducer { action, state, _ in
             switch action {
             case .start:
-                guard n > 0, m > 0 else { return nil }
-                return .doSomething(i: 0, j: 0)
+                guard n > 0, m > 0 else { return [] }
+                return [.doSomething(i: 0, j: 0)]
 
             case let .doSomething(i, j):
                 state.results.append(Pair(i: i, j: j))
 
                 if j + 1 < m {
-                    return .doSomething(i: i, j: j + 1)
+                    return [.doSomething(i: i, j: j + 1)]
                 }
                 else if i + 1 < n {
-                    return .doSomething(i: i + 1, j: 0)
+                    return [.doSomething(i: i + 1, j: 0)]
                 }
                 else {
-                    return nil
+                    return []
                 }
             }
         },

--- a/Tests/ActomatonCoreTests/MealyMachineActionFeedbackTests.swift
+++ b/Tests/ActomatonCoreTests/MealyMachineActionFeedbackTests.swift
@@ -6,16 +6,16 @@ final class MealyMachineActionFeedbackTests: XCTestCase
 {
     func test_singleFeedback() async
     {
-        let machine = MealyMachine<FeedbackAction, String, FeedbackAction?>(
+        let machine = MealyMachine<FeedbackAction, String, [FeedbackAction]>(
             state: "",
             reducer: MealyReducer { action, state, _ in
                 switch action {
                 case .start:
                     state = "started"
-                    return .finish
+                    return [.finish]
                 case .finish:
                     state = "finished"
-                    return nil
+                    return []
                 }
             },
             effectManager: ActionEffectManager()
@@ -30,19 +30,19 @@ final class MealyMachineActionFeedbackTests: XCTestCase
 
     func test_chainedFeedback() async
     {
-        let machine = MealyMachine<ChainAction, [String], ChainAction?>(
+        let machine = MealyMachine<ChainAction, [String], [ChainAction]>(
             state: [],
             reducer: MealyReducer { action, state, _ in
                 switch action {
                 case .step1:
                     state.append("step1")
-                    return .step2
+                    return [.step2]
                 case .step2:
                     state.append("step2")
-                    return .step3
+                    return [.step3]
                 case .step3:
                     state.append("step3")
-                    return nil
+                    return []
                 }
             },
             effectManager: ActionEffectManager()
@@ -55,11 +55,11 @@ final class MealyMachineActionFeedbackTests: XCTestCase
 
     func test_noFeedback() async
     {
-        let machine = MealyMachine<ChainAction, [String], ChainAction?>(
+        let machine = MealyMachine<ChainAction, [String], [ChainAction]>(
             state: [],
             reducer: MealyReducer { action, state, _ in
                 state.append("\(action)")
-                return nil
+                return []
             },
             effectManager: ActionEffectManager()
         )


### PR DESCRIPTION
## Summary

Refactor `ActionEffectManager`'s `Output` type from `Action?` to `[Action]` to support multiple synchronous feedback actions from a single reducer call.

### Motivation

With `Action?`, only a single feedback action could be returned per reducer invocation. This is insufficient for upcoming `TestActomaton` support, where `Effect<Action>` will be mapped to `[Action]` via `map(output:)` — extracting all `.next` actions (potentially multiple) while stripping async effects.

### Changes

- **`ActionEffectManager`**: `Output` changed from `Action?` to `[Action]`. `preprocessOutput` now iterates over all actions in the array and recursively processes each one's nested output.
- **Tests**: Updated all 3 test files (`MealyMachineActionFeedbackTests`, `DoubleLoopSingleMealyMachineTests`, `DoubleLoopDoubleMealyMachineTests`) to return `[Action]` / `[]` instead of `Action?` / `nil`.
- **README**: Updated the `EffectManagerProtocol` conformers table.
