### PR TITLE
Add swift-docc-plugin combined docs and GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/swift-docc.yml
+++ b/.github/workflows/swift-docc.yml
@@ -1,0 +1,47 @@
+name: Deploy DocC to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build documentation
+        run: make docc
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docbuild
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,39 @@ _docs:
 	@# Clean up.
 	rm -rf $(DOCBUILD_BUILD_DIR)
 
+#--------------------------------------------------
+# DocC (experimental combined documentation via swift-docc-plugin)
+#--------------------------------------------------
+
+.PHONY: docc
+docc:
+	$(MAKE) _docc DOC_HOSTING_BASE_PATH=$(DOC_HOSTING_BASE_PATH)
+
+.PHONY: docc-local
+docc-local:
+	@# NOTE: `DOC_HOSTING_BASE_PATH=/` is only for local viewer, and does not work for GitHub Pages.
+	$(MAKE) _docc DOC_HOSTING_BASE_PATH=/
+
+	#--------------------------------------------------
+	# Open http://localhost:8000/documentation
+	#--------------------------------------------------
+	python3 -m http.server 8000 -d $(DOCBUILD_OUTPUT_DIR)
+
+.PHONY: _docc
+_docc:
+	rm -rf $(DOCBUILD_OUTPUT_DIR)
+
+	DOCC=1 swift package \
+		--allow-writing-to-directory $(DOCBUILD_OUTPUT_DIR) \
+		generate-documentation \
+		--enable-experimental-combined-documentation \
+		--target Actomaton \
+		--target ActomatonUI \
+		--target ActomatonDebugging \
+		--transform-for-static-hosting \
+		--hosting-base-path $(DOC_HOSTING_BASE_PATH) \
+		--output-path $(DOCBUILD_OUTPUT_DIR)
+
 define udid_for
 $(shell xcrun simctl list devices available '$(1)' | grep '$(2)' | sort -r | head -1 | awk -F '[()]' '{ print $$(NF-3) }')
 endef

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,9 @@ let package = Package(
             .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),
             .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
         ]
+        if ProcessInfo.processInfo.environment["DOCC"] != nil {
+            deps.append(.package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.6"))
+        }
         if ProcessInfo.processInfo.environment["SWIFTFORMAT"] != nil {
             deps.append(.package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"))
         }


### PR DESCRIPTION
Add `make docc` / `make docc-local` targets using swift-docc-plugin's experimental combined documentation feature, and a GitHub Actions workflow for automatic deployment to GitHub Pages.

### Changes

- **`Package.swift`**: Conditionally include `swift-docc-plugin` only when `DOCC` environment variable is set (same pattern as `SWIFTFORMAT`)
- **`Makefile`**: Add `docc`, `docc-local`, and `_docc` targets that run `swift package generate-documentation --enable-experimental-combined-documentation` for Actomaton, ActomatonUI, and ActomatonDebugging
- **`.github/workflows/swift-docc.yml`**: New workflow that builds docs via `make docc` on `macos-26` and deploys to GitHub Pages using `actions/deploy-pages@v4`

### Notes

- The existing `make docs` / `make docs-local` (xcodebuild-based with manual jq merging) is preserved as-is
- GitHub Pages source has been switched from `gh-pages` branch to GitHub Actions (`build_type: workflow`)
- The `gh-pages` branch has been deleted
