### PR TITLE
Use typed existentials in Effect map functions

### DIFF
--- a/Sources/Actomaton/Reducer+Effect.swift
+++ b/Sources/Actomaton/Reducer+Effect.swift
@@ -67,7 +67,7 @@ extension MealyReducer where Output == Effect<Action>
     // MARK: - Functor
 
     /// Changes `EffectID`.
-    public func map<ID>(id f: @escaping @Sendable (EffectID?) -> ID?) -> Self
+    public func map<ID>(id f: @escaping @Sendable ((any EffectIDProtocol)?) -> ID?) -> Self
         where ID: EffectIDProtocol
     {
         .init { action, state, environment in
@@ -78,7 +78,7 @@ extension MealyReducer where Output == Effect<Action>
     }
 
     /// Changes `EffectQueue`.
-    public func map<Queue>(queue f: @escaping @Sendable (EffectQueue?) -> Queue?) -> Self
+    public func map<Queue>(queue f: @escaping @Sendable ((any EffectQueueProtocol)?) -> Queue?) -> Self
         where Queue: EffectQueueProtocol
     {
         .init { action, state, environment in

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -393,7 +393,7 @@ extension Effect
     }
 
     /// Changes `EffectID`.
-    public func map<ID>(id f: @escaping (EffectID?) -> ID?) -> Effect
+    public func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect
         where ID: EffectIDProtocol
     {
         .init(kinds: self.kinds.map { kind in
@@ -414,16 +414,16 @@ extension Effect
     }
 
     /// Changes `EffectQueue`.
-    public func map<Queue>(queue f: @escaping (EffectQueue?) -> Queue?) -> Effect
+    public func map<Queue>(queue f: @escaping ((any EffectQueueProtocol)?) -> Queue?) -> Effect
         where Queue: EffectQueueProtocol
     {
         .init(kinds: self.kinds.map { kind in
             switch kind {
             case let .single(single):
-                return .single(single.map(queue: { f($0.map(EffectQueue.init)) }))
+                return .single(single.map(queue: { f($0) }))
 
             case let .sequence(sequence):
-                return .sequence(sequence.map(queue: { f($0.map(EffectQueue.init)) }))
+                return .sequence(sequence.map(queue: { f($0) }))
 
             case .next:
                 return kind
@@ -543,10 +543,10 @@ extension Effect
             }
         }
 
-        internal func map<ID>(id f: @escaping (EffectID?) -> ID?) -> Effect.Single
+        internal func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect.Single
             where ID: EffectIDProtocol
         {
-            .init(id: f(id).map(EffectID.init), queue: queue, run: run)
+            .init(id: f(id?.value).map(EffectID.init), queue: queue, run: run)
         }
 
         internal func map(
@@ -593,10 +593,10 @@ extension Effect
             })
         }
 
-        internal func map<ID>(id f: @escaping (EffectID?) -> ID?) -> Effect._Sequence
+        internal func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect._Sequence
             where ID: EffectIDProtocol
         {
-            .init(id: f(id).map(EffectID.init), queue: queue, sequence: sequence)
+            .init(id: f(id?.value).map(EffectID.init), queue: queue, sequence: sequence)
         }
 
         internal func map(


### PR DESCRIPTION
## Summary

- Change `map(id:)` closure argument from `EffectID?` to `(any EffectIDProtocol)?`
- Change `map(queue:)` closure argument from `EffectQueue?` to `(any EffectQueueProtocol)?`
- Simplify queue map internals by removing wrapper conversion dance (`$0.map(EffectQueue.init)` → direct passthrough)

## Motivation

Continuation of #120 and #121. The public `map(id:)` and `map(queue:)` functor APIs still exposed the `EffectID`/`EffectQueue` wrapper structs in their closure signatures, forcing callers to work with wrappers instead of the underlying existentials. This aligns the public API with the typed existential migration.
