### PR TITLE
Add missing DocC targets for ActomatonCore, ActomatonEffect, and ActomatonTesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,12 @@ _docc:
 		--allow-writing-to-directory $(DOCBUILD_OUTPUT_DIR) \
 		generate-documentation \
 		--enable-experimental-combined-documentation \
+		--target ActomatonCore \
+		--target ActomatonEffect \
 		--target Actomaton \
 		--target ActomatonUI \
 		--target ActomatonDebugging \
+		--target ActomatonTesting \
 		--transform-for-static-hosting \
 		--hosting-base-path $(DOC_HOSTING_BASE_PATH) \
 		--output-path $(DOCBUILD_OUTPUT_DIR)


### PR DESCRIPTION
## Summary
- Add `ActomatonCore`, `ActomatonEffect`, and `ActomatonTesting` as `--target` arguments to the DocC documentation generation command in the Makefile
- These modules were missing from the combined documentation build, resulting in incomplete API documentation

## Test plan
- [x] Verify `make docc` generates documentation that includes ActomatonCore, ActomatonEffect, and ActomatonTesting modules
