### PR TITLE
Add receive assertion and TestMachineTask to TestMachine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ let package = Package(
         ),
         .testTarget(
             name: "ActomatonTestingTests",
-            dependencies: ["ActomatonTesting"]
+            dependencies: ["ActomatonTesting", "TestFixtures"]
         ),
         .testTarget(
             name: "ReadMeTests",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository consists of 6 modules:
 3. **`ActomatonDebugging`**: Helper module to print `Action` and `State` (with diffing) per `Reducer` call.
     - [Documentation](https://actomaton.github.io/Actomaton/documentation/actomatondebugging/)
 
-4. **`ActomatonTesting`**: `TestMachine` — exhaustive state-transition testing utility. Wraps `MealyMachine` + `ActionEffectManager` to assert state changes with `customDump` diffs, similar to TCA's `TestStore`.
+4. **`ActomatonTesting`**: `TestMachine` — exhaustive state-transition testing utility. Wraps `MealyMachine` + `EffectManager` to assert TCA-like `send` / `receive` flows with `customDump` diffs.
 
 In addition, the following lower-level modules are available for advanced use cases:
 

--- a/Sources/ActomatonTesting/TestMachine.swift
+++ b/Sources/ActomatonTesting/TestMachine.swift
@@ -105,10 +105,12 @@ public actor TestMachine<Action, State, Environment>
         if !unhandledActions.isEmpty {
             var actions = ""
             customDump(unhandledActions, to: &actions)
+            let s = unhandledActions.count == 1 ? "" : "s"
 
             XCTFail(
                 """
-                Must handle \(unhandledActions.count) received action\(unhandledActions.count == 1 ? "" : "s") before sending an action.
+                Must handle \(unhandledActions.count) received \
+                action\(s) before sending an action.
 
                   \(fileID):\(line)
 
@@ -234,7 +236,8 @@ extension TestMachine
             fileID: fileID,
             filePath: filePath,
             line: line
-        ) else { return }
+        )
+        else { return }
 
         guard
             let (receivedAction, stateBefore, stateAfter) = await self.nextReceivedAction()

--- a/Sources/ActomatonTesting/TestMachine.swift
+++ b/Sources/ActomatonTesting/TestMachine.swift
@@ -3,8 +3,8 @@ import ActomatonEffect
 import CustomDump
 import XCTest
 
-/// A testing utility that wraps `MealyMachine` + `ActionEffectManager` to provide
-/// exhaustive state-transition assertions with readable diff output.
+/// A testing utility that wraps `MealyMachine` + `EffectManager` to provide
+/// TCA-like `send` / `receive` assertions with readable diff output.
 ///
 /// ```swift
 /// let tm = TestMachine(
@@ -17,76 +17,382 @@ import XCTest
 ///     state.count = 1
 /// }
 ///
-/// await tm.send(.login) { state in
-///     state.isLoggedIn = true
-///     state.username = "alice"
+/// await tm.receive(.didLoad) { state in
+///     state.isLoading = false
 /// }
 /// ```
-public final class TestMachine<Action, State, Environment>
+public actor TestMachine<Action, State, Environment>
     where Action: Sendable, State: Sendable & Equatable, Environment: Sendable
 {
-    private let machine: MealyMachine<Action, State, [Action]>
+    private typealias InternalAction = TestMachineAction<Action>
+    private typealias RuntimeState = TestMachineRuntimeState<Action, State>
 
-    /// Creates a `TestMachine` with a reducer that already outputs `[Action]`.
-    public init(
-        state: State,
-        reducer: MealyReducer<Action, State, Environment, [Action]>,
-        environment: Environment
-    )
-    {
-        let envReducer = MealyReducer<Action, State, (), [Action]> { action, state, _ in
-            reducer.run(action, &state, environment)
-        }
-
-        self.machine = MealyMachine(
-            state: state,
-            reducer: envReducer,
-            effectManager: ActionEffectManager()
-        )
-    }
+    private let machine: MealyMachine<InternalAction, RuntimeState, Effect<InternalAction>>
+    private let receivedActionSignal: AsyncStream<Void>
+    private var consumedReceivedActionCount: Int = 0
 
     /// Creates a `TestMachine` from an `Effect`-based reducer.
     ///
-    /// The reducer's `Effect<Action>` output is transformed via `map(output:)` to extract
-    /// synchronous `.next` actions, discarding async effects. This enables deterministic,
-    /// synchronous testing using `ActionEffectManager`.
-    public convenience init(
+    /// Unlike the original implementation, async effects are preserved and can be asserted with
+    /// ``receive(_:timeout:assert:fileID:file:line:)``.
+    public init(
         state: State,
         reducer: MealyReducer<Action, State, Environment, Effect<Action>>,
-        environment: Environment
+        environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
     )
     {
-        let mappedReducer: MealyReducer<Action, State, Environment, [Action]> = reducer.map(output: { effect in
-            effect.kinds.compactMap { kind in
-                if case let .next(action) = kind { return action }
-                return nil
-            }
-        })
+        let receivedActionSignal = AsyncStream.makeStream(of: Void.self)
+        self.receivedActionSignal = receivedActionSignal.stream
 
-        self.init(state: state, reducer: mappedReducer, environment: environment)
+        let reducer = MealyReducer<InternalAction, RuntimeState, (), Effect<InternalAction>> { action, state, _ in
+            let stateBeforeAction = state.current
+            let effect = reducer.run(action.action, &state.current, environment)
+            let mappedEffect = effect.map(InternalAction.receive)
+
+            switch action {
+            case .send:
+                state.latestSentState = state.current
+                return mappedEffect
+
+            case let .receive(innerAction):
+                state.receivedActions.append(
+                    (
+                        action: innerAction,
+                        stateBefore: stateBeforeAction,
+                        stateAfter: state.current
+                    )
+                )
+
+                return Effect.fireAndForget {
+                    receivedActionSignal.continuation.yield()
+                } + mappedEffect
+            }
+        }
+
+        self.machine = MealyMachine(
+            state: .init(current: state),
+            reducer: reducer,
+            effectManager: EffectManager(effectContext: effectContext)
+        )
     }
 
-    /// Sends an action and asserts state changes exhaustively.
+    /// Sends an action and asserts how state changes before any feedback action is received.
     ///
-    /// The closure receives `expectedState` as `inout`. Mutate it to declare
-    /// what the state should look like after the action. If the mutated expected state
-    /// differs from the actual state, the test fails with a `customDump` diff.
+    /// Feedback actions emitted from `.next`, `async`, or `AsyncSequence` effects must be asserted
+    /// separately via ``receive(_:timeout:assert:fileID:file:line:)``.
+    /// If previously received feedback actions remain unhandled, this method fails immediately and
+    /// does not dispatch `action`.
     ///
-    /// - Parameters:
-    ///   - action: The action to send.
-    ///   - assert: A closure that mutates the expected state. Omit if the state should not change.
+    /// Returns a ``TestMachineTask`` that can be used to await completion of the triggered effect
+    /// chain or cancel it explicitly.
+    @discardableResult
     public func send(
         _ action: Action,
+        assert: ((_ state: inout State) -> Void)? = nil,
+        timeout: Duration = .seconds(1),
         fileID: StaticString = #fileID,
         file filePath: StaticString = #filePath,
-        line: UInt = #line,
-        assert: ((_ state: inout State) -> Void)? = nil
+        line: UInt = #line
+    ) async -> TestMachineTask
+    {
+        let runtimeState = await self.machine.state
+
+        let unhandledActions = runtimeState.receivedActions
+            .dropFirst(self.consumedReceivedActionCount)
+            .map(\.action)
+
+        if !unhandledActions.isEmpty {
+            var actions = ""
+            customDump(unhandledActions, to: &actions)
+
+            XCTFail(
+                """
+                Must handle \(unhandledActions.count) received action\(unhandledActions.count == 1 ? "" : "s") before sending an action.
+
+                  \(fileID):\(line)
+
+                Unhandled actions:
+                \(actions)
+                """,
+                file: filePath,
+                line: line
+            )
+
+            return TestMachineTask(task: nil, timeout: timeout)
+        }
+
+        let expected = runtimeState.current
+
+        let task = await self.machine.send(.send(action), tracksFeedbacks: true)
+
+        guard let actual = (await self.machine.state).latestSentState else {
+            XCTFail(
+                """
+                Internal error: failed to capture state after sending \(action).
+
+                  \(fileID):\(line)
+                """,
+                file: filePath,
+                line: line
+            )
+            return .init(task: task, timeout: timeout)
+        }
+
+        self.assertStateChange(
+            label: "sent \(action)",
+            expected: expected,
+            actual: actual,
+            fileID: fileID,
+            filePath: filePath,
+            line: line,
+            assert: assert
+        )
+
+        await Self.drainImmediateFeedbacks()
+
+        return .init(task: task, timeout: timeout)
+    }
+
+    /// Asserts an action was received from an effect and verifies the resulting state change.
+    public func receive(
+        _ isMatching: @escaping (_ action: Action) -> Bool,
+        assert updateStateToExpectedResult: ((_ state: inout State) -> Void)? = nil,
+        timeout: Duration = .seconds(1),
+        fileID: StaticString = #fileID,
+        file filePath: StaticString = #filePath,
+        line: UInt = #line
     ) async
     {
-        var expected = await machine.state
-        await machine.send(action)
-        let actual = await machine.state
+        await self._receive(
+            matching: isMatching,
+            assert: updateStateToExpectedResult,
+            noQueuedMessage: "Expected to receive an action, but none was queued.",
+            unexpectedActionDescription: { receivedAction in
+                var actionDump = ""
+                customDump(receivedAction, to: &actionDump, indent: 2)
+                return actionDump
+            },
+            timeout: timeout,
+            fileID: fileID,
+            filePath: filePath,
+            line: line
+        )
+    }
+}
 
+extension TestMachine where Action: Equatable
+{
+    /// Asserts the next received action matches `expectedAction`, then verifies the resulting state
+    /// change.
+    public func receive(
+        _ expectedAction: Action,
+        assert updateStateToExpectedResult: ((_ state: inout State) -> Void)? = nil,
+        timeout: Duration = .seconds(1),
+        fileID: StaticString = #fileID,
+        file filePath: StaticString = #filePath,
+        line: UInt = #line
+    ) async
+    {
+        await self._receive(
+            matching: { $0 == expectedAction },
+            assert: updateStateToExpectedResult,
+            noQueuedMessage: "Expected to receive \(expectedAction), but no action was queued.",
+            unexpectedActionDescription: { receivedAction in
+                CustomDump.diff(expectedAction, receivedAction, format: .proportional)
+                    ?? """
+                    Expected:
+                      \(expectedAction)
+
+                    Received:
+                      \(receivedAction)
+                    """
+            },
+            timeout: timeout,
+            fileID: fileID,
+            filePath: filePath,
+            line: line
+        )
+    }
+}
+
+extension TestMachine
+{
+    private func _receive(
+        matching isMatching: @escaping (Action) -> Bool,
+        assert updateStateToExpectedResult: ((_ state: inout State) -> Void)?,
+        noQueuedMessage: @autoclosure () -> String,
+        unexpectedActionDescription: (Action) -> String,
+        timeout: Duration,
+        fileID: StaticString,
+        filePath: StaticString,
+        line: UInt
+    ) async
+    {
+        guard await self.waitForReceivedAction(
+            timeout: timeout,
+            fileID: fileID,
+            filePath: filePath,
+            line: line
+        ) else { return }
+
+        guard
+            let (receivedAction, stateBefore, stateAfter) = await self.nextReceivedAction()
+        else {
+            XCTFail(
+                """
+                \(noQueuedMessage())
+
+                  \(fileID):\(line)
+                """,
+                file: filePath,
+                line: line
+            )
+            return
+        }
+
+        let receivedActionLater = await self.hasLaterReceivedAction(matching: isMatching)
+
+        if !isMatching(receivedAction) {
+            XCTFail(
+                """
+                Received unexpected action\(receivedActionLater ? " before this one" : ""):
+
+                  \(fileID):\(line)
+
+                \(unexpectedActionDescription(receivedAction))
+                """,
+                file: filePath,
+                line: line
+            )
+        }
+        else {
+            self.assertStateChange(
+                label: "received \(receivedAction)",
+                expected: stateBefore,
+                actual: stateAfter,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                assert: updateStateToExpectedResult
+            )
+        }
+
+        await Self.drainImmediateFeedbacks()
+    }
+
+    private func waitForReceivedAction(
+        timeout: Duration,
+        fileID: StaticString,
+        filePath: StaticString,
+        line: UInt
+    ) async -> Bool
+    {
+        await Self.drainImmediateFeedbacks()
+
+        if await self.unconsumedReceivedActionsCount > 0 {
+            return true
+        }
+
+        let didReceive = await self.waitForReceivedActionSignal(timeout: timeout)
+
+        if !didReceive, await self.unconsumedReceivedActionsCount == 0 {
+            XCTFail(
+                """
+                Expected to receive an action, but received none\(timeout > .zero ? " after \(timeout)" : "").
+
+                  \(fileID):\(line)
+                """,
+                file: filePath,
+                line: line
+            )
+            return false
+        }
+
+        return true
+    }
+
+    private func waitForReceivedActionSignal(
+        timeout: Duration
+    ) async -> Bool
+    {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask { [self] in
+                while !Task.isCancelled {
+                    guard await self.awaitReceivedActionSignal() else { return false }
+
+                    if await self.unconsumedReceivedActionsCount > 0 {
+                        return true
+                    }
+                }
+
+                return false
+            }
+
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func awaitReceivedActionSignal() async -> Bool
+    {
+        var iterator = self.receivedActionSignal.makeAsyncIterator()
+        let next: Void? = await iterator.next()
+        return next != nil
+    }
+
+    private var unconsumedReceivedActionsCount: Int
+    {
+        get async {
+            let runtimeState = await self.machine.state
+            return runtimeState.receivedActions.count - self.consumedReceivedActionCount
+        }
+    }
+
+    private func nextReceivedAction() async
+        -> (action: Action, stateBefore: State, stateAfter: State)?
+    {
+        let runtimeState = await self.machine.state
+
+        guard runtimeState.receivedActions.indices.contains(self.consumedReceivedActionCount) else { return nil }
+
+        let receivedAction = runtimeState.receivedActions[self.consumedReceivedActionCount]
+        self.consumedReceivedActionCount += 1
+        return (
+            action: receivedAction.action,
+            stateBefore: receivedAction.stateBefore,
+            stateAfter: receivedAction.stateAfter
+        )
+    }
+
+    private func hasLaterReceivedAction(
+        matching predicate: (Action) -> Bool
+    ) async -> Bool
+    {
+        let runtimeState = await self.machine.state
+
+        return runtimeState.receivedActions
+            .dropFirst(self.consumedReceivedActionCount)
+            .contains(where: { predicate($0.action) })
+    }
+
+    private func assertStateChange(
+        label: String,
+        expected: State,
+        actual: State,
+        fileID: StaticString,
+        filePath: StaticString,
+        line: UInt,
+        assert: ((_ state: inout State) -> Void)?
+    )
+    {
+        var expected = expected
         assert?(&expected)
 
         if expected != actual {
@@ -94,7 +400,7 @@ public final class TestMachine<Action, State, Environment>
 
             XCTFail(
                 """
-                State mismatch after sending \(action):
+                State mismatch after \(label):
 
                   \(fileID):\(line)
 
@@ -104,5 +410,51 @@ public final class TestMachine<Action, State, Environment>
                 line: line
             )
         }
+    }
+
+    /// Gives the concurrency runtime a few turns to surface already-triggered feedback actions.
+    ///
+    /// This is intentionally a small race-avoidance shim for tests, not a way to wait for full
+    /// effect completion. Time-based effects should still be driven explicitly by a test clock or
+    /// by awaiting the task returned from `send`.
+    private static func drainImmediateFeedbacks(count: Int = 20) async
+    {
+        for _ in 0 ..< count {
+            await Task.yield()
+        }
+    }
+}
+
+private enum TestMachineAction<Action>: Sendable
+    where Action: Sendable
+{
+    case send(Action)
+    case receive(Action)
+
+    var action: Action
+    {
+        switch self {
+        case let .send(action), let .receive(action):
+            return action
+        }
+    }
+}
+
+private struct TestMachineRuntimeState<Action, State>: Sendable
+    where Action: Sendable, State: Sendable
+{
+    var current: State
+    var latestSentState: State?
+    var receivedActions: [(action: Action, stateBefore: State, stateAfter: State)] = []
+
+    init(
+        current: State,
+        latestSentState: State? = nil,
+        receivedActions: [(action: Action, stateBefore: State, stateAfter: State)] = []
+    )
+    {
+        self.current = current
+        self.latestSentState = latestSentState
+        self.receivedActions = receivedActions
     }
 }

--- a/Sources/ActomatonTesting/TestMachineTask.swift
+++ b/Sources/ActomatonTesting/TestMachineTask.swift
@@ -25,6 +25,11 @@ public struct TestMachineTask: Sendable
 
     /// Waits for the underlying task to finish, throwing ``TimeoutError`` if it does not finish in
     /// time.
+    ///
+    /// - Important:
+    /// This method only waits for task completion and enforces its timeout using wall-clock time.
+    /// It does not advance an injected test clock. If the effect is sleeping on a ``TestClock`` or
+    /// another manually-driven clock, advance that clock separately before awaiting `finish()`.
     public func finish(timeout: Duration? = nil) async throws
     {
         let duration = timeout ?? self.timeout

--- a/Sources/ActomatonTesting/TestMachineTask.swift
+++ b/Sources/ActomatonTesting/TestMachineTask.swift
@@ -1,0 +1,151 @@
+/// A test task returned from ``TestMachine/send(_:assert:fileID:file:line:)``.
+///
+/// Use this value to wait for all effects triggered by the sent action to finish, or to cancel
+/// them explicitly.
+public struct TestMachineTask: Sendable
+{
+    private let task: Task<(), any Error>?
+    private let timeout: Duration
+
+    init(
+        task: Task<(), any Error>?,
+        timeout: Duration
+    )
+    {
+        self.task = task
+        self.timeout = timeout
+    }
+
+    /// Cancels the underlying task and waits for it to settle.
+    public func cancel() async
+    {
+        self.task?.cancel()
+        _ = await self.task?.result
+    }
+
+    /// Waits for the underlying task to finish, throwing ``TimeoutError`` if it does not finish in
+    /// time.
+    public func finish(timeout: Duration? = nil) async throws
+    {
+        let duration = timeout ?? self.timeout
+
+        guard let rawValue = self.task else { return }
+
+        let completion = _TaskCompletion()
+
+        Task.detached {
+            let result = await rawValue.result
+
+            switch result {
+            case .success:
+                await completion.succeed()
+            case let .failure(error):
+                await completion.fail(error)
+            }
+        }
+
+        try await _withTimeout(duration) {
+            try await completion.wait()
+        }
+    }
+
+    /// Whether the underlying task has been cancelled.
+    public var isCancelled: Bool
+    {
+        self.task?.isCancelled ?? true
+    }
+}
+
+// MARK: - Private
+
+private func _withTimeout<T: Sendable>(
+    _ duration: Duration,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T
+{
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask(operation: operation)
+
+        group.addTask {
+            try await Task.sleep(for: duration)
+            throw TestTimeoutError(duration: duration)
+        }
+
+        do {
+            guard let result = try await group.next() else {
+                throw TestTimeoutError(duration: duration)
+            }
+
+            group.cancelAll()
+            return result
+        }
+        catch {
+            group.cancelAll()
+            throw error
+        }
+    }
+}
+
+private actor _TaskCompletion
+{
+    private var result: Result<Void, any Error>?
+    private var continuation: CheckedContinuation<Void, any Error>?
+
+    func wait() async throws
+    {
+        if let result = self.result {
+            return try result.get()
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if let result = self.result {
+                    continuation.resume(with: result)
+                    return
+                }
+
+                precondition(self.continuation == nil, "Concurrent waits are not supported.")
+                self.continuation = continuation
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWait()
+            }
+        }
+    }
+
+    func succeed()
+    {
+        self.resolve(.success(()))
+    }
+
+    func fail(_ error: any Error)
+    {
+        self.resolve(.failure(error))
+    }
+
+    private func resolve(
+        _ result: Result<Void, any Error>
+    )
+    {
+        guard self.result == nil else { return }
+
+        self.result = result
+
+        switch result {
+        case .success:
+            self.continuation?.resume()
+
+        case let .failure(error):
+            self.continuation?.resume(throwing: error)
+        }
+
+        self.continuation = nil
+    }
+
+    private func cancelWait()
+    {
+        self.continuation?.resume(throwing: CancellationError())
+        self.continuation = nil
+    }
+}

--- a/Sources/ActomatonTesting/TestTimeoutError.swift
+++ b/Sources/ActomatonTesting/TestTimeoutError.swift
@@ -1,0 +1,10 @@
+/// Error thrown when an async operation does not finish before the timeout expires.
+public struct TestTimeoutError: Error
+{
+    public let duration: Duration
+
+    public init(duration: Duration)
+    {
+        self.duration = duration
+    }
+}

--- a/Tests/ActomatonTestingTests/TestMachineTests.swift
+++ b/Tests/ActomatonTestingTests/TestMachineTests.swift
@@ -33,7 +33,10 @@ final class TestMachineTests: MainTestCase
             state.count = 1
         }
 
+        // `finish()` waits for task completion, but does not drive `effectContext.clock`.
+        // When `TEST_CLOCK=1`, advance the injected `TestClock` so the effect can complete.
         await clock.advance(by: .ticks(1))
+
         try await task.finish()
     }
 

--- a/Tests/ActomatonTestingTests/TestMachineTests.swift
+++ b/Tests/ActomatonTestingTests/TestMachineTests.swift
@@ -70,8 +70,7 @@ final class TestMachineTests: MainTestCase
             try await task.finish(timeout: .milliseconds(50))
             XCTFail("Expected timeout.")
         }
-        catch is TestTimeoutError {
-        }
+        catch is TestTimeoutError {}
         catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -324,7 +323,9 @@ private enum CounterAction: Equatable, Sendable
     case reset
 }
 
-private let counterReducer = MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+private let counterReducer = MealyReducer<
+    CounterAction, CounterState, Void, Effect<CounterAction>
+> { action, state, _ in
     switch action {
     case .increment:
         state.count += 1

--- a/Tests/ActomatonTestingTests/TestMachineTests.swift
+++ b/Tests/ActomatonTestingTests/TestMachineTests.swift
@@ -1,10 +1,85 @@
 import ActomatonCore
 import ActomatonEffect
 import ActomatonTesting
+import TestFixtures
 import XCTest
 
-final class TestMachineTests: XCTestCase
+final class TestMachineTests: MainTestCase
 {
+    func test_sendTask_finish_success() async throws
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count = 1
+                    return Effect.fireAndForget { context in
+                        try await context.clock.sleep(for: .ticks(1))
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return .empty
+                case .reset:
+                    state.count = 0
+                    return .empty
+                }
+            },
+            environment: (),
+            effectContext: effectContext
+        )
+
+        let task = await tm.send(.increment) { state in
+            state.count = 1
+        }
+
+        try await task.finish()
+    }
+
+    func test_sendTask_finish_timeout() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count = 1
+                    return Effect.fireAndForget { context in
+                        try await context.clock.sleep(for: .ticks(20))
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return .empty
+                case .reset:
+                    state.count = 0
+                    return .empty
+                }
+            },
+            environment: (),
+            effectContext: effectContext
+        )
+
+        let task = await tm.send(.increment) { state in
+            state.count = 1
+        }
+
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        do {
+            try await task.finish(timeout: .milliseconds(50))
+            XCTFail("Expected timeout.")
+        }
+        catch is TestTimeoutError {
+        }
+        catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let elapsed = start.duration(to: clock.now)
+        XCTAssertLessThan(elapsed, .seconds(0.5))
+    }
+
     // MARK: - Basic send + assertion
 
     func test_singleSend() async
@@ -43,6 +118,45 @@ final class TestMachineTests: XCTestCase
         }
     }
 
+    func test_sendFailsFastWhenReceivedActionIsUnhandled() async throws
+    {
+        let recorder = ResultsCollector<CounterAction>()
+
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, ResultsCollector<CounterAction>, Effect<CounterAction>> {
+                action, state, recorder in
+                let recordEffect = Effect<CounterAction>.fireAndForget {
+                    await recorder.append(action)
+                }
+
+                switch action {
+                case .increment:
+                    state.count += 1
+                    return recordEffect + .nextAction(.reset)
+                case .decrement:
+                    state.count -= 1
+                    return recordEffect
+                case .reset:
+                    state.count = 0
+                    return recordEffect
+                }
+            },
+            environment: recorder
+        )
+
+        let task = await tm.send(.increment) { state in
+            state.count = 1
+        }
+        try await task.finish()
+
+        XCTExpectFailure("`send` should fail before dispatching a new action when feedback remains unhandled.")
+        _ = await tm.send(.decrement)
+
+        let recordedActions = await recorder.results
+        XCTAssertEqual(recordedActions, [.increment, .reset])
+    }
+
     // MARK: - No-assertion send (state unchanged)
 
     func test_noAssertionSend_stateUnchanged() async
@@ -63,31 +177,57 @@ final class TestMachineTests: XCTestCase
     {
         let tm = TestMachine(
             state: ChainState(steps: []),
-            reducer: MealyReducer<ChainAction, ChainState, Void, [ChainAction]> { action, state, _ in
-                switch action {
-                case .step1:
-                    state.steps.append("step1")
-                    return [.step2]
-                case .step2:
-                    state.steps.append("step2")
-                    return [.step3]
-                case .step3:
-                    state.steps.append("step3")
-                    return []
-                }
-            },
+            reducer: chainReducer,
             environment: ()
         )
 
-        // Single send triggers entire chain via ActionEffectManager.
         await tm.send(.step1) { state in
+            state.steps = ["step1"]
+        }
+
+        await tm.receive(.step2) { state in
+            state.steps = ["step1", "step2"]
+        }
+
+        await tm.receive(.step3) { state in
             state.steps = ["step1", "step2", "step3"]
         }
     }
 
     // MARK: - Effect-based reducer convenience init
 
-    func test_effectBasedReducer() async
+    func test_effectBasedReducer_asyncNextAction() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+                    return Effect {
+                        .reset
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return .empty
+                case .reset:
+                    state.count = 0
+                    return .empty
+                }
+            },
+            environment: ()
+        )
+
+        await tm.send(.increment) { state in
+            state.count = 1
+        }
+
+        await tm.receive(.reset) { state in
+            state.count = 0
+        }
+    }
+
+    func test_effectBasedReducer_syncNextAction() async
     {
         let tm = TestMachine(
             state: CounterState(count: 0),
@@ -107,8 +247,43 @@ final class TestMachineTests: XCTestCase
             environment: ()
         )
 
-        // .increment triggers feedback .reset via .next extraction.
         await tm.send(.increment) { state in
+            state.count = 1
+        }
+
+        await tm.receive(.reset) { state in
+            state.count = 0
+        }
+    }
+
+    func test_asyncEffectReceive() async
+    {
+        let tm = TestMachine(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count = 1
+                    return Effect {
+                        await Task.yield()
+                        return .reset
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return .empty
+                case .reset:
+                    state.count = 0
+                    return .empty
+                }
+            },
+            environment: ()
+        )
+
+        await tm.send(.increment) { state in
+            state.count = 1
+        }
+
+        await tm.receive(.reset) { state in
             state.count = 0
         }
     }
@@ -119,18 +294,7 @@ final class TestMachineTests: XCTestCase
     {
         let tm = TestMachine(
             state: UserState(name: "", loggedIn: false),
-            reducer: MealyReducer<UserAction, UserState, Void, [UserAction]> { action, state, _ in
-                switch action {
-                case let .login(name):
-                    state.name = name
-                    state.loggedIn = true
-                    return []
-                case .logout:
-                    state.name = ""
-                    state.loggedIn = false
-                    return []
-                }
-            },
+            reducer: userReducer,
             environment: ()
         )
 
@@ -153,24 +317,24 @@ private struct CounterState: Equatable, Sendable
     var count: Int
 }
 
-private enum CounterAction: Sendable
+private enum CounterAction: Equatable, Sendable
 {
     case increment
     case decrement
     case reset
 }
 
-private let counterReducer = MealyReducer<CounterAction, CounterState, Void, [CounterAction]> { action, state, _ in
+private let counterReducer = MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
     switch action {
     case .increment:
         state.count += 1
-        return []
+        return .empty
     case .decrement:
         state.count -= 1
-        return []
+        return .empty
     case .reset:
         state.count = 0
-        return []
+        return .empty
     }
 }
 
@@ -186,6 +350,20 @@ private enum ChainAction: Sendable
     case step3
 }
 
+private let chainReducer = MealyReducer<ChainAction, ChainState, Void, Effect<ChainAction>> { action, state, _ in
+    switch action {
+    case .step1:
+        state.steps.append("step1")
+        return .nextAction(.step2)
+    case .step2:
+        state.steps.append("step2")
+        return .nextAction(.step3)
+    case .step3:
+        state.steps.append("step3")
+        return .empty
+    }
+}
+
 private struct UserState: Equatable, Sendable
 {
     var name: String
@@ -196,4 +374,17 @@ private enum UserAction: Sendable
 {
     case login(name: String)
     case logout
+}
+
+private let userReducer = MealyReducer<UserAction, UserState, Void, Effect<UserAction>> { action, state, _ in
+    switch action {
+    case let .login(name):
+        state.name = name
+        state.loggedIn = true
+        return .empty
+    case .logout:
+        state.name = ""
+        state.loggedIn = false
+        return .empty
+    }
 }

--- a/Tests/ActomatonTestingTests/TestMachineTests.swift
+++ b/Tests/ActomatonTestingTests/TestMachineTests.swift
@@ -33,6 +33,7 @@ final class TestMachineTests: MainTestCase
             state.count = 1
         }
 
+        await clock.advance(by: .ticks(1))
         try await task.finish()
     }
 
@@ -119,6 +120,9 @@ final class TestMachineTests: MainTestCase
 
     func test_sendFailsFastWhenReceivedActionIsUnhandled() async throws
     {
+#if os(Linux)
+        throw XCTSkip("`XCTExpectFailure` is unavailable on Linux.")
+#else
         let recorder = ResultsCollector<CounterAction>()
 
         let tm = TestMachine(
@@ -154,6 +158,7 @@ final class TestMachineTests: MainTestCase
 
         let recordedActions = await recorder.results
         XCTAssertEqual(recordedActions, [.increment, .reset])
+#endif
     }
 
     // MARK: - No-assertion send (state unchanged)

--- a/Tests/TestFixtures/TestDuration.swift
+++ b/Tests/TestFixtures/TestDuration.swift
@@ -5,17 +5,17 @@ import Foundation
 /// One tick is currently 50 ms.
 public struct TestDuration: Sendable, Hashable
 {
-    public let ticks: TimeInterval
+    public let ticks: Ticks
 
     private init(
-        ticks: TimeInterval
+        ticks: Ticks
     )
     {
         self.ticks = ticks
     }
 
     public static func ticks(
-        _ ticks: TimeInterval
+        _ ticks: Ticks
     ) -> Self
     {
         Self(ticks: ticks)
@@ -30,6 +30,8 @@ public struct TestDuration: Sendable, Hashable
     {
         .nanoseconds(Int64((Double(oneTickNanoseconds) * self.ticks).rounded()))
     }
+
+    public typealias Ticks = Double
 }
 
 public func + (


### PR DESCRIPTION
Continued from:
- https://github.com/Actomaton/Actomaton/pull/117

## Summary
- Add `receive(_:timeout:assert:)` to `TestMachine` for asserting actions produced by effects (TCA-like exhaustive testing)
- Add `TestMachineTask` for managing effect lifecycle (`cancel()` / `finish(timeout:)`)
- Add `TestTimeoutError` for timeout handling
- Expand test coverage with new test cases for receive assertions

## Changes
- `Sources/ActomatonTesting/TestMachine.swift` — Extended with receive assertion support and internal action tracking
- `Sources/ActomatonTesting/TestMachineTask.swift` — New type for effect task management
- `Sources/ActomatonTesting/TestTimeoutError.swift` — New timeout error type
- `Tests/ActomatonTestingTests/TestMachineTests.swift` — Added tests for receive assertions
