### PR TITLE
Internalize EffectID and EffectQueue as _EffectID and _EffectQueue

### DIFF
--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -39,7 +39,7 @@ extension Effect
     )
         where ID: EffectIDProtocol
     {
-        self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: nil, run: run))])
+        self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: nil, run: run))])
     }
 
     /// Single-`async` side-effect without `EffectContext`.
@@ -81,7 +81,7 @@ extension Effect
         run: @escaping @Sendable (EffectContext) async throws -> Action?
     ) where ID: EffectIDProtocol, Queue: EffectQueueProtocol
     {
-        self.init(kinds: [.single(Single(id: id.map(EffectID.init), queue: queue, run: run))])
+        self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: queue, run: run))])
     }
 
     /// Single-`async` side-effect without `EffectContext`.
@@ -132,7 +132,7 @@ extension Effect
         self.init(
             kinds: [.sequence(
                 _Sequence(
-                    id: id.map(EffectID.init),
+                    id: id.map(_EffectID.init),
                     queue: nil,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
@@ -190,7 +190,7 @@ extension Effect
         self.init(
             kinds: [.sequence(
                 _Sequence(
-                    id: id.map(EffectID.init),
+                    id: id.map(_EffectID.init),
                     queue: queue,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
@@ -330,7 +330,7 @@ extension Effect
     // MARK: - cancel
 
     /// Cancels running `async`s by specifying `ids`.
-    public static func cancel(ids: @escaping @Sendable (EffectID) -> Bool) -> Effect<Action>
+    public static func cancel(ids: @escaping @Sendable (any EffectIDProtocol) -> Bool) -> Effect<Action>
     {
         Effect(kinds: [.cancel(ids)])
     }
@@ -339,7 +339,7 @@ extension Effect
     public static func cancel<ID>(id: ID) -> Effect<Action>
         where ID: EffectIDProtocol
     {
-        Effect(kinds: [.cancel { $0 == EffectID(id) }])
+        Effect(kinds: [.cancel { AnyHashable($0) == AnyHashable(id) }])
     }
 }
 
@@ -392,7 +392,7 @@ extension Effect
         })
     }
 
-    /// Changes `EffectID`.
+    /// Changes `_EffectID`.
     public func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect
         where ID: EffectIDProtocol
     {
@@ -449,7 +449,7 @@ extension Effect
         self.kinds.compactMap { $0.sequence }
     }
 
-    internal var cancels: [(EffectID) -> Bool]
+    internal var cancels: [(any EffectIDProtocol) -> Bool]
     {
         self.kinds.compactMap { $0.cancel }
     }
@@ -468,8 +468,8 @@ extension Effect
         /// No async func effect, only returning next action only.
         case next(Action)
 
-        /// Cancellation effect with filtering `EffectID`s by a predicate.
-        case cancel(@Sendable (EffectID) -> Bool)
+        /// Cancellation effect with filtering effect IDs by a predicate.
+        case cancel(@Sendable (any EffectIDProtocol) -> Bool)
 
         internal var single: Single?
         {
@@ -483,13 +483,13 @@ extension Effect
             return value
         }
 
-        internal var cancel: ((EffectID) -> Bool)?
+        internal var cancel: ((any EffectIDProtocol) -> Bool)?
         {
             guard case let .cancel(value) = self else { return nil }
             return value
         }
 
-        internal var id: EffectID?
+        internal var id: _EffectID?
         {
             switch self {
             case let .single(single):
@@ -521,12 +521,12 @@ extension Effect
     /// Wrapper of `async`.
     package struct Single: Sendable
     {
-        internal let id: EffectID?
+        internal let id: _EffectID?
         internal let queue: (any EffectQueueProtocol)?
         internal let run: @Sendable (EffectContext) async throws -> Action?
 
         internal init(
-            id: EffectID? = nil,
+            id: _EffectID? = nil,
             queue: (any EffectQueueProtocol)? = nil,
             run: @escaping @Sendable (EffectContext) async throws -> Action?
         )
@@ -546,7 +546,7 @@ extension Effect
         internal func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect.Single
             where ID: EffectIDProtocol
         {
-            .init(id: f(id?.value).map(EffectID.init), queue: queue, run: run)
+            .init(id: f(id?.value).map(_EffectID.init), queue: queue, run: run)
         }
 
         internal func map(
@@ -560,13 +560,13 @@ extension Effect
     /// Wrapper of `AsyncSequence`.
     package struct _Sequence: Sendable
     {
-        internal let id: EffectID?
+        internal let id: _EffectID?
         internal let queue: (any EffectQueueProtocol)?
         internal let sequence: @Sendable (EffectContext) async throws
             -> (any AsyncSequence<Action, any Error> & Sendable)?
 
         internal init(
-            id: EffectID? = nil,
+            id: _EffectID? = nil,
             queue: (any EffectQueueProtocol)? = nil,
             sequence: @escaping @Sendable (EffectContext) async throws
                 -> (any AsyncSequence<Action, any Error> & Sendable)?
@@ -596,7 +596,7 @@ extension Effect
         internal func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect._Sequence
             where ID: EffectIDProtocol
         {
-            .init(id: f(id?.value).map(EffectID.init), queue: queue, sequence: sequence)
+            .init(id: f(id?.value).map(_EffectID.init), queue: queue, sequence: sequence)
         }
 
         internal func map(

--- a/Sources/ActomatonEffect/EffectID.swift
+++ b/Sources/ActomatonEffect/EffectID.swift
@@ -1,25 +1,3 @@
-/// Effect identifier for manual cancellation via `Effect.cancel`.
-public struct EffectID: Hashable, Sendable
-{
-    /// Raw value that conforms to `EffectIDProtocol`.
-    public let value: any EffectIDProtocol
-
-    internal init(_ value: some EffectIDProtocol)
-    {
-        self.value = value
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool
-    {
-        AnyHashable(lhs.value) == AnyHashable(rhs.value)
-    }
-
-    public func hash(into hasher: inout Hasher)
-    {
-        AnyHashable(value).hash(into: &hasher)
-    }
-}
-
 /// A protocol that every effect-identifier should conform to.
 public protocol EffectIDProtocol: Hashable, Sendable {}
 

--- a/Sources/ActomatonEffect/EffectQueue.swift
+++ b/Sources/ActomatonEffect/EffectQueue.swift
@@ -1,30 +1,3 @@
-/// Effect queue for automatic cancellation of existing tasks or suspending of new effects.
-public struct EffectQueue: Hashable, Sendable
-{
-    /// Raw value that conforms to `EffectQueueProtocol`.
-    public let value: any EffectQueueProtocol
-
-    internal init(_ value: some EffectQueueProtocol)
-    {
-        self.value = value
-    }
-
-    internal init(_ value: any EffectQueueProtocol)
-    {
-        self.value = value
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool
-    {
-        AnyHashable(lhs.value) == AnyHashable(rhs.value)
-    }
-
-    public func hash(into hasher: inout Hasher)
-    {
-        AnyHashable(value).hash(into: &hasher)
-    }
-}
-
 /// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of
 /// new effects.
 public protocol EffectQueueProtocol: Hashable, Sendable

--- a/Sources/ActomatonEffect/Internal/EffectManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectManager.swift
@@ -16,17 +16,17 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     // MARK: - Task tracking
 
     /// Effect-identified running tasks for manual cancellation or on-deinit cancellation.
-    /// - Note: Multiple effects can have same ``EffectID``.
-    private var runningTasks: [EffectID: Set<Task<(), any Error>>] = [:]
+    /// - Note: Multiple effects can have same ``_EffectID``.
+    private var runningTasks: [_EffectID: Set<Task<(), any Error>>] = [:]
 
     /// Effect-queue-designated running tasks for automatic cancellation & suspension.
-    private var queuedRunningTasks: [EffectQueue: [Task<(), any Error>]] = [:]
+    private var queuedRunningTasks: [_EffectQueue: [Task<(), any Error>]] = [:]
 
     /// Suspended effects.
-    private var pendingEffectKinds: [EffectQueue: [Effect<Action>.Kind]] = [:]
+    private var pendingEffectKinds: [_EffectQueue: [Effect<Action>.Kind]] = [:]
 
     /// Tracked latest effect start time for delayed effects calculation.
-    private var latestEffectTime: [EffectQueue: AnyClock<Duration>.Instant] = [:]
+    private var latestEffectTime: [_EffectQueue: AnyClock<Duration>.Instant] = [:]
 
     // MARK: - Callbacks (set via setUp)
 
@@ -119,7 +119,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     }
 
     private func handleTaskCompleted(
-        id: EffectID,
+        id: _EffectID,
         task: Task<(), any Error>,
         queue: (any EffectQueueProtocol)?,
         priority: TaskPriority?,
@@ -130,7 +130,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         runningTasks[id]?.remove(task)
 
         if let queue {
-            let effectQueue = EffectQueue(queue)
+            let effectQueue = _EffectQueue(queue)
 
             if let removingIndex = queuedRunningTasks[effectQueue]?.firstIndex(where: { $0 == task }) {
                 Debug.print("[handleTaskCompleted] Remove completed queue-task: \(queue) \(removingIndex)")
@@ -212,7 +212,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     {
         guard let queue = effectKind.queue else { return true }
 
-        let effectQueue = EffectQueue(queue)
+        let effectQueue = _EffectQueue(queue)
 
         switch queue.effectQueuePolicy {
         case let .runNewest(maxCount):
@@ -334,13 +334,13 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// for safe bookkeeping updates, avoiding strong capture of the actor.
     private func enqueueTask(
         _ task: Task<(), any Error>,
-        id: EffectID?,
+        id: _EffectID?,
         queue: (any EffectQueueProtocol)?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     )
     {
-        let effectID = id ?? EffectID(DefaultEffectID())
+        let effectID = id ?? _EffectID(DefaultEffectID())
 
         // Register task.
         Debug.print("[enqueueTask] Append id-task: \(effectID)")
@@ -348,7 +348,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
 
         if let queue {
             Debug.print("[enqueueTask] Append queue-task: \(queue)")
-            self.queuedRunningTasks[EffectQueue(queue), default: []].append(task)
+            self.queuedRunningTasks[_EffectQueue(queue), default: []].append(task)
         }
 
         // Clean up after `task` is completed.
@@ -375,12 +375,12 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
 
     /// Cancels running and pending effects matching the predicate.
     private func cancelEffects(
-        predicate: @escaping @Sendable (EffectID) -> Bool
+        predicate: @escaping @Sendable (any EffectIDProtocol) -> Bool
     )
     {
         // Cancel running tasks.
         for id in runningTasks.keys {
-            if predicate(id), let previousTasks = runningTasks.removeValue(forKey: id) {
+            if predicate(id.value), let previousTasks = runningTasks.removeValue(forKey: id) {
                 for previousTask in previousTasks {
                     previousTask.cancel()
                 }
@@ -390,7 +390,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         // Cancel pending effects.
         for (effectQueue, effectKinds) in pendingEffectKinds {
             for (i, effectKind) in effectKinds.enumerated().reversed() {
-                if let effectID = effectKind.id, predicate(effectID) {
+                if let effectID = effectKind.id, predicate(effectID.value) {
                     if let kind = pendingEffectKinds[effectQueue]?.remove(at: i) {
                         cancelEffectKind(kind)
                     }
@@ -406,7 +406,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     {
         guard let queue else { return nil }
 
-        let effectQueue = EffectQueue(queue)
+        let effectQueue = _EffectQueue(queue)
         let now = self.effectContext.clock.now
 
         guard let latestTime = self.latestEffectTime[effectQueue] else {
@@ -436,7 +436,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?
     {
-        let effectQueue = EffectQueue(queue)
+        let effectQueue = _EffectQueue(queue)
 
         guard pendingEffectKinds[effectQueue]?.isEmpty == false else { return nil }
 

--- a/Sources/ActomatonEffect/Internal/_EffectID.swift
+++ b/Sources/ActomatonEffect/Internal/_EffectID.swift
@@ -1,0 +1,21 @@
+/// Effect identifier for manual cancellation via `Effect.cancel`.
+struct _EffectID: Hashable, Sendable
+{
+    /// Raw value that conforms to `EffectIDProtocol`.
+    let value: any EffectIDProtocol
+
+    init(_ value: some EffectIDProtocol)
+    {
+        self.value = value
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool
+    {
+        AnyHashable(lhs.value) == AnyHashable(rhs.value)
+    }
+
+    func hash(into hasher: inout Hasher)
+    {
+        AnyHashable(value).hash(into: &hasher)
+    }
+}

--- a/Sources/ActomatonEffect/Internal/_EffectQueue.swift
+++ b/Sources/ActomatonEffect/Internal/_EffectQueue.swift
@@ -1,0 +1,26 @@
+/// Effect queue for automatic cancellation of existing tasks or suspending of new effects.
+struct _EffectQueue: Hashable, Sendable
+{
+    /// Raw value that conforms to `EffectQueueProtocol`.
+    let value: any EffectQueueProtocol
+
+    init(_ value: some EffectQueueProtocol)
+    {
+        self.value = value
+    }
+
+    init(_ value: any EffectQueueProtocol)
+    {
+        self.value = value
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool
+    {
+        AnyHashable(lhs.value) == AnyHashable(rhs.value)
+    }
+
+    func hash(into hasher: inout Hasher)
+    {
+        AnyHashable(value).hash(into: &hasher)
+    }
+}

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -85,7 +85,7 @@ final class PendingEffectCancellationTests: MainTestCase
                     return Effect.fireAndForget { await flags.mark(result2: .completed) }
 
                 case .cancelAll:
-                    return Effect.cancel(ids: { $0.value is EffectID })
+                    return Effect.cancel(ids: { $0 is EffectID })
                 }
             },
             effectContext: effectContext


### PR DESCRIPTION
## Summary
- Rename `EffectID` → `_EffectID` and `EffectQueue` → `_EffectQueue` as `internal` types (previously `public`)
- Change `Effect.cancel(ids:)` closure parameter from `(EffectID) -> Bool` to `(any EffectIDProtocol) -> Bool`
- Public protocols (`EffectIDProtocol`, `EffectQueueProtocol`, etc.) remain unchanged

These wrapper structs exist only to make `any EffectIDProtocol` / `any EffectQueueProtocol` usable as `Hashable` dictionary keys internally. Users never needed to construct or reference them directly.
