### PR TITLE
Remove AnyEffectQueue in favor of typed existential

### DIFF
--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -59,7 +59,7 @@ extension Effect
         run: @escaping @Sendable (EffectContext) async throws -> Action?
     ) where Queue: EffectQueueProtocol
     {
-        self.init(kinds: [.single(Single(id: nil, queue: queue.map(AnyEffectQueue.init), run: run))])
+        self.init(kinds: [.single(Single(id: nil, queue: queue, run: run))])
     }
 
     /// Single-`async` side-effect without `EffectContext`.
@@ -81,7 +81,7 @@ extension Effect
         run: @escaping @Sendable (EffectContext) async throws -> Action?
     ) where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
-        self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: queue.map(AnyEffectQueue.init), run: run))])
+        self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: queue, run: run))])
     }
 
     /// Single-`async` side-effect without `EffectContext`.
@@ -161,7 +161,7 @@ extension Effect
             kinds: [.sequence(
                 _Sequence(
                     id: nil,
-                    queue: queue.map(AnyEffectQueue.init),
+                    queue: queue,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
             )]
@@ -191,7 +191,7 @@ extension Effect
             kinds: [.sequence(
                 _Sequence(
                     id: id.map(EffectID.init),
-                    queue: queue.map(AnyEffectQueue.init),
+                    queue: queue,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
             )]
@@ -420,10 +420,10 @@ extension Effect
         .init(kinds: self.kinds.map { kind in
             switch kind {
             case let .single(single):
-                return .single(single.map(queue: { f($0?.queue) }))
+                return .single(single.map(queue: { f($0.map(EffectQueue.init)) }))
 
             case let .sequence(sequence):
-                return .sequence(sequence.map(queue: { f($0?.queue) }))
+                return .sequence(sequence.map(queue: { f($0.map(EffectQueue.init)) }))
 
             case .next:
                 return kind
@@ -503,7 +503,7 @@ extension Effect
             }
         }
 
-        internal var queue: AnyEffectQueue?
+        internal var queue: (any EffectQueueProtocol)?
         {
             switch self {
             case let .single(single):
@@ -522,12 +522,12 @@ extension Effect
     package struct Single: Sendable
     {
         internal let id: EffectID?
-        internal let queue: AnyEffectQueue?
+        internal let queue: (any EffectQueueProtocol)?
         internal let run: @Sendable (EffectContext) async throws -> Action?
 
         internal init(
             id: EffectID? = nil,
-            queue: AnyEffectQueue? = nil,
+            queue: (any EffectQueueProtocol)? = nil,
             run: @escaping @Sendable (EffectContext) async throws -> Action?
         )
         {
@@ -549,10 +549,11 @@ extension Effect
             .init(id: f(id).map(EffectID.init), queue: queue, run: run)
         }
 
-        internal func map<Queue>(queue f: @escaping (AnyEffectQueue?) -> Queue?) -> Effect.Single
-            where Queue: EffectQueueProtocol
+        internal func map(
+            queue f: @escaping ((any EffectQueueProtocol)?) -> (any EffectQueueProtocol)?
+        ) -> Effect.Single
         {
-            .init(id: id, queue: f(queue).map(AnyEffectQueue.init), run: run)
+            .init(id: id, queue: f(queue), run: run)
         }
     }
 
@@ -560,13 +561,13 @@ extension Effect
     package struct _Sequence: Sendable
     {
         internal let id: EffectID?
-        internal let queue: AnyEffectQueue?
+        internal let queue: (any EffectQueueProtocol)?
         internal let sequence: @Sendable (EffectContext) async throws
             -> (any AsyncSequence<Action, any Error> & Sendable)?
 
         internal init(
             id: EffectID? = nil,
-            queue: AnyEffectQueue? = nil,
+            queue: (any EffectQueueProtocol)? = nil,
             sequence: @escaping @Sendable (EffectContext) async throws
                 -> (any AsyncSequence<Action, any Error> & Sendable)?
         )
@@ -598,10 +599,11 @@ extension Effect
             .init(id: f(id).map(EffectID.init), queue: queue, sequence: sequence)
         }
 
-        internal func map<Queue>(queue f: @escaping (AnyEffectQueue?) -> Queue?) -> Effect._Sequence
-            where Queue: EffectQueueProtocol
+        internal func map(
+            queue f: @escaping ((any EffectQueueProtocol)?) -> (any EffectQueueProtocol)?
+        ) -> Effect._Sequence
         {
-            .init(id: id, queue: f(queue).map(AnyEffectQueue.init), sequence: sequence)
+            .init(id: id, queue: f(queue), sequence: sequence)
         }
     }
 }

--- a/Sources/ActomatonEffect/EffectQueue.swift
+++ b/Sources/ActomatonEffect/EffectQueue.swift
@@ -9,6 +9,11 @@ public struct EffectQueue: Hashable, Sendable
         self.value = value
     }
 
+    internal init(_ value: any EffectQueueProtocol)
+    {
+        self.value = value
+    }
+
     public static func == (lhs: Self, rhs: Self) -> Bool
     {
         AnyHashable(lhs.value) == AnyHashable(rhs.value)
@@ -75,22 +80,5 @@ extension Oldest1SuspendNewEffectQueueProtocol
     public var effectQueuePolicy: EffectQueuePolicy
     {
         .runOldest(maxCount: 1, .suspendNew)
-    }
-}
-
-// MARK: - Internals
-
-public struct AnyEffectQueue: EffectQueueProtocol, Sendable
-{
-    public let queue: EffectQueue
-    public let effectQueuePolicy: EffectQueuePolicy
-    public let effectQueueDelay: EffectQueueDelay
-
-    public init<Queue>(_ queue: Queue)
-        where Queue: EffectQueueProtocol
-    {
-        self.queue = EffectQueue(queue)
-        self.effectQueuePolicy = queue.effectQueuePolicy
-        self.effectQueueDelay = queue.effectQueueDelay
     }
 }

--- a/Sources/ActomatonEffect/Internal/EffectManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectManager.swift
@@ -121,7 +121,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     private func handleTaskCompleted(
         id: EffectID,
         task: Task<(), any Error>,
-        queue: AnyEffectQueue?,
+        queue: (any EffectQueueProtocol)?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     )
@@ -130,9 +130,11 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         runningTasks[id]?.remove(task)
 
         if let queue {
-            if let removingIndex = queuedRunningTasks[queue.queue]?.firstIndex(where: { $0 == task }) {
+            let effectQueue = EffectQueue(queue)
+
+            if let removingIndex = queuedRunningTasks[effectQueue]?.firstIndex(where: { $0 == task }) {
                 Debug.print("[handleTaskCompleted] Remove completed queue-task: \(queue) \(removingIndex)")
-                queuedRunningTasks[queue.queue]?.remove(at: removingIndex)
+                queuedRunningTasks[effectQueue]?.remove(at: removingIndex)
 
                 // Try to dequeue pending effects.
                 switch queue.effectQueuePolicy {
@@ -210,13 +212,15 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     {
         guard let queue = effectKind.queue else { return true }
 
+        let effectQueue = EffectQueue(queue)
+
         switch queue.effectQueuePolicy {
         case let .runNewest(maxCount):
             // NOTE: +1 to make a space for new effect.
-            let droppingCount = (queuedRunningTasks[queue.queue]?.count ?? 0) - maxCount + 1
+            let droppingCount = (queuedRunningTasks[effectQueue]?.count ?? 0) - maxCount + 1
             if droppingCount > 0 {
                 for _ in 0 ..< droppingCount {
-                    let droppingTask = queuedRunningTasks[queue.queue]?.removeFirst()
+                    let droppingTask = queuedRunningTasks[effectQueue]?.removeFirst()
 
                     if let droppingTask {
 #if DEBUG
@@ -234,13 +238,13 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
             return true
 
         case let .runOldest(maxCount, overflowPolicy):
-            let currentCount = queuedRunningTasks[queue.queue]?.count ?? 0
+            let currentCount = queuedRunningTasks[effectQueue]?.count ?? 0
             if currentCount >= maxCount {
                 switch overflowPolicy {
                 case .suspendNew:
                     // Enqueue to pending buffer.
                     Debug.print("[checkQueuePolicy] [runOldest-suspendNew] Enqueue to pending buffer")
-                    pendingEffectKinds[queue.queue, default: []].append(effectKind)
+                    pendingEffectKinds[effectQueue, default: []].append(effectKind)
                     return false
 
                 case .discardNew:
@@ -331,7 +335,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     private func enqueueTask(
         _ task: Task<(), any Error>,
         id: EffectID?,
-        queue: AnyEffectQueue?,
+        queue: (any EffectQueueProtocol)?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     )
@@ -344,7 +348,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
 
         if let queue {
             Debug.print("[enqueueTask] Append queue-task: \(queue)")
-            self.queuedRunningTasks[queue.queue, default: []].append(task)
+            self.queuedRunningTasks[EffectQueue(queue), default: []].append(task)
         }
 
         // Clean up after `task` is completed.
@@ -398,26 +402,27 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Calculates absolute effect start time for queue-based delay scheduling.
     ///
     /// Returns `nil` when the effect should run immediately without additional sleeping.
-    private func calculateEffectTime(queue: AnyEffectQueue?) -> AnyClock<Duration>.Instant?
+    private func calculateEffectTime(queue: (any EffectQueueProtocol)?) -> AnyClock<Duration>.Instant?
     {
         guard let queue else { return nil }
 
+        let effectQueue = EffectQueue(queue)
         let now = self.effectContext.clock.now
 
-        guard let latestTime = self.latestEffectTime[queue.queue] else {
-            self.latestEffectTime[queue.queue] = now
+        guard let latestTime = self.latestEffectTime[effectQueue] else {
+            self.latestEffectTime[effectQueue] = now
             return nil
         }
 
         let targetDelay = now.duration(to: latestTime) + queue.effectQueueDelay.duration
 
         if targetDelay <= .zero {
-            self.latestEffectTime[queue.queue] = now
+            self.latestEffectTime[effectQueue] = now
             return nil
         }
 
         let nextTime = now.advanced(by: targetDelay)
-        self.latestEffectTime[queue.queue] = nextTime
+        self.latestEffectTime[effectQueue] = nextTime
 
         Debug.print("[calculateEffectDelay] scheduled via effectContext.clock")
         return nextTime
@@ -426,15 +431,19 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Dequeues a pending effect if possible (for `runOldest-suspendNew` policy).
     @discardableResult
     private func dequeuePendingIfPossible(
-        queue: AnyEffectQueue,
+        queue: any EffectQueueProtocol,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?
     {
-        guard pendingEffectKinds[queue.queue]?.isEmpty == false else { return nil }
-        let kind = pendingEffectKinds[queue.queue]!.removeFirst()
+        let effectQueue = EffectQueue(queue)
+
+        guard pendingEffectKinds[effectQueue]?.isEmpty == false else { return nil }
+
+        let kind = pendingEffectKinds[effectQueue]!.removeFirst()
         let time = calculateEffectTime(queue: queue)
         Debug.print("[dequeuePendingIfPossible] Dequeued pending effect")
+
         return makeTask(
             effectKind: kind,
             time: time,


### PR DESCRIPTION
## Summary

- Replace custom `AnyEffectQueue` type-erasure wrapper with Swift's typed existential `any EffectQueueProtocol`
- Add convenience `EffectQueue.init(_ value: any EffectQueueProtocol)` initializer for wrapping existentials at dictionary-key boundaries
- Delete `AnyEffectQueue` struct (net code reduction)

## Motivation

Continuation of #120. Swift's typed existentials make hand-rolled type-erasure wrappers unnecessary. `AnyEffectQueue` was the last remaining wrapper — this completes the migration.
