### PR TITLE
Add ActomatonTesting module with TestMachine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
             name: "ActomatonEffect",
             targets: ["ActomatonEffect"]
         ),
+        .library(
+            name: "ActomatonTesting",
+            targets: ["ActomatonTesting"]
+        ),
     ],
     dependencies: {
         var deps: [Package.Dependency] = [
@@ -73,6 +77,14 @@ let package = Package(
                 .product(name: "CustomDump", package: "swift-custom-dump")
             ]),
         .target(
+            name: "ActomatonTesting",
+            dependencies: [
+                "ActomatonCore",
+                "ActomatonEffect",
+                .product(name: "CustomDump", package: "swift-custom-dump"),
+            ]
+        ),
+        .target(
             name: "TestFixtures",
             dependencies: [
                 "Actomaton",
@@ -92,6 +104,10 @@ let package = Package(
         .testTarget(
             name: "ActomatonUITests",
             dependencies: ["ActomatonUI", "TestFixtures"]
+        ),
+        .testTarget(
+            name: "ActomatonTestingTests",
+            dependencies: ["ActomatonTesting"]
         ),
         .testTarget(
             name: "ReadMeTests",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ inspired by [Elm](http://elm-lang.org/) and [swift-composable-architecture](http
 
 ## Overview
 
-This repository consists of 5 modules:
+This repository consists of 6 modules:
 
 1. **`Actomaton`**: Actor-based effect-handling state-machine, which is a convenience layer that wires `ActomatonCore` + `ActomatonEffect` together.
     - [Documentation](https://actomaton.github.io/Actomaton/documentation/actomaton/)
@@ -19,19 +19,22 @@ This repository consists of 5 modules:
 3. **`ActomatonDebugging`**: Helper module to print `Action` and `State` (with diffing) per `Reducer` call.
     - [Documentation](https://actomaton.github.io/Actomaton/documentation/actomatondebugging/)
 
+4. **`ActomatonTesting`**: `TestMachine` — exhaustive state-transition testing utility. Wraps `MealyMachine` + `ActionEffectManager` to assert state changes with `customDump` diffs, similar to TCA's `TestStore`.
+
 In addition, the following lower-level modules are available for advanced use cases:
 
-4. **`ActomatonCore`**: Generic Mealy machine (`MealyMachine`) and composable `MealyReducer`, independent of any effect system. Pair it with a pluggable `EffectManagerProtocol` conformer to choose what "output" means — `Void` (no effects), `Action?` (synchronous feedback), or your own custom type.
-5. **`ActomatonEffect`**: The `Effect<Action>` type and its default `EffectManager` — queue-based async task lifecycle (creation, cancellation, suspension, delay).
+5. **`ActomatonCore`**: Generic Mealy machine (`MealyMachine`) and composable `MealyReducer`, independent of any effect system. Pair it with a pluggable `EffectManagerProtocol` conformer to choose what "output" means — `Void` (no effects), `Action?` (synchronous feedback), or your own custom type.
+6. **`ActomatonEffect`**: The `Effect<Action>` type and its default `EffectManager` — queue-based async task lifecycle (creation, cancellation, suspension, delay).
 
 ### Module dependency graph
 
 ```
 ActomatonCore          -- generic MealyMachine + MealyReducer + EffectManagerProtocol
   └─ ActomatonEffect   -- Effect<Action>, EffectManager, EffectQueue, EffectID
-       └─ Actomaton    -- Actomaton typealias, Reducer typealias, CasePath integration
-            ├─ ActomatonUI         -- Store, RouteStore (SwiftUI / UIKit)
-            └─ ActomatonDebugging  -- debug / log reducers
+       ├─ Actomaton    -- Actomaton typealias, Reducer typealias, CasePath integration
+       │    ├─ ActomatonUI         -- Store, RouteStore (SwiftUI / UIKit)
+       │    └─ ActomatonDebugging  -- debug / log reducers
+       └─ ActomatonTesting         -- TestMachine (exhaustive state-transition testing)
 ```
 
 ### Why the split?

--- a/Sources/ActomatonTesting/TestMachine.swift
+++ b/Sources/ActomatonTesting/TestMachine.swift
@@ -58,7 +58,7 @@ public final class TestMachine<Action, State, Environment>
     {
         let mappedReducer: MealyReducer<Action, State, Environment, [Action]> = reducer.map(output: { effect in
             effect.kinds.compactMap { kind in
-                if case .next(let action) = kind { return action }
+                if case let .next(action) = kind { return action }
                 return nil
             }
         })

--- a/Sources/ActomatonTesting/TestMachine.swift
+++ b/Sources/ActomatonTesting/TestMachine.swift
@@ -1,0 +1,108 @@
+import ActomatonCore
+import ActomatonEffect
+import CustomDump
+import XCTest
+
+/// A testing utility that wraps `MealyMachine` + `ActionEffectManager` to provide
+/// exhaustive state-transition assertions with readable diff output.
+///
+/// ```swift
+/// let tm = TestMachine(
+///     state: MyState(),
+///     reducer: myReducer,
+///     environment: ()
+/// )
+///
+/// await tm.send(.increment) { state in
+///     state.count = 1
+/// }
+///
+/// await tm.send(.login) { state in
+///     state.isLoggedIn = true
+///     state.username = "alice"
+/// }
+/// ```
+public final class TestMachine<Action, State, Environment>
+    where Action: Sendable, State: Sendable & Equatable, Environment: Sendable
+{
+    private let machine: MealyMachine<Action, State, [Action]>
+
+    /// Creates a `TestMachine` with a reducer that already outputs `[Action]`.
+    public init(
+        state: State,
+        reducer: MealyReducer<Action, State, Environment, [Action]>,
+        environment: Environment
+    )
+    {
+        let envReducer = MealyReducer<Action, State, (), [Action]> { action, state, _ in
+            reducer.run(action, &state, environment)
+        }
+
+        self.machine = MealyMachine(
+            state: state,
+            reducer: envReducer,
+            effectManager: ActionEffectManager()
+        )
+    }
+
+    /// Creates a `TestMachine` from an `Effect`-based reducer.
+    ///
+    /// The reducer's `Effect<Action>` output is transformed via `map(output:)` to extract
+    /// synchronous `.next` actions, discarding async effects. This enables deterministic,
+    /// synchronous testing using `ActionEffectManager`.
+    public convenience init(
+        state: State,
+        reducer: MealyReducer<Action, State, Environment, Effect<Action>>,
+        environment: Environment
+    )
+    {
+        let mappedReducer: MealyReducer<Action, State, Environment, [Action]> = reducer.map(output: { effect in
+            effect.kinds.compactMap { kind in
+                if case .next(let action) = kind { return action }
+                return nil
+            }
+        })
+
+        self.init(state: state, reducer: mappedReducer, environment: environment)
+    }
+
+    /// Sends an action and asserts state changes exhaustively.
+    ///
+    /// The closure receives `expectedState` as `inout`. Mutate it to declare
+    /// what the state should look like after the action. If the mutated expected state
+    /// differs from the actual state, the test fails with a `customDump` diff.
+    ///
+    /// - Parameters:
+    ///   - action: The action to send.
+    ///   - assert: A closure that mutates the expected state. Omit if the state should not change.
+    public func send(
+        _ action: Action,
+        fileID: StaticString = #fileID,
+        file filePath: StaticString = #filePath,
+        line: UInt = #line,
+        assert: ((_ state: inout State) -> Void)? = nil
+    ) async
+    {
+        var expected = await machine.state
+        await machine.send(action)
+        let actual = await machine.state
+
+        assert?(&expected)
+
+        if expected != actual {
+            let diff = CustomDump.diff(expected, actual) ?? "(diff unavailable)"
+
+            XCTFail(
+                """
+                State mismatch after sending \(action):
+
+                  \(fileID):\(line)
+
+                \(diff)
+                """,
+                file: filePath,
+                line: line
+            )
+        }
+    }
+}

--- a/Tests/ActomatonTestingTests/TestMachineTests.swift
+++ b/Tests/ActomatonTestingTests/TestMachineTests.swift
@@ -1,0 +1,199 @@
+import ActomatonCore
+import ActomatonEffect
+import ActomatonTesting
+import XCTest
+
+final class TestMachineTests: XCTestCase
+{
+    // MARK: - Basic send + assertion
+
+    func test_singleSend() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: counterReducer,
+            environment: ()
+        )
+
+        await tm.send(.increment) { state in
+            state.count = 1
+        }
+    }
+
+    // MARK: - Chained sends with accumulating expectedState
+
+    func test_chainedSends() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: counterReducer,
+            environment: ()
+        )
+
+        await tm.send(.increment) { state in
+            state.count = 1
+        }
+
+        await tm.send(.increment) { state in
+            state.count = 2
+        }
+
+        await tm.send(.decrement) { state in
+            state.count = 1
+        }
+    }
+
+    // MARK: - No-assertion send (state unchanged)
+
+    func test_noAssertionSend_stateUnchanged() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: counterReducer,
+            environment: ()
+        )
+
+        // Reset when count is already 0 — state doesn't change, so no assertion needed.
+        await tm.send(.reset)
+    }
+
+    // MARK: - Action feedback chain
+
+    func test_actionFeedbackChain() async
+    {
+        let tm = TestMachine(
+            state: ChainState(steps: []),
+            reducer: MealyReducer<ChainAction, ChainState, Void, [ChainAction]> { action, state, _ in
+                switch action {
+                case .step1:
+                    state.steps.append("step1")
+                    return [.step2]
+                case .step2:
+                    state.steps.append("step2")
+                    return [.step3]
+                case .step3:
+                    state.steps.append("step3")
+                    return []
+                }
+            },
+            environment: ()
+        )
+
+        // Single send triggers entire chain via ActionEffectManager.
+        await tm.send(.step1) { state in
+            state.steps = ["step1", "step2", "step3"]
+        }
+    }
+
+    // MARK: - Effect-based reducer convenience init
+
+    func test_effectBasedReducer() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+                    return .nextAction(.reset)
+                case .decrement:
+                    state.count -= 1
+                    return .empty
+                case .reset:
+                    state.count = 0
+                    return .empty
+                }
+            },
+            environment: ()
+        )
+
+        // .increment triggers feedback .reset via .next extraction.
+        await tm.send(.increment) { state in
+            state.count = 0
+        }
+    }
+
+    // MARK: - Multiple field changes
+
+    func test_multipleFieldChanges() async
+    {
+        let tm = TestMachine(
+            state: UserState(name: "", loggedIn: false),
+            reducer: MealyReducer<UserAction, UserState, Void, [UserAction]> { action, state, _ in
+                switch action {
+                case let .login(name):
+                    state.name = name
+                    state.loggedIn = true
+                    return []
+                case .logout:
+                    state.name = ""
+                    state.loggedIn = false
+                    return []
+                }
+            },
+            environment: ()
+        )
+
+        await tm.send(.login(name: "alice")) { state in
+            state.name = "alice"
+            state.loggedIn = true
+        }
+
+        await tm.send(.logout) { state in
+            state.name = ""
+            state.loggedIn = false
+        }
+    }
+}
+
+// MARK: - Test Types
+
+private struct CounterState: Equatable, Sendable
+{
+    var count: Int
+}
+
+private enum CounterAction: Sendable
+{
+    case increment
+    case decrement
+    case reset
+}
+
+private let counterReducer = MealyReducer<CounterAction, CounterState, Void, [CounterAction]> { action, state, _ in
+    switch action {
+    case .increment:
+        state.count += 1
+        return []
+    case .decrement:
+        state.count -= 1
+        return []
+    case .reset:
+        state.count = 0
+        return []
+    }
+}
+
+private struct ChainState: Equatable, Sendable
+{
+    var steps: [String]
+}
+
+private enum ChainAction: Sendable
+{
+    case step1
+    case step2
+    case step3
+}
+
+private struct UserState: Equatable, Sendable
+{
+    var name: String
+    var loggedIn: Bool
+}
+
+private enum UserAction: Sendable
+{
+    case login(name: String)
+    case logout
+}


### PR DESCRIPTION
## Summary

- Add `ActomatonTesting` module with `TestMachine` — an exhaustive state-transition testing utility inspired by TCA's `TestStore`
- `TestMachine` wraps `MealyMachine` + `ActionEffectManager`, providing `send` with `inout` state assertion and `customDump` diff output
- Convenience init for `Effect`-based reducers via `map(output:)` to extract synchronous `.next` actions
- Update README with module description and dependency graph

## Reference

- [TCA TestStore](https://github.com/pointfreeco/swift-composable-architecture/blob/main/Sources/ComposableArchitecture/TestStore.swift)

## Test plan

- [x] 6 tests in `ActomatonTestingTests` — single send, chained sends, no-assertion, action feedback chain, Effect-based reducer, multiple field changes
- [x] All existing tests unaffected
