### PR TITLE
Remove Protocol suffix from protocol names and rename EffectManager to EffectQueueManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ This repository consists of 6 modules:
 
 In addition, the following lower-level modules are available for advanced use cases:
 
-5. **`ActomatonCore`**: Generic Mealy machine (`MealyMachine`) and composable `MealyReducer`, independent of any effect system. Pair it with a pluggable `EffectManagerProtocol` conformer to choose what "output" means — `Void` (no effects), `Action?` (synchronous feedback), or your own custom type.
-6. **`ActomatonEffect`**: The `Effect<Action>` type and its default `EffectManager` — queue-based async task lifecycle (creation, cancellation, suspension, delay).
+5. **`ActomatonCore`**: Generic Mealy machine (`MealyMachine`) and composable `MealyReducer`, independent of any effect system. Pair it with a pluggable `EffectManager` conformer to choose what "output" means — `Void` (no effects), `Action?` (synchronous feedback), or your own custom type.
+6. **`ActomatonEffect`**: The `Effect<Action>` type and its default `EffectManager` conformer (`EffectQueueManager`) — queue-based async task lifecycle (creation, cancellation, suspension, delay).
 
 ### Module dependency graph
 
 ```
-ActomatonCore          -- generic MealyMachine + MealyReducer + EffectManagerProtocol
-  └─ ActomatonEffect   -- Effect<Action>, EffectManager, EffectQueue, EffectID
+ActomatonCore          -- generic MealyMachine + MealyReducer + EffectManager
+  └─ ActomatonEffect   -- Effect<Action>, EffectQueueManager, EffectQueue, EffectID
        ├─ Actomaton    -- Actomaton typealias, Reducer typealias, CasePath integration
        │    ├─ ActomatonUI         -- Store, RouteStore (SwiftUI / UIKit)
        │    └─ ActomatonDebugging  -- debug / log reducers
@@ -41,11 +41,11 @@ ActomatonCore          -- generic MealyMachine + MealyReducer + EffectManagerPro
 
 `ActomatonCore` is intentionally free of `Effect` and async task management.
 This makes `MealyMachine` usable in contexts where full effect infrastructure is overkill — for example, purely synchronous state machines, game logic, or protocol parsers.
-Built-in `EffectManagerProtocol` conformers cover common cases:
+Built-in `EffectManager` conformers cover common cases:
 
 | Conformer | Output type | Use case |
 |---|---|---|
-| `EffectManager` | `Effect<Action>` | Full async effect lifecycle (in `ActomatonEffect`) |
+| `EffectQueueManager` (internal) | `Effect<Action>` | Full async effect lifecycle (in `ActomatonEffect`) |
 | `NoOpEffectManager` | `Void` | Pure state transitions, no side-effects |
 | `ActionEffectManager` | `[Action]` | Synchronous action feedback loops |
 
@@ -185,7 +185,7 @@ enum Action: Sendable {
 // next effect with same `EffectID` will automatically cancel the previous one.
 //
 // Note that `EffectID` is also useful for manual cancellation via `Effect.cancel`.
-struct LoginFlowEffectID: EffectIDProtocol {}
+struct LoginFlowEffectID: EffectID {}
 
 struct Environment: Sendable {
     let loginEffect: (userId: String) -> Effect<Action>
@@ -305,7 +305,7 @@ enum Action: Sendable {
     case start, tick, stop
 }
 
-struct TimerID: EffectIDProtocol {}
+struct TimerID: EffectID {}
 
 struct Environment {
     let timerEffect: Effect<Action>
@@ -391,7 +391,7 @@ struct Environment: Sendable {
     let fetch: @Sendable (_ id: String) async throws -> Data
 }
 
-struct DelayedEffectQueue: EffectQueueProtocol {
+struct DelayedEffectQueue: EffectQueue {
     // First 3 effects will run concurrently, and other sent effects will be suspended.
     var effectQueuePolicy: EffectQueuePolicy {
         .runOldest(maxCount: 3, .suspendNew)
@@ -428,12 +428,12 @@ await actomaton.send(.fetch(id: "item3")) // min delay of 0.1 (after item2 actua
 await actomaton.send(.fetch(id: "item4")) // starts when item1 or 2 or 3 finishes
 ```
 
-Above code uses a custom `DelayedEffectQueue` that conforms to `EffectQueueProtocol` with suspendable `EffectQueuePolicy` and delays between each effect by `EffectQueueDelay`.
+Above code uses a custom `DelayedEffectQueue` that conforms to `EffectQueue` with suspendable `EffectQueuePolicy` and delays between each effect by `EffectQueueDelay`.
 
 See [EffectQueuePolicy](https://github.com/Actomaton/Actomaton/blob/main/Sources/Actomaton/EffectQueuePolicy.swift) for how each policy takes different queueing strategy for effects.
 
 ```swift
-/// `EffectQueueProtocol`'s buffering policy.
+/// `EffectQueue`'s buffering policy.
 public enum EffectQueuePolicy: Hashable, Sendable
 {
     /// Runs `maxCount` newest effects, cancelling old running effects.
@@ -453,20 +453,20 @@ public enum EffectQueuePolicy: Hashable, Sendable
 }
 ```
 
-For convenient `EffectQueueProtocol` protocol conformance, there are built-in sub-protocols:
+For convenient `EffectQueue` protocol conformance, there are built-in sub-protocols:
 
 ```swift
 /// A helper protocol where `effectQueuePolicy` is set to `.runNewest(maxCount: 1)`.
-public protocol Newest1EffectQueueProtocol: EffectQueueProtocol {}
+public protocol Newest1EffectQueue: EffectQueue {}
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .discardNew)`.
-public protocol Oldest1DiscardNewEffectQueueProtocol: EffectQueueProtocol {}
+public protocol Oldest1DiscardNewEffectQueue: EffectQueue {}
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .suspendNew)`.
-public protocol Oldest1SuspendNewEffectQueueProtocol: EffectQueueProtocol {}
+public protocol Oldest1SuspendNewEffectQueue: EffectQueue {}
 ```
 
-so that we can write in one-liner: `struct MyEffectQueue: Newest1EffectQueueProtocol {}`
+so that we can write in one-liner: `struct MyEffectQueue: Newest1EffectQueue {}`
 
 ### Example 1-5. Reducer composition
 

--- a/Sources/Actomaton/Actomaton+Init.swift
+++ b/Sources/Actomaton/Actomaton+Init.swift
@@ -1,7 +1,7 @@
 import ActomatonCore
 import ActomatonEffect
 
-/// Convenience initializers that default to ``EffectManager``.
+/// Convenience initializers that default to ``EffectQueueManager``.
 extension MealyMachine where Output == Effect<Action>
 {
     /// Initializer without `environment`.
@@ -14,7 +14,7 @@ extension MealyMachine where Output == Effect<Action>
         self.init(
             state: state,
             reducer: reducer,
-            effectManager: EffectManager<Action, State>(effectContext: effectContext)
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
         )
     }
 
@@ -31,7 +31,7 @@ extension MealyMachine where Output == Effect<Action>
             reducer: Reducer<Action, State, ()> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectManager<Action, State>(effectContext: effectContext)
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
         )
     }
 
@@ -50,7 +50,7 @@ extension MealyMachine where Output == Effect<Action>
             reducer: Reducer<Action, State, ()> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectManager<Action, State>(effectContext: effectContext),
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext),
             executingActor: executingActor
         )
     }

--- a/Sources/Actomaton/Actomaton.docc/Actomaton.md
+++ b/Sources/Actomaton/Actomaton.docc/Actomaton.md
@@ -63,17 +63,12 @@ To play with real-world app using Actomaton, see SwiftUI / UIKit Gallery app bel
 ### Effects
 
 - ``Effect``
-- ``EffectIDProtocol``
-- ``EffectQueueProtocol``
+- ``EffectID``
+- ``EffectQueue``
 
 ### EffectQueuePolicy and built-ins
 
 - ``EffectQueuePolicy``
-- ``Newest1EffectQueueProtocol``
-- ``Oldest1DiscardNewEffectQueueProtocol``
-- ``Oldest1SuspendNewEffectQueueProtocol``
-
-### EffectID/Queue Wrapper
-
-- ``EffectID``
-- ``EffectQueue``
+- ``Newest1EffectQueue``
+- ``Oldest1DiscardNewEffectQueue``
+- ``Oldest1SuspendNewEffectQueue``

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/02-LoginLogout.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/02-LoginLogout.md
@@ -22,11 +22,11 @@ enum State: Sendable {
 // NOTE:
 // By attaching this EffectQueue to multiple `Effect`s,
 // they will incorporate with each other under the same `EffectQueuePolicy`,
-// in this case: `Newest1EffectQueueProtocol`.
+// in this case: `Newest1EffectQueue`.
 // 
 // This policy will only allow at most newest 1 effect to survive,
 // and rest of the queued running effects will be automatically cancelled.
-struct LoginFlowEffectQueue: Newest1EffectQueueProtocol {}
+struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
 struct Environment: Sendable {
     let loginEffect: @Sendable (userId: String) -> Effect<Action>
@@ -133,7 +133,7 @@ enum Main {
 Here we see the notions of `EffectQueue`, `Environment`, and `let task: Task<(), Error> = actomaton.send(...)`
 
 - `EffectQueue` is for automatic cancellation or suspension of effects. 
-  In this example, `Newest1EffectQueueProtocol` is used so that only the newest 1 effect (`forceLogout`) will survive,
+  In this example, `Newest1EffectQueue` is used so that only the newest 1 effect (`forceLogout`) will survive,
   and rest of old queued effects (e.g. previous `login`) will be automatically cancelled.
 - `Environment` is useful for injecting effects to be called inside `Reducer` so that they become replaceable. 
   **`Environment` is known as Dependency Injection Container** (using Reader monad).

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-Timer.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-Timer.md
@@ -13,7 +13,7 @@ enum Action: Sendable {
 
 typealias State = Int
 
-struct TimerID: EffectIDProtocol {}
+struct TimerID: EffectID {}
 
 struct Environment: Sendable {
     let timerEffect: Effect<Action>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/04-EffectQueue.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/04-EffectQueue.md
@@ -24,7 +24,7 @@ struct Environment: Sendable {
     let fetch: @Sendable (_ id: String) async throws -> Data
 }
 
-struct DelayedEffectQueue: EffectQueueProtocol {
+struct DelayedEffectQueue: EffectQueue {
     // First 3 effects will run concurrently, and other sent effects will be suspended.
     var effectQueuePolicy: EffectQueuePolicy {
         .runOldest(maxCount: 3, .suspendNew)
@@ -61,12 +61,12 @@ await actomaton.send(.fetch(id: "item3")) // min delay of 0.1 (after item2 actua
 await actomaton.send(.fetch(id: "item4")) // starts when item1 or 2 or 3 finishes
 ```
 
-Above code uses a custom `DelayedEffectQueue` that conforms to ``EffectQueueProtocol`` with suspendable ``EffectQueuePolicy`` and delays between each effect by ``EffectQueueDelay``.
+Above code uses a custom `DelayedEffectQueue` that conforms to ``EffectQueue`` with suspendable ``EffectQueuePolicy`` and delays between each effect by ``EffectQueueDelay``.
 
-See [EffectQueuePolicy](https://github.com/Actomaton/Actomaton/blob/main/Sources/Actomaton/EffectQueuePolicy.swift) for how each policy takes different queueing strategy for effects.
+See [EffectQueuePolicy](https://github.com/Actomaton/Actomaton/blob/main/Sources/ActomatonEffect/EffectQueuePolicy.swift) for how each policy takes different queueing strategy for effects.
 
 ```swift
-/// `EffectQueueProtocol`'s buffering policy.
+/// `EffectQueue`'s buffering policy.
 public enum EffectQueuePolicy: Hashable, Sendable
 {
     /// Runs `maxCount` newest effects, cancelling old running effects.
@@ -86,27 +86,27 @@ public enum EffectQueuePolicy: Hashable, Sendable
 }
 ```
 
-For convenient ``EffectQueueProtocol`` protocol conformance, there are built-in sub-protocols:
+For convenient ``EffectQueue`` protocol conformance, there are built-in sub-protocols:
 
 ```swift
 /// A helper protocol where `effectQueuePolicy` is set to `.runNewest(maxCount: 1)`.
-public protocol Newest1EffectQueueProtocol: EffectQueueProtocol {}
+public protocol Newest1EffectQueue: EffectQueue {}
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .discardNew)`.
-public protocol Oldest1DiscardNewEffectQueueProtocol: EffectQueueProtocol {}
+public protocol Oldest1DiscardNewEffectQueue: EffectQueue {}
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .suspendNew)`.
-public protocol Oldest1SuspendNewEffectQueueProtocol: EffectQueueProtocol {}
+public protocol Oldest1SuspendNewEffectQueue: EffectQueue {}
 ```
 
-so that we can write in one-liner: `struct MyEffectQueue: Newest1EffectQueueProtocol {}`
+so that we can write in one-liner: `struct MyEffectQueue: Newest1EffectQueue {}`
 
 ## Dynamic maxCount
 
-Since ``EffectQueueProtocol`` conforms to `Hashable`, you can make `maxCount` dynamic at runtime by separating the queue's identity (hash/equality) from its policy values. The key insight is that `EffectManager` looks up queued tasks by the queue's hash, but reads `maxCount` from the queue instance passed with each effect.
+Since ``EffectQueue`` conforms to `Hashable`, you can make `maxCount` dynamic at runtime by separating the queue's identity (hash/equality) from its policy values. The key insight is that `EffectQueueManager` looks up queued tasks by the queue's hash, but reads `maxCount` from the queue instance passed with each effect.
 
 ```swift
-struct DynamicQueue: EffectQueueProtocol {
+struct DynamicQueue: EffectQueue {
     var maxCount: Int
 
     var effectQueuePolicy: EffectQueuePolicy {
@@ -114,7 +114,7 @@ struct DynamicQueue: EffectQueueProtocol {
     }
 
     // Hash and equality ignore maxCount, so all instances
-    // map to the same queue in EffectManager.
+    // map to the same queue in EffectQueueManager.
     func hash(into hasher: inout Hasher) {
         hasher.combine("DynamicQueue")
     }

--- a/Sources/Actomaton/MainActomaton.swift
+++ b/Sources/Actomaton/MainActomaton.swift
@@ -38,7 +38,7 @@ package final class MainActomaton<Action, State>
         self.actomaton = Actomaton(
             state: state,
             reducer: reducer,
-            effectManager: EffectManager<Action, State>(effectContext: effectContext),
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext),
             executingActor: MainActor.shared,
             willChangeState: { @Sendable _, old, new in
                 MainActor.assumeIsolated {

--- a/Sources/Actomaton/Reducer+Effect.swift
+++ b/Sources/Actomaton/Reducer+Effect.swift
@@ -67,8 +67,8 @@ extension MealyReducer where Output == Effect<Action>
     // MARK: - Functor
 
     /// Changes `EffectID`.
-    public func map<ID>(id f: @escaping @Sendable ((any EffectIDProtocol)?) -> ID?) -> Self
-        where ID: EffectIDProtocol
+    public func map<ID>(id f: @escaping @Sendable ((any EffectID)?) -> ID?) -> Self
+        where ID: EffectID
     {
         .init { action, state, environment in
             let effect = self.run(action, &state, environment)
@@ -78,8 +78,8 @@ extension MealyReducer where Output == Effect<Action>
     }
 
     /// Changes `EffectQueue`.
-    public func map<Queue>(queue f: @escaping @Sendable ((any EffectQueueProtocol)?) -> Queue?) -> Self
-        where Queue: EffectQueueProtocol
+    public func map<Queue>(queue f: @escaping @Sendable ((any EffectQueue)?) -> Queue?) -> Self
+        where Queue: EffectQueue
     {
         .init { action, state, environment in
             let effect = self.run(action, &state, environment)

--- a/Sources/ActomatonCore/EffectManager.swift
+++ b/Sources/ActomatonCore/EffectManager.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// The conformer does NOT own the reducer or state — those are managed by ``MealyMachine``.
 /// It only receives the reducer's output and processes it (e.g., creating tasks, managing queues).
-public protocol EffectManagerProtocol<Action, State, Output>: AnyObject
+public protocol EffectManager<Action, State, Output>: AnyObject
 {
     associatedtype Action
     associatedtype State
@@ -19,7 +19,7 @@ public protocol EffectManagerProtocol<Action, State, Output>: AnyObject
     /// - Parameters:
     ///   - performIsolated:
     ///     Closure to run a block within the owning actor's isolation.
-    ///     This method is a proof that `self` (EffectManager) is owned and protected by `isolated any Actor`,
+    ///     This method is a proof that `self` (the conformer) is owned and protected by `isolated any Actor`,
     ///     which guarantees e.g. safe clean up work inside `Task` closure while `self` is usually a non-`Sendable`
     /// class.
     ///   - sendAction:

--- a/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
@@ -6,14 +6,14 @@ import Foundation
 /// Each action in the output array is fed back into the reducer sequentially.
 /// Any further actions produced by those feedback calls are recursively processed
 /// until no more actions remain.
-public final class ActionEffectManager<Action, State>: EffectManagerProtocol
+public final class ActionEffectManager<Action, State>: EffectManager
     where Action: Sendable
 {
     public typealias Output = [Action]
 
     public init() {}
 
-    // MARK: - EffectManagerProtocol
+    // MARK: - EffectManager
 
     public func setUp(
         performIsolated: @escaping @Sendable (

--- a/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// Effectless, Actionless (feedbackless) Effect Manager where `Output` is `Void`.
-public final class NoOpEffectManager<Action, State>: EffectManagerProtocol
+public final class NoOpEffectManager<Action, State>: EffectManager
     where Action: Sendable
 {
     public typealias Output = Void
 
     public init() {}
 
-    // MARK: - EffectManagerProtocol
+    // MARK: - EffectManager
 
     public func setUp(
         performIsolated: @escaping @Sendable (

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Deterministic finite state machine that receives "action" and with "current state" transform to "next state" &
 /// additional "output",
-/// which then generates Swift Concurrency side-effects via ``EffectManagerProtocol``.
+/// which then generates Swift Concurrency side-effects via ``EffectManager``.
 public actor MealyMachine<Action, State, Output>
 {
 #if !DISABLE_COMBINE && canImport(Combine)
@@ -26,7 +26,7 @@ public actor MealyMachine<Action, State, Output>
 
     /// Core manages effect lifecycle: task creation, queue policies, and cancellation.
     /// Agnostic about reducer and state mutation.
-    package let effectManager: any EffectManagerProtocol<Action, State, Output>
+    package let effectManager: any EffectManager<Action, State, Output>
 
 #if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
     /// Mirrors `effectManager` so `deinit` can shut it down without relying on
@@ -35,7 +35,7 @@ public actor MealyMachine<Action, State, Output>
     /// `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` exists for non-WASI builds that
     /// are compiled by the Swift.org 6.2.4 toolchain, where `isolated deinit`
     /// also crashes during SIL lowering.
-    private nonisolated(unsafe) let unsafeEffectManager: any EffectManagerProtocol<Action, State, Output>
+    private nonisolated(unsafe) let unsafeEffectManager: any EffectManager<Action, State, Output>
 #endif
 
     /// Underlying actor that replaces `MealyMachine`'s `unownedExecutor`.
@@ -48,7 +48,7 @@ public actor MealyMachine<Action, State, Output>
     public init(
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
-        effectManager: some EffectManagerProtocol<Action, State, Output>
+        effectManager: some EffectManager<Action, State, Output>
     ) where Action: Sendable
     {
         self.init(
@@ -64,7 +64,7 @@ public actor MealyMachine<Action, State, Output>
         state: State,
         reducer: MealyReducer<Action, State, Environment, Output>,
         environment: Environment,
-        effectManager: some EffectManagerProtocol<Action, State, Output>
+        effectManager: some EffectManager<Action, State, Output>
     ) where Action: Sendable, Environment: Sendable
     {
         self.init(
@@ -87,7 +87,7 @@ public actor MealyMachine<Action, State, Output>
         willChangeState: @escaping (
             _ isolation: isolated MealyMachine, _ old: State, _ new: State
         ) -> Void = { _, _, _ in }
-    ) where Action: Sendable, EffM: EffectManagerProtocol<Action, State, Output>
+    ) where Action: Sendable, EffM: EffectManager<Action, State, Output>
     {
 #if !DISABLE_COMBINE && canImport(Combine)
         self._state = Published(initialValue: state)
@@ -170,10 +170,10 @@ public actor MealyMachine<Action, State, Output>
     /// Runs a block within `self`'s isolation with `EffM` force-casting.
     /// This method is a proof that `effectManager` is owned and protected by `self`.
     ///
-    /// Used by ``EffectManagerProtocol`` conformers to re-enter actor isolation from detached tasks.
+    /// Used by ``EffectManager`` conformers to re-enter actor isolation from detached tasks.
     private func performIsolated<EffM>(
         _ f: @Sendable (isolated any Actor, EffM) -> Void
-    ) where EffM: EffectManagerProtocol<Action, State, Output>
+    ) where EffM: EffectManager<Action, State, Output>
     {
         f(self, self.effectManager as! EffM)
     }

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -37,7 +37,7 @@ extension Effect
         id: ID? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> Action?
     )
-        where ID: EffectIDProtocol
+        where ID: EffectID
     {
         self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: nil, run: run))])
     }
@@ -45,7 +45,7 @@ extension Effect
     /// Single-`async` side-effect without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     public init<ID>(id: ID? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where ID: EffectIDProtocol
+        where ID: EffectID
     {
         self.init(id: id, run: { _ in
             try await run()
@@ -57,7 +57,7 @@ extension Effect
     public init<Queue>(
         queue: Queue? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> Action?
-    ) where Queue: EffectQueueProtocol
+    ) where Queue: EffectQueue
     {
         self.init(kinds: [.single(Single(id: nil, queue: queue, run: run))])
     }
@@ -65,7 +65,7 @@ extension Effect
     /// Single-`async` side-effect without `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<Queue>(queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where Queue: EffectQueueProtocol
+        where Queue: EffectQueue
     {
         self.init(queue: queue, run: { _ in
             try await run()
@@ -79,7 +79,7 @@ extension Effect
         id: ID? = nil,
         queue: Queue? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> Action?
-    ) where ID: EffectIDProtocol, Queue: EffectQueueProtocol
+    ) where ID: EffectID, Queue: EffectQueue
     {
         self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: queue, run: run))])
     }
@@ -88,7 +88,7 @@ extension Effect
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where ID: EffectIDProtocol, Queue: EffectQueueProtocol
+        where ID: EffectID, Queue: EffectQueue
     {
         self.init(id: id, queue: queue, run: { _ in
             try await run()
@@ -127,7 +127,7 @@ extension Effect
     public init<ID, S, E: Error>(
         id: ID? = nil,
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where ID: EffectIDProtocol, S: AsyncSequence<Action, E> & Sendable
+    ) where ID: EffectID, S: AsyncSequence<Action, E> & Sendable
     {
         self.init(
             kinds: [.sequence(
@@ -143,7 +143,7 @@ extension Effect
     /// `AsyncSequence` side-effect without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     public init<ID, S, E: Error>(id: ID? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where ID: EffectIDProtocol, S: AsyncSequence<Action, E> & Sendable
+        where ID: EffectID, S: AsyncSequence<Action, E> & Sendable
     {
         self.init(id: id, sequence: { _ in
             try await sequence()
@@ -155,7 +155,7 @@ extension Effect
     public init<S, E: Error, Queue>(
         queue: Queue? = nil,
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueueProtocol
+    ) where S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
     {
         self.init(
             kinds: [.sequence(
@@ -171,7 +171,7 @@ extension Effect
     /// `AsyncSequence` side-effect without `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<S, E: Error, Queue>(queue: Queue? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueueProtocol
+        where S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
     {
         self.init(queue: queue, sequence: { _ in
             try await sequence()
@@ -185,7 +185,7 @@ extension Effect
         id: ID? = nil,
         queue: Queue? = nil,
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where ID: EffectIDProtocol, S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueueProtocol
+    ) where ID: EffectID, S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
     {
         self.init(
             kinds: [.sequence(
@@ -205,7 +205,7 @@ extension Effect
         id: ID? = nil,
         queue: Queue? = nil,
         sequence: @escaping @Sendable () async throws -> S?
-    ) where ID: EffectIDProtocol, S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueueProtocol
+    ) where ID: EffectID, S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
     {
         self.init(id: id, queue: queue, sequence: { _ in
             try await sequence()
@@ -239,7 +239,7 @@ extension Effect
         id: ID? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
     ) -> Effect<Action>
-        where ID: EffectIDProtocol
+        where ID: EffectID
     {
         self.init(id: id, run: { context in
             try await run(context)
@@ -253,7 +253,7 @@ extension Effect
         id: ID? = nil,
         run: @escaping @Sendable () async throws -> ()
     ) -> Effect<Action>
-        where ID: EffectIDProtocol
+        where ID: EffectID
     {
         self.fireAndForget(id: id, run: { _ in
             try await run()
@@ -266,7 +266,7 @@ extension Effect
         queue: Queue? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
     ) -> Effect<Action>
-        where Queue: EffectQueueProtocol
+        where Queue: EffectQueue
     {
         self.init(queue: queue, run: { context in
             try await run(context)
@@ -280,7 +280,7 @@ extension Effect
         queue: Queue? = nil,
         run: @escaping @Sendable () async throws -> ()
     ) -> Effect<Action>
-        where Queue: EffectQueueProtocol
+        where Queue: EffectQueue
     {
         self.fireAndForget(queue: queue, run: { _ in
             try await run()
@@ -295,7 +295,7 @@ extension Effect
         queue: Queue? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
     ) -> Effect<Action>
-        where ID: EffectIDProtocol, Queue: EffectQueueProtocol
+        where ID: EffectID, Queue: EffectQueue
     {
         self.init(id: id, queue: queue, run: { context in
             try await run(context)
@@ -311,7 +311,7 @@ extension Effect
         queue: Queue? = nil,
         run: @escaping @Sendable () async throws -> ()
     ) -> Effect<Action>
-        where ID: EffectIDProtocol, Queue: EffectQueueProtocol
+        where ID: EffectID, Queue: EffectQueue
     {
         self.fireAndForget(id: id, queue: queue, run: { _ in
             try await run()
@@ -330,14 +330,14 @@ extension Effect
     // MARK: - cancel
 
     /// Cancels running `async`s by specifying `ids`.
-    public static func cancel(ids: @escaping @Sendable (any EffectIDProtocol) -> Bool) -> Effect<Action>
+    public static func cancel(ids: @escaping @Sendable (any EffectID) -> Bool) -> Effect<Action>
     {
         Effect(kinds: [.cancel(ids)])
     }
 
     /// Cancels running `async`s by specifying `identifier`.
     public static func cancel<ID>(id: ID) -> Effect<Action>
-        where ID: EffectIDProtocol
+        where ID: EffectID
     {
         Effect(kinds: [.cancel { AnyHashable($0) == AnyHashable(id) }])
     }
@@ -393,8 +393,8 @@ extension Effect
     }
 
     /// Changes `_EffectID`.
-    public func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect
-        where ID: EffectIDProtocol
+    public func map<ID>(id f: @escaping ((any EffectID)?) -> ID?) -> Effect
+        where ID: EffectID
     {
         .init(kinds: self.kinds.map { kind in
             switch kind {
@@ -414,8 +414,8 @@ extension Effect
     }
 
     /// Changes `EffectQueue`.
-    public func map<Queue>(queue f: @escaping ((any EffectQueueProtocol)?) -> Queue?) -> Effect
-        where Queue: EffectQueueProtocol
+    public func map<Queue>(queue f: @escaping ((any EffectQueue)?) -> Queue?) -> Effect
+        where Queue: EffectQueue
     {
         .init(kinds: self.kinds.map { kind in
             switch kind {
@@ -449,7 +449,7 @@ extension Effect
         self.kinds.compactMap { $0.sequence }
     }
 
-    internal var cancels: [(any EffectIDProtocol) -> Bool]
+    internal var cancels: [(any EffectID) -> Bool]
     {
         self.kinds.compactMap { $0.cancel }
     }
@@ -469,7 +469,7 @@ extension Effect
         case next(Action)
 
         /// Cancellation effect with filtering effect IDs by a predicate.
-        case cancel(@Sendable (any EffectIDProtocol) -> Bool)
+        case cancel(@Sendable (any EffectID) -> Bool)
 
         internal var single: Single?
         {
@@ -483,7 +483,7 @@ extension Effect
             return value
         }
 
-        internal var cancel: ((any EffectIDProtocol) -> Bool)?
+        internal var cancel: ((any EffectID) -> Bool)?
         {
             guard case let .cancel(value) = self else { return nil }
             return value
@@ -503,7 +503,7 @@ extension Effect
             }
         }
 
-        internal var queue: (any EffectQueueProtocol)?
+        internal var queue: (any EffectQueue)?
         {
             switch self {
             case let .single(single):
@@ -522,12 +522,12 @@ extension Effect
     package struct Single: Sendable
     {
         internal let id: _EffectID?
-        internal let queue: (any EffectQueueProtocol)?
+        internal let queue: (any EffectQueue)?
         internal let run: @Sendable (EffectContext) async throws -> Action?
 
         internal init(
             id: _EffectID? = nil,
-            queue: (any EffectQueueProtocol)? = nil,
+            queue: (any EffectQueue)? = nil,
             run: @escaping @Sendable (EffectContext) async throws -> Action?
         )
         {
@@ -543,14 +543,14 @@ extension Effect
             }
         }
 
-        internal func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect.Single
-            where ID: EffectIDProtocol
+        internal func map<ID>(id f: @escaping ((any EffectID)?) -> ID?) -> Effect.Single
+            where ID: EffectID
         {
             .init(id: f(id?.value).map(_EffectID.init), queue: queue, run: run)
         }
 
         internal func map(
-            queue f: @escaping ((any EffectQueueProtocol)?) -> (any EffectQueueProtocol)?
+            queue f: @escaping ((any EffectQueue)?) -> (any EffectQueue)?
         ) -> Effect.Single
         {
             .init(id: id, queue: f(queue), run: run)
@@ -561,13 +561,13 @@ extension Effect
     package struct _Sequence: Sendable
     {
         internal let id: _EffectID?
-        internal let queue: (any EffectQueueProtocol)?
+        internal let queue: (any EffectQueue)?
         internal let sequence: @Sendable (EffectContext) async throws
             -> (any AsyncSequence<Action, any Error> & Sendable)?
 
         internal init(
             id: _EffectID? = nil,
-            queue: (any EffectQueueProtocol)? = nil,
+            queue: (any EffectQueue)? = nil,
             sequence: @escaping @Sendable (EffectContext) async throws
                 -> (any AsyncSequence<Action, any Error> & Sendable)?
         )
@@ -593,14 +593,14 @@ extension Effect
             })
         }
 
-        internal func map<ID>(id f: @escaping ((any EffectIDProtocol)?) -> ID?) -> Effect._Sequence
-            where ID: EffectIDProtocol
+        internal func map<ID>(id f: @escaping ((any EffectID)?) -> ID?) -> Effect._Sequence
+            where ID: EffectID
         {
             .init(id: f(id?.value).map(_EffectID.init), queue: queue, sequence: sequence)
         }
 
         internal func map(
-            queue f: @escaping ((any EffectQueueProtocol)?) -> (any EffectQueueProtocol)?
+            queue f: @escaping ((any EffectQueue)?) -> (any EffectQueue)?
         ) -> Effect._Sequence
         {
             .init(id: id, queue: f(queue), sequence: sequence)

--- a/Sources/ActomatonEffect/EffectID.swift
+++ b/Sources/ActomatonEffect/EffectID.swift
@@ -1,5 +1,5 @@
 /// A protocol that every effect-identifier should conform to.
-public protocol EffectIDProtocol: Hashable, Sendable {}
+public protocol EffectID: Hashable, Sendable {}
 
-/// Default anonymous efffect.
-internal struct DefaultEffectID: EffectIDProtocol {}
+/// Default anonymous effect.
+internal struct DefaultEffectID: EffectID {}

--- a/Sources/ActomatonEffect/EffectQueue.swift
+++ b/Sources/ActomatonEffect/EffectQueue.swift
@@ -1,6 +1,6 @@
 /// A protocol that every effect queue should conform to, for automatic cancellation of existing tasks or suspending of
 /// new effects.
-public protocol EffectQueueProtocol: Hashable, Sendable
+public protocol EffectQueue: Hashable, Sendable
 {
     /// Effect buffering policy.
     var effectQueuePolicy: EffectQueuePolicy { get }
@@ -9,7 +9,7 @@ public protocol EffectQueueProtocol: Hashable, Sendable
     var effectQueueDelay: EffectQueueDelay { get }
 }
 
-extension EffectQueueProtocol
+extension EffectQueue
 {
     public var effectQueueDelay: EffectQueueDelay
     {
@@ -17,12 +17,12 @@ extension EffectQueueProtocol
     }
 }
 
-// MARK: - Newest1EffectQueueProtocol
+// MARK: - Newest1EffectQueue
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runNewest(maxCount: 1)`.
-public protocol Newest1EffectQueueProtocol: EffectQueueProtocol {}
+public protocol Newest1EffectQueue: EffectQueue {}
 
-extension Newest1EffectQueueProtocol
+extension Newest1EffectQueue
 {
     public var effectQueuePolicy: EffectQueuePolicy
     {
@@ -30,12 +30,12 @@ extension Newest1EffectQueueProtocol
     }
 }
 
-// MARK: - Oldest1DiscardNewEffectQueueProtocol
+// MARK: - Oldest1DiscardNewEffectQueue
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .discardNew)`.
-public protocol Oldest1DiscardNewEffectQueueProtocol: EffectQueueProtocol {}
+public protocol Oldest1DiscardNewEffectQueue: EffectQueue {}
 
-extension Oldest1DiscardNewEffectQueueProtocol
+extension Oldest1DiscardNewEffectQueue
 {
     public var effectQueuePolicy: EffectQueuePolicy
     {
@@ -43,12 +43,12 @@ extension Oldest1DiscardNewEffectQueueProtocol
     }
 }
 
-// MARK: - Oldest1SuspendNewEffectQueueProtocol
+// MARK: - Oldest1SuspendNewEffectQueue
 
 /// A helper protocol where `effectQueuePolicy` is set to `.runOldest(maxCount: 1, .suspendNew)`.
-public protocol Oldest1SuspendNewEffectQueueProtocol: EffectQueueProtocol {}
+public protocol Oldest1SuspendNewEffectQueue: EffectQueue {}
 
-extension Oldest1SuspendNewEffectQueueProtocol
+extension Oldest1SuspendNewEffectQueue
 {
     public var effectQueuePolicy: EffectQueuePolicy
     {

--- a/Sources/ActomatonEffect/EffectQueueDelay.swift
+++ b/Sources/ActomatonEffect/EffectQueueDelay.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// ``EffectQueueProtocol``'s  delaying strategy.
+/// ``EffectQueue``'s  delaying strategy.
 public enum EffectQueueDelay: Hashable, Sendable
 {
     case constant(TimeInterval)

--- a/Sources/ActomatonEffect/EffectQueuePolicy.swift
+++ b/Sources/ActomatonEffect/EffectQueuePolicy.swift
@@ -1,4 +1,4 @@
-/// `EffectQueueProtocol`'s buffering policy.
+/// `EffectQueue`'s buffering policy.
 public enum EffectQueuePolicy: Hashable, Sendable
 {
     /// Runs `maxCount` newest effects, cancelling old running effects.

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -2,11 +2,11 @@ import ActomatonCore
 import Clocks
 import Foundation
 
-/// Default ``EffectManagerProtocol`` implementation that manages ``Effect<Action>`` with queue-based task lifecycle.
+/// Default ``EffectManager`` implementation that manages ``Effect<Action>`` with queue-based task lifecycle.
 ///
 /// Handles task creation, queue policies (newest/oldest), effect delays, and pending effect suspension.
 /// Does NOT own the reducer or state — those are managed by ``MealyMachine``.
-package final class EffectManager<Action, State>: EffectManagerProtocol
+package final class EffectQueueManager<Action, State>: EffectManager
     where Action: Sendable
 {
     package typealias Output = Effect<Action>
@@ -35,7 +35,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Closure to run a block within the owning actor's isolation for safe bookkeeping updates.
     private var performIsolated: (
         @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
         ) async -> Void
     )?
 
@@ -46,11 +46,11 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
         self.effectContext = effectContext
     }
 
-    // MARK: - EffectManagerProtocol
+    // MARK: - EffectManager
 
     package func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -121,7 +121,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     private func handleTaskCompleted(
         id: _EffectID,
         task: Task<(), any Error>,
-        queue: (any EffectQueueProtocol)?,
+        queue: (any EffectQueue)?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     )
@@ -195,7 +195,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
             return []
 
         case .next:
-            // Should not appear — Actomaton resolves .next before passing to EffectManager.
+            // Should not appear — Actomaton resolves .next before passing to EffectQueueManager.
             return []
 
         case let .cancel(predicate):
@@ -335,7 +335,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     private func enqueueTask(
         _ task: Task<(), any Error>,
         id: _EffectID?,
-        queue: (any EffectQueueProtocol)?,
+        queue: (any EffectQueue)?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     )
@@ -375,7 +375,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
 
     /// Cancels running and pending effects matching the predicate.
     private func cancelEffects(
-        predicate: @escaping @Sendable (any EffectIDProtocol) -> Bool
+        predicate: @escaping @Sendable (any EffectID) -> Bool
     )
     {
         // Cancel running tasks.
@@ -402,7 +402,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Calculates absolute effect start time for queue-based delay scheduling.
     ///
     /// Returns `nil` when the effect should run immediately without additional sleeping.
-    private func calculateEffectTime(queue: (any EffectQueueProtocol)?) -> AnyClock<Duration>.Instant?
+    private func calculateEffectTime(queue: (any EffectQueue)?) -> AnyClock<Duration>.Instant?
     {
         guard let queue else { return nil }
 
@@ -431,7 +431,7 @@ package final class EffectManager<Action, State>: EffectManagerProtocol
     /// Dequeues a pending effect if possible (for `runOldest-suspendNew` policy).
     @discardableResult
     private func dequeuePendingIfPossible(
-        queue: any EffectQueueProtocol,
+        queue: any EffectQueue,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?

--- a/Sources/ActomatonEffect/Internal/_EffectID.swift
+++ b/Sources/ActomatonEffect/Internal/_EffectID.swift
@@ -1,10 +1,10 @@
 /// Effect identifier for manual cancellation via `Effect.cancel`.
 struct _EffectID: Hashable, Sendable
 {
-    /// Raw value that conforms to `EffectIDProtocol`.
-    let value: any EffectIDProtocol
+    /// Raw value that conforms to `EffectID`.
+    let value: any EffectID
 
-    init(_ value: some EffectIDProtocol)
+    init(_ value: some EffectID)
     {
         self.value = value
     }

--- a/Sources/ActomatonEffect/Internal/_EffectQueue.swift
+++ b/Sources/ActomatonEffect/Internal/_EffectQueue.swift
@@ -1,15 +1,15 @@
 /// Effect queue for automatic cancellation of existing tasks or suspending of new effects.
 struct _EffectQueue: Hashable, Sendable
 {
-    /// Raw value that conforms to `EffectQueueProtocol`.
-    let value: any EffectQueueProtocol
+    /// Raw value that conforms to `EffectQueue`.
+    let value: any EffectQueue
 
-    init(_ value: some EffectQueueProtocol)
+    init(_ value: some EffectQueue)
     {
         self.value = value
     }
 
-    init(_ value: any EffectQueueProtocol)
+    init(_ value: any EffectQueue)
     {
         self.value = value
     }

--- a/Sources/ActomatonTesting/TestMachine.swift
+++ b/Sources/ActomatonTesting/TestMachine.swift
@@ -3,7 +3,7 @@ import ActomatonEffect
 import CustomDump
 import XCTest
 
-/// A testing utility that wraps `MealyMachine` + `EffectManager` to provide
+/// A testing utility that wraps `MealyMachine` + `EffectQueueManager` to provide
 /// TCA-like `send` / `receive` assertions with readable diff output.
 ///
 /// ```swift
@@ -73,7 +73,7 @@ public actor TestMachine<Action, State, Environment>
         self.machine = MealyMachine(
             state: .init(current: state),
             reducer: reducer,
-            effectManager: EffectManager(effectContext: effectContext)
+            effectManager: EffectQueueManager(effectContext: effectContext)
         )
     }
 

--- a/Sources/ActomatonUI/ActomatonUI.docc/Articles/OOP-Tutorial/02-LoginLogout.md
+++ b/Sources/ActomatonUI/ActomatonUI.docc/Articles/OOP-Tutorial/02-LoginLogout.md
@@ -71,7 +71,7 @@ let reducer = Reducer { action, state, environment in
 > Important:
 これらの副作用は `return` されているだけで、まだ実行されていません！ なので、この `Reducer` は **純粋関数** です。実際には `Reducer` を純粋関数として実行した後、得られた `Effect` について Actomaton の内部で遅延評価されます（このとき初めて「現実世界における副作用」が発生します）。副作用を常に `Effect` の中に宣言することが、副作用を適切に管理・設計する上で "とてもとても" 大切です。
 
-`Effect` の実装方法は5種類があります。特に重要なのが 3. 4. 5. です（3. は 1. と 2. を兼ねます）。
+`Effect` の実装方法は 5 種類があります。特に重要なのが 3. 4. 5. です（3. は 1. と 2. を兼ねます）。
 
 1. 副作用を発生せず、次のアクションのみを転送する
     - `Effect.nextAction()`
@@ -134,7 +134,7 @@ let mockEnvironment = Environment(
 
 前述の `environment` 実装で API 通信として定義した `login` と `logout` ですが、例えば今回の例における `forceLogout` のように、 **ログイン途中でも強制的にキャンセルしてログアウト処理に移行したい** 場合などが考えられます。
 
-このようなシナリオでは、次の2つのキャンセル処理のアプローチを検討することができます。
+このようなシナリオでは、次の 2 つのキャンセル処理のアプローチを検討することができます。
 
 1. `EffectID` による手動キャンセル
 2. `EffectQueue` による自動キャンセル
@@ -142,10 +142,10 @@ let mockEnvironment = Environment(
 ### 1. EffectID による手動キャンセル
 
 `Effect` の初期化時に識別子として `EffectID` を付与し、 `Effect.cancel(id:)` を手動で呼ぶ方法です。
-具体的には `protocol EffectIDProtocol` を使い、 `Hashable` な識別子を `Effect` の初期化時に渡します。
+具体的には `protocol EffectID` を使い、 `Hashable` な識別子を `Effect` の初期化時に渡します。
 
 ```swift
-struct LoginEffectID: EffectIDProtocol {} // 空実装でOK
+struct LoginFlowEffectID: EffectID {} // 空実装で OK
 
 let environment = Environment(
     login: { userId in
@@ -169,12 +169,12 @@ let environment = Environment(
 `EffectID` による手動キャンセルは、毎回直前に `Effect.cancel(id:)` を書く必要性があるため、時として面倒に感じることもあります。
 その場合は Actomaton の `EffectQueue` を使った、より高度な副作用管理システムを試してみて下さい。
 
-`EffectID` と同様、`EffectQueue` もまた Hashable ベースの識別子として、 `protocol EffectQueueProtocol` を採用することで作成できます。
-今回の例では、その中でも最も利用頻度の高い `Newest1EffectQueueProtocol` サブプロトコルを使います。
-これは **最新1件の副作用のみを実行し、直前までに同じキューで登録されていた副作用をすべてキャンセルする** というキューです。
+`EffectID` と同様、`EffectQueue` もまた Hashable ベースの識別子として、 `protocol EffectQueue` を採用することで作成できます。
+今回の例では、その中でも最も利用頻度の高い `Newest1EffectQueue` サブプロトコルを使います。
+これは **最新 1 件の副作用のみを実行し、直前までに同じキューで登録されていた副作用をすべてキャンセルする** というキューです。
 
 ```swift
-struct LoginFlowEffectQueue: Newest1EffectQueueProtocol {} // 空実装でOK
+struct LoginFlowEffectQueue: Newest1EffectQueue {} // 空実装で OK
 
 let environment = Environment(
     login: { userId in
@@ -197,9 +197,9 @@ let environment = Environment(
 > Important:
 > `EffectQueue` の種類には：
 > 
-> - `Newest1EffectQueueProtocol` (Rx.flatMapLatest)
-> - `Oldest1DiscardNewEffectQueueProtocol` (Rx.flatMapFirst)
-> - `Oldest1SuspendNewEffectQueueProtocol` (Rx.concat)
+> - `Newest1EffectQueue` (Rx.flatMapLatest)
+> - `Oldest1DiscardNewEffectQueue` (Rx.flatMapFirst)
+> - `Oldest1SuspendNewEffectQueue` (Rx.concat)
 > 
 > などがビルトインで定義されており、カスタムで最大同時実行数の設定もできます。
 

--- a/Tests/ActomatonCoreTests/MealyReducerTests.swift
+++ b/Tests/ActomatonCoreTests/MealyReducerTests.swift
@@ -138,7 +138,7 @@ private struct WrapperAction: Sendable
 }
 
 /// Minimal effect manager for `String` output, used only in `test_map_output`.
-private final class StringEffectManager<Action: Sendable, State>: EffectManagerProtocol
+private final class StringEffectManager<Action: Sendable, State>: EffectManager
 {
     typealias Output = String
 

--- a/Tests/ActomatonTests/EffectCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectCancellationTests.swift
@@ -35,8 +35,8 @@ final class EffectCancellationTests: MainTestCase
     {
         flags = Flags()
 
-        struct EffectID1To2: EffectIDProtocol {}
-        struct EffectID2To3: EffectIDProtocol {}
+        struct EffectID1To2: EffectID {}
+        struct EffectID2To3: EffectID {}
 
         let actomaton = Actomaton<Action, State>(
             state: ._1,

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Combine
 #endif
 
-/// Tests for `Newest1EffectQueueProtocol` where previous effect will be automatically cancelled by the next effect.
+/// Tests for `Newest1EffectQueue` where previous effect will be automatically cancelled by the next effect.
 final class EffectIDAutoCancellationTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -35,7 +35,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
     {
         flags = Flags()
 
-        struct Newest1EffectQueue: Newest1EffectQueueProtocol {}
+        struct TestNewest1EffectQueue: Newest1EffectQueue {}
 
         let actomaton = Actomaton<Action, State>(
             state: ._1,
@@ -45,7 +45,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
                     guard state == ._1 else { return .empty }
 
                     state = ._2
-                    return Effect(queue: Newest1EffectQueue()) { context in
+                    return Effect(queue: TestNewest1EffectQueue()) { context in
                         return try await context.clock.sleep(for: .ticks(1)) {
                             return ._2To3
                         } ifCancelled: {
@@ -59,7 +59,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
                     guard state == ._2 else { return .empty }
 
                     state = ._3
-                    return Effect(queue: Newest1EffectQueue()) { context in
+                    return Effect(queue: TestNewest1EffectQueue()) { context in
                         return try await context.clock.sleep(for: .ticks(1)) {
                             return ._3To4
                         } ifCancelled: {
@@ -77,7 +77,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
 
                 case ._toEnd:
                     state = ._end
-                    return Effect(queue: Newest1EffectQueue()) { context in
+                    return Effect(queue: TestNewest1EffectQueue()) { context in
                         try await context.clock.sleep(for: .ticks(1))
                         return nil
                     }

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -8,7 +8,7 @@ import Combine
 /// Tests for `EffectQueueDelay`.
 final class EffectQueueDelayTests: MainTestCase
 {
-    private func makeActomaton<Queue: EffectQueueProtocol>(
+    private func makeActomaton<Queue: EffectQueue>(
         queue: Queue,
         effectTime: TestDuration
     ) -> (Actomaton<Action, State>, startedIDs: ResultsCollector<String>, cancelledIDs: ResultsCollector<String>)
@@ -21,7 +21,7 @@ final class EffectQueueDelayTests: MainTestCase
             reducer: Reducer { action, state, _ in
                 switch action {
                 case let .fetch(id):
-                    return Effect(id: EffectID(name: "running \(id)"), queue: queue) { context in
+                    return Effect(id: DelayEffectID(name: "running \(id)"), queue: queue) { context in
                         // NOTE: Due to `queue`'s delay, this scope may run at delayed schedule time.
 
                         print("Start: \(id), Task.isCancelled = \(Task.isCancelled)")
@@ -247,12 +247,12 @@ private struct State: Equatable
     var finishedIDs: Set<String> = []
 }
 
-private struct EffectID: EffectIDProtocol
+private struct DelayEffectID: EffectID
 {
     var name: String
 }
 
-private struct DelayedEffectQueue: EffectQueueProtocol
+private struct DelayedEffectQueue: EffectQueue
 {
     let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
@@ -264,7 +264,7 @@ private struct DelayedEffectQueue: EffectQueueProtocol
     }
 }
 
-private struct DelayedNewest2EffectQueue: EffectQueueProtocol
+private struct DelayedNewest2EffectQueue: EffectQueue
 {
     let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
@@ -276,7 +276,7 @@ private struct DelayedNewest2EffectQueue: EffectQueueProtocol
     }
 }
 
-private struct DelayedOldest2SuspendNewEffectQueue: EffectQueueProtocol
+private struct DelayedOldest2SuspendNewEffectQueue: EffectQueue
 {
     let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {
@@ -288,7 +288,7 @@ private struct DelayedOldest2SuspendNewEffectQueue: EffectQueueProtocol
     }
 }
 
-private struct DelayedOldest2DiscardNewEffectQueue: EffectQueueProtocol
+private struct DelayedOldest2DiscardNewEffectQueue: EffectQueue
 {
     let delay: TestDuration
     var effectQueuePolicy: EffectQueuePolicy {

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -29,7 +29,7 @@ final class LoginLogoutTests: MainTestCase
     {
         flags = Flags()
 
-        struct LoginFlowEffectQueue: Newest1EffectQueueProtocol {}
+        struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
         let actomaton = Actomaton<Action, State>(
             state: .loggedOut,

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Combine
 #endif
 
-/// Tests for `Effect.cancel` to cancel pending effects by `Oldest1SuspendNewEffectQueueProtocol`.
+/// Tests for `Effect.cancel` to cancel pending effects by `Oldest1SuspendNewEffectQueue`.
 final class PendingEffectCancellationTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -42,19 +42,19 @@ final class PendingEffectCancellationTests: MainTestCase
     {
         flags = Flags()
 
-        struct EffectID: EffectIDProtocol
+        struct CancelEffectID: EffectID
         {
             let name: String
         }
 
-        struct Oldest1SuspendNewEffectQueue: Oldest1SuspendNewEffectQueueProtocol {}
+        struct TestOldest1SuspendNewEffectQueue: Oldest1SuspendNewEffectQueue {}
 
         let actomaton = Actomaton<Action, State>(
             state: .init(),
             reducer: Reducer { [flags] action, _, _ in
                 switch action {
                 case .fetch1:
-                    return Effect(id: EffectID(name: "1"), queue: Oldest1SuspendNewEffectQueue()) { context in
+                    return Effect(id: CancelEffectID(name: "1"), queue: TestOldest1SuspendNewEffectQueue()) { context in
                         return try await context.clock.sleep(for: .ticks(1)) {
                             return ._didFetch1
                         } ifCancelled: {
@@ -65,7 +65,7 @@ final class PendingEffectCancellationTests: MainTestCase
                     }
 
                 case .fetch2:
-                    return Effect(id: EffectID(name: "2"), queue: Oldest1SuspendNewEffectQueue()) { context in
+                    return Effect(id: CancelEffectID(name: "2"), queue: TestOldest1SuspendNewEffectQueue()) { context in
                         return try await context.clock.sleep(for: .ticks(1)) {
                             return ._didFetch2
                         } ifCancelled: {
@@ -85,7 +85,7 @@ final class PendingEffectCancellationTests: MainTestCase
                     return Effect.fireAndForget { await flags.mark(result2: .completed) }
 
                 case .cancelAll:
-                    return Effect.cancel(ids: { $0 is EffectID })
+                    return Effect.cancel(ids: { $0 is CancelEffectID })
                 }
             },
             effectContext: effectContext

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Combine
 #endif
 
-/// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runNewest(maxCount: n)`.
+/// Tests for `EffectQueue` with `EffectQueuePolicy.runNewest(maxCount: n)`.
 final class RunNewestDiscardOldTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -16,7 +16,7 @@ final class RunNewestDiscardOldTests: MainTestCase
     {
         self.resultsCollector = ResultsCollector<Int>()
 
-        struct NewestEffectQueue: EffectQueueProtocol
+        struct NewestEffectQueue: EffectQueue
         {
             var maxCount: Int
 

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Combine
 #endif
 
-/// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
+/// Tests for `EffectQueue` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
 final class RunOldestDiscardNewTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -16,7 +16,7 @@ final class RunOldestDiscardNewTests: MainTestCase
     {
         self.resultsCollector = ResultsCollector<Int>()
 
-        struct OldestDiscardNewEffectQueue: EffectQueueProtocol
+        struct OldestDiscardNewEffectQueue: EffectQueue
         {
             var maxCount: Int
 

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Combine
 #endif
 
-/// Tests for `EffectQueueProtocol` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
+/// Tests for `EffectQueue` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
 final class RunOldestSuspendNewTests: MainTestCase
 {
     fileprivate var actomaton: Actomaton<Action, State>!
@@ -16,7 +16,7 @@ final class RunOldestSuspendNewTests: MainTestCase
     {
         self.resultsCollector = ResultsCollector<Int>()
 
-        struct OldestSuspendNewEffectQueue: EffectQueueProtocol
+        struct OldestSuspendNewEffectQueue: EffectQueue
         {
             var maxCount: Int
 

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -12,7 +12,7 @@ final class TimerTests: MainTestCase
 
     override func setUp() async throws
     {
-        struct TimerID: EffectIDProtocol {}
+        struct TimerID: EffectID {}
 
         let timerEffect = Effect(id: TimerID(), sequence: { context in
             AsyncStream<()> { continuation in

--- a/Tests/ReadMeTests/ReadMeTests.swift
+++ b/Tests/ReadMeTests/ReadMeTests.swift
@@ -55,7 +55,7 @@ private func readMe1_4() async throws
         let fetch: @Sendable (_ id: String) async throws -> Data
     }
 
-    struct DelayedEffectQueue: EffectQueueProtocol {
+    struct DelayedEffectQueue: EffectQueue {
         // First 3 effects will run concurrently, and other sent effects will be suspended.
         var effectQueuePolicy: EffectQueuePolicy {
             .runOldest(maxCount: 3, .suspendNew)


### PR DESCRIPTION
## Summary
- Remove `Protocol` suffix from all protocol names, following Swift API Design Guidelines:
  - `EffectIDProtocol` → `EffectID`
  - `EffectQueueProtocol` → `EffectQueue`
  - `Newest1EffectQueueProtocol` → `Newest1EffectQueue`
  - `Oldest1DiscardNewEffectQueueProtocol` → `Oldest1DiscardNewEffectQueue`
  - `Oldest1SuspendNewEffectQueueProtocol` → `Oldest1SuspendNewEffectQueue`
  - `EffectManagerProtocol` → `EffectManager`
- Rename `class EffectManager` → `class EffectQueueManager` (reflects its actual responsibility: queue-based effect lifecycle)
- Fix pre-existing doc issues: broken GitHub URL in EffectQueue example, inconsistent `LoginEffectID`/`LoginFlowEffectID` in OOP tutorial

Follows #123 which internalized the wrapper structs as `_EffectID`/`_EffectQueue`, freeing the clean names for the protocols.
