### PR TITLE
Add Effect.updateQueue for dynamic queue metadata updates

### DIFF
--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -341,6 +341,23 @@ extension Effect
     {
         Effect(kinds: [.cancel { AnyHashable($0) == AnyHashable(id) }])
     }
+
+    // MARK: - updateQueue
+
+    /// Updates queue metadata (e.g. dynamic `maxCount`) and re-evaluates pending effects
+    /// without creating any async task.
+    ///
+    /// Use this when changing queue capacity via state without sending a new effect:
+    /// ```swift
+    /// case let .updateMaxConcurrent(n):
+    ///     state.maxConcurrent = n
+    ///     return .updateQueue(DynamicQueue(maxCount: n))
+    /// ```
+    public static func updateQueue<Queue>(_ queue: Queue) -> Effect<Action>
+        where Queue: EffectQueue
+    {
+        Effect(kinds: [.updateQueue(queue)])
+    }
 }
 
 // MARK: - Monoid
@@ -388,6 +405,9 @@ extension Effect
 
             case let .cancel(predicate):
                 return .cancel(predicate)
+
+            case let .updateQueue(queue):
+                return .updateQueue(queue)
             }
         })
     }
@@ -409,6 +429,9 @@ extension Effect
 
             case let .cancel(predicate):
                 return .cancel(predicate)
+
+            case .updateQueue:
+                return kind
             }
         })
     }
@@ -430,6 +453,12 @@ extension Effect
 
             case let .cancel(predicate):
                 return .cancel(predicate)
+
+            case let .updateQueue(queue):
+                if let newQueue = f(queue) {
+                    return .updateQueue(newQueue)
+                }
+                return kind
             }
         })
     }
@@ -471,6 +500,9 @@ extension Effect
         /// Cancellation effect with filtering effect IDs by a predicate.
         case cancel(@Sendable (any EffectID) -> Bool)
 
+        /// Updates queue metadata (e.g. dynamic `maxCount`) and re-evaluates pending effects.
+        case updateQueue(any EffectQueue)
+
         internal var single: Single?
         {
             guard case let .single(value) = self else { return nil }
@@ -500,6 +532,8 @@ extension Effect
                 return nil
             case .cancel:
                 return nil
+            case .updateQueue:
+                return nil
             }
         }
 
@@ -514,6 +548,8 @@ extension Effect
                 return nil
             case .cancel:
                 return nil
+            case let .updateQueue(queue):
+                return queue
             }
         }
     }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -28,6 +28,10 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// Tracked latest effect start time for delayed effects calculation.
     private var latestEffectTime: [_EffectQueue: AnyClock<Duration>.Instant] = [:]
 
+    /// Latest known queue per effect queue, updated on each new effect submission.
+    /// Used to retrieve the most recent `effectQueuePolicy` (e.g. dynamic `maxCount`) at dequeue time.
+    private var latestQueue: [_EffectQueue: any EffectQueue] = [:]
+
     // MARK: - Callbacks (set via setUp)
 
     private var sendAction: (@Sendable (Action, TaskPriority?, Bool) async -> Task<(), any Error>?)?
@@ -136,11 +140,15 @@ package final class EffectQueueManager<Action, State>: EffectManager
                 Debug.print("[handleTaskCompleted] Remove completed queue-task: \(queue) \(removingIndex)")
                 queuedRunningTasks[effectQueue]?.remove(at: removingIndex)
 
+                // Use the latest known queue to get the most recent policy/maxCount,
+                // falling back to the completing task's queue.
+                let currentQueue = latestQueue[effectQueue] ?? queue
+
                 // Try to dequeue pending effects.
-                switch queue.effectQueuePolicy {
+                switch currentQueue.effectQueuePolicy {
                 case .runOldest(_, .suspendNew):
                     dequeuePendingIfPossible(
-                        queue: queue,
+                        queue: currentQueue,
                         priority: priority,
                         tracksFeedbacks: tracksFeedbacks
                     )
@@ -201,6 +209,16 @@ package final class EffectQueueManager<Action, State>: EffectManager
         case let .cancel(predicate):
             cancelEffects(predicate: predicate)
             return []
+
+        case let .updateQueue(queue):
+            latestQueue[_EffectQueue(queue)] = queue
+
+            dequeuePendingIfPossible(
+                queue: queue,
+                priority: priority,
+                tracksFeedbacks: tracksFeedbacks
+            )
+            return []
         }
     }
 
@@ -213,6 +231,9 @@ package final class EffectQueueManager<Action, State>: EffectManager
         guard let queue = effectKind.queue else { return true }
 
         let effectQueue = _EffectQueue(queue)
+
+        // Track the latest queue so dequeue logic can use the most recent policy/maxCount.
+        latestQueue[effectQueue] = queue
 
         switch queue.effectQueuePolicy {
         case let .runNewest(maxCount):
@@ -323,7 +344,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
             )
             return task
 
-        case .next, .cancel:
+        case .next, .cancel, .updateQueue:
             return nil
         }
     }
@@ -428,28 +449,36 @@ package final class EffectQueueManager<Action, State>: EffectManager
         return nextTime
     }
 
-    /// Dequeues a pending effect if possible (for `runOldest-suspendNew` policy).
-    @discardableResult
+    /// Dequeues pending effects up to the current capacity (for `runOldest-suspendNew` policy).
+    ///
+    /// Uses the latest known `maxCount` so that dynamic capacity increases
+    /// are reflected immediately, rather than draining one-at-a-time.
     private func dequeuePendingIfPossible(
         queue: any EffectQueue,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
-    ) -> Task<(), any Error>?
+    )
     {
+        guard case let .runOldest(maxCount, _) = queue.effectQueuePolicy else { return }
+
         let effectQueue = _EffectQueue(queue)
 
-        guard pendingEffectKinds[effectQueue]?.isEmpty == false else { return nil }
+        while pendingEffectKinds[effectQueue]?.isEmpty == false {
+            let currentCount = queuedRunningTasks[effectQueue]?.count ?? 0
+            guard currentCount < maxCount else { break }
 
-        let kind = pendingEffectKinds[effectQueue]!.removeFirst()
-        let time = calculateEffectTime(queue: queue)
-        Debug.print("[dequeuePendingIfPossible] Dequeued pending effect")
+            let kind = pendingEffectKinds[effectQueue]!.removeFirst()
+            let time = calculateEffectTime(queue: queue)
 
-        return makeTask(
-            effectKind: kind,
-            time: time,
-            priority: priority,
-            tracksFeedbacks: tracksFeedbacks
-        )
+            Debug.print("[dequeuePendingIfPossible] Dequeued pending effect (running: \(currentCount), maxCount: \(maxCount))")
+
+            _ = makeTask(
+                effectKind: kind,
+                time: time,
+                priority: priority,
+                tracksFeedbacks: tracksFeedbacks
+            )
+        }
     }
 
     /// Cancels `effectKind`'s `single` or `sequence` immediately
@@ -469,7 +498,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
                 _ = try await sequence.sequence(context)
             }
             .cancel() // Cancel immediately.
-        case .next, .cancel:
+        case .next, .cancel, .updateQueue:
             return
         }
     }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -470,7 +470,10 @@ package final class EffectQueueManager<Action, State>: EffectManager
             let kind = pendingEffectKinds[effectQueue]!.removeFirst()
             let time = calculateEffectTime(queue: queue)
 
-            Debug.print("[dequeuePendingIfPossible] Dequeued pending effect (running: \(currentCount), maxCount: \(maxCount))")
+            Debug
+                .print(
+                    "[dequeuePendingIfPossible] Dequeued pending effect (running: \(currentCount), maxCount: \(maxCount))"
+                )
 
             _ = makeTask(
                 effectKind: kind,

--- a/Tests/ActomatonTests/DynamicQueueTests.swift
+++ b/Tests/ActomatonTests/DynamicQueueTests.swift
@@ -1,0 +1,282 @@
+@testable import Actomaton
+import XCTest
+
+#if !DISABLE_COMBINE && canImport(Combine)
+import Combine
+#endif
+
+/// Tests for dynamic `EffectQueue` where `maxCount` changes at runtime.
+final class DynamicQueueTests: MainTestCase
+{
+    fileprivate var actomaton: Actomaton<Action, State>!
+
+    fileprivate var resultsCollector: ResultsCollector<String> = .init()
+
+    override func setUp() async throws
+    {
+        self.resultsCollector = ResultsCollector<String>()
+
+        let actomaton = Actomaton<Action, State>(
+            state: State(),
+            reducer: Reducer { [resultsCollector] action, state, _ in
+                switch action {
+                case let .fetch(id):
+                    state.fetchCount += 1
+
+                    let queue = DynamicSuspendQueue(maxCount: state.maxConcurrent)
+                    return Effect(queue: queue) { context in
+                        return try await context.clock.sleep(for: .ticks(3)) {
+                            Debug.print("Effect \(id) success")
+                            await resultsCollector.append("completed:\(id)")
+                            return .effectCompleted
+                        } ifCancelled: {
+                            Debug.print("Effect \(id) cancelled")
+                            await resultsCollector.append("cancelled:\(id)")
+                            return nil
+                        }
+                    }
+
+                case let .updateMaxConcurrent(n):
+                    state.maxConcurrent = n
+                    return .empty
+
+                case let .updateMaxConcurrentWithQueue(n):
+                    state.maxConcurrent = n
+                    return .updateQueue(DynamicSuspendQueue(maxCount: n))
+
+                case .effectCompleted:
+                    state.effectCompletedCount += 1
+                    return .empty
+                }
+            },
+            effectContext: effectContext
+        )
+        self.actomaton = actomaton
+    }
+
+    // MARK: - Tests for latestQueue fix (dequeue uses latest maxCount)
+
+    /// When maxCount increases and a running task completes, pending effects should
+    /// be dequeued up to the new capacity (not just one-at-a-time).
+    func test_dynamicMaxCount_increaseViaNewEffect() async throws
+    {
+        assertEqual(await actomaton.state, State())
+
+        // Start with maxConcurrent = 1.
+        // Send 4 fetches: 1 runs, 3 are pending.
+        await actomaton.send(.fetch(id: "A"))
+        await actomaton.send(.fetch(id: "B"))
+        await actomaton.send(.fetch(id: "C"))
+        await actomaton.send(.fetch(id: "D"))
+
+        assertEqual(await actomaton.state.fetchCount, 4)
+        assertEqual(await actomaton.state.effectCompletedCount, 0)
+
+        // Increase maxConcurrent to 4.
+        // Then send a new fetch so that `checkQueuePolicy` updates `latestQueue`.
+        await actomaton.send(.updateMaxConcurrent(4))
+        await actomaton.send(.fetch(id: "E"))
+        assertEqual(await actomaton.state.fetchCount, 5)
+
+        // Let effect A complete. With maxCount now 4, pending B, C, D should all dequeue.
+        await clock.advance(by: .ticks(3.5))
+
+        // A completed + B, C, D dequeued and started.
+        // E also started (was under capacity when sent).
+        let completedCount1 = await actomaton.state.effectCompletedCount
+        XCTAssertGreaterThanOrEqual(
+            completedCount1, 1,
+            "At least A should have completed."
+        )
+
+        // Let all remaining effects complete.
+        await clock.advance(by: .ticks(7))
+
+        assertEqual(
+            await actomaton.state.effectCompletedCount, 5,
+            "All 5 effects should have completed."
+        )
+
+        let results = await resultsCollector.results
+        let completedResults = results.filter { $0.hasPrefix("completed:") }.sorted()
+        XCTAssertEqual(
+            completedResults,
+            ["completed:A", "completed:B", "completed:C", "completed:D", "completed:E"]
+        )
+    }
+
+    // MARK: - Tests for .updateQueue (no new effect needed)
+
+    /// `.updateQueue` should re-evaluate pending effects and dequeue them immediately
+    /// without requiring a new effect to be sent.
+    func test_updateQueue_dequeuePendingImmediately() async throws
+    {
+        // Start with maxConcurrent = 1.
+        // Send 3 fetches: 1 runs, 2 are pending.
+        await actomaton.send(.fetch(id: "A"))
+        await actomaton.send(.fetch(id: "B"))
+        await actomaton.send(.fetch(id: "C"))
+
+        assertEqual(await actomaton.state.fetchCount, 3)
+        assertEqual(await actomaton.state.effectCompletedCount, 0)
+
+        // Increase maxConcurrent to 3 via `.updateQueue`.
+        // This should immediately dequeue B and C (no need to wait for A to complete).
+        await actomaton.send(.updateMaxConcurrentWithQueue(3))
+
+        // Now A, B, C should all be running. Let them complete.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(
+            await actomaton.state.effectCompletedCount, 3,
+            "All 3 effects should have completed because `.updateQueue` dequeued pending effects."
+        )
+
+        let results = await resultsCollector.results
+        let completedResults = results.filter { $0.hasPrefix("completed:") }.sorted()
+        XCTAssertEqual(
+            completedResults,
+            ["completed:A", "completed:B", "completed:C"]
+        )
+    }
+
+    /// `.updateQueue` with no capacity change should not dequeue extra effects.
+    func test_updateQueue_sameMaxCount_noChange() async throws
+    {
+        // maxConcurrent = 1 (default).
+        await actomaton.send(.fetch(id: "A"))
+        await actomaton.send(.fetch(id: "B"))
+
+        // Send updateQueue with same maxCount.
+        await actomaton.send(.updateMaxConcurrentWithQueue(1))
+
+        // Only A should be running. B is still pending.
+        assertEqual(await actomaton.state.effectCompletedCount, 0)
+
+        // Let A complete → B dequeues.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(await actomaton.state.effectCompletedCount, 1, "Only A should have completed.")
+
+        // Let B complete.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(await actomaton.state.effectCompletedCount, 2, "Both A and B should have completed.")
+    }
+
+    /// Without `.updateQueue`, increasing maxConcurrent via state alone should NOT
+    /// dequeue pending effects until a new effect or task completion triggers it.
+    func test_withoutUpdateQueue_pendingEffectsStayPending() async throws
+    {
+        // maxConcurrent = 1 (default).
+        await actomaton.send(.fetch(id: "A"))
+        await actomaton.send(.fetch(id: "B"))
+        await actomaton.send(.fetch(id: "C"))
+
+        // Increase maxConcurrent but do NOT send `.updateQueue`.
+        await actomaton.send(.updateMaxConcurrent(3))
+
+        // B, C are still pending because no re-evaluation was triggered.
+        assertEqual(await actomaton.state.effectCompletedCount, 0)
+
+        // Let A complete → dequeue uses latestQueue from last `checkQueuePolicy`.
+        // Since no new effect updated latestQueue after maxConcurrent changed,
+        // only 1 pending effect dequeues (old maxCount=1 in latestQueue).
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(
+            await actomaton.state.effectCompletedCount, 1,
+            "Only A completed. Without `.updateQueue`, latestQueue still has old maxCount."
+        )
+
+        // Let B complete → C dequeues.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(await actomaton.state.effectCompletedCount, 2)
+
+        // Let C complete.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(await actomaton.state.effectCompletedCount, 3)
+    }
+
+    /// Decrease maxConcurrent via `.updateQueue` should not affect already-running tasks,
+    /// but should prevent excess pending effects from being dequeued.
+    func test_updateQueue_decreaseMaxCount() async throws
+    {
+        // Start with maxConcurrent = 3.
+        await actomaton.send(.updateMaxConcurrentWithQueue(3))
+
+        // Send 5 fetches: 3 run, 2 are pending.
+        await actomaton.send(.fetch(id: "A"))
+        await actomaton.send(.fetch(id: "B"))
+        await actomaton.send(.fetch(id: "C"))
+        await actomaton.send(.fetch(id: "D"))
+        await actomaton.send(.fetch(id: "E"))
+
+        assertEqual(await actomaton.state.fetchCount, 5)
+
+        // Decrease maxConcurrent to 1. Already running A, B, C are not cancelled.
+        await actomaton.send(.updateMaxConcurrentWithQueue(1))
+
+        // Let A, B, C complete.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(
+            await actomaton.state.effectCompletedCount, 3,
+            "A, B, C should have completed."
+        )
+
+        // After 3 completions with maxCount=1, only 1 pending should dequeue at a time.
+        // D should now be running.
+
+        // Let D complete → E dequeues.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(await actomaton.state.effectCompletedCount, 4)
+
+        // Let E complete.
+        await clock.advance(by: .ticks(3.5))
+
+        assertEqual(await actomaton.state.effectCompletedCount, 5)
+    }
+}
+
+// MARK: - Private
+
+private enum Action: Sendable
+{
+    case fetch(id: String)
+    case updateMaxConcurrent(Int)
+    case updateMaxConcurrentWithQueue(Int)
+    case effectCompleted
+}
+
+private struct State: Equatable, Sendable
+{
+    var fetchCount: Int = 0
+    var maxConcurrent: Int = 1
+    var effectCompletedCount: Int = 0
+}
+
+/// Dynamic queue where `maxCount` can change at runtime.
+/// Hash and equality ignore `maxCount` so all instances map to the same queue in EffectManager.
+private struct DynamicSuspendQueue: EffectQueue
+{
+    var maxCount: Int
+
+    var effectQueuePolicy: EffectQueuePolicy
+    {
+        .runOldest(maxCount: maxCount, .suspendNew)
+    }
+
+    func hash(into hasher: inout Hasher)
+    {
+        hasher.combine("DynamicSuspendQueue")
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool
+    {
+        true
+    }
+}

--- a/Tests/TestFixtures/Fixtures.swift
+++ b/Tests/TestFixtures/Fixtures.swift
@@ -90,7 +90,7 @@ public func assertEqual<T>(
 
 // MARK: - ResultsCollector
 
-public actor ResultsCollector<T>
+public actor ResultsCollector <T>
 {
     public private(set) var results: [T] = []
 

--- a/Tests/TestFixtures/Fixtures.swift
+++ b/Tests/TestFixtures/Fixtures.swift
@@ -90,7 +90,7 @@ public func assertEqual<T>(
 
 // MARK: - ResultsCollector
 
-public actor ResultsCollector <T>
+public actor ResultsCollector<T>
 {
     public private(set) var results: [T] = []
 


### PR DESCRIPTION
## Summary
- Add `Effect.updateQueue(_:)` that updates queue parameters (e.g. `maxCount`) at runtime without spawning async tasks, enabling dynamic concurrency control
- Update `EffectQueueManager` to handle `.updateQueue` kind by re-evaluating and dequeuing pending effects against the new queue policy
- Add comprehensive `DynamicQueueTests` covering increase/decrease of `maxCount`, no-op same count, and comparison with state-only updates (without `.updateQueue`)

## Test plan
- [x] `DynamicQueueTests.test_dynamicMaxCount_increaseViaNewEffect` — capacity increase via new effect triggers dequeue
- [x] `DynamicQueueTests.test_updateQueue_dequeuePendingImmediately` — `.updateQueue` immediately dequeues pending effects
- [x] `DynamicQueueTests.test_updateQueue_sameMaxCount_noChange` — same maxCount is a no-op
- [x] `DynamicQueueTests.test_withoutUpdateQueue_pendingEffectsStayPending` — without `.updateQueue`, pending effects stay pending
- [x] `DynamicQueueTests.test_updateQueue_decreaseMaxCount` — decrease respects new capacity for future dequeues
