### PR TITLE
Conform EffectManager to SendableMetatype

### DIFF
--- a/Sources/ActomatonCore/EffectManager.swift
+++ b/Sources/ActomatonCore/EffectManager.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// The conformer does NOT own the reducer or state — those are managed by ``MealyMachine``.
 /// It only receives the reducer's output and processes it (e.g., creating tasks, managing queues).
-public protocol EffectManager<Action, State, Output>
+public protocol EffectManager<Action, State, Output>: SendableMetatype
 {
     associatedtype Action
     associatedtype State

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -102,27 +102,10 @@ public actor MealyMachine<Action, State, Output>
         self.executingActor = executingActor
         self.willChangeState = willChangeState
 
-        typealias NonSendablePerformIsolated = (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffM) -> Void
-        ) async -> Void
-
-        // swiftformat:disable:next wrapAttributes
-        typealias SendablePerformIsolated = @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffM) -> Void
-        ) async -> Void
-
-        // Create as non-`@Sendable` closure to avoid too conservative `SendableMetatype` check of `EffM`,
-        // then `unsafeBitCast` to `@Sendable` for passing to `effectManager.setUp()`.
-        // This is considered as a safe operation because the only capture is `[weak self]` which is `Sendable`.
-        let performIsolated: SendablePerformIsolated = unsafeBitCast(
-            { [weak self] f in
-                await self?.performIsolated(f)
-            } as NonSendablePerformIsolated,
-            to: SendablePerformIsolated.self
-        )
-
         effectManager.setUp(
-            performIsolated: performIsolated,
+            performIsolated: { [weak self] f in
+                await self?.performIsolated(f)
+            },
             sendAction: { [weak self] action, priority, tracksFeedbacks in
                 await self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
             }


### PR DESCRIPTION
## Summary
- Add `SendableMetatype` conformance to `EffectManager` protocol so the generic `EffM` parameter carries the metatype-Sendable guarantee
- Remove the `unsafeBitCast` workaround in `MealyMachine.init` that was previously needed to bypass the too-conservative `SendableMetatype` check on `EffM` — `effectManager.setUp(performIsolated:sendAction:)` can now be called directly with an inline `@Sendable` closure

## Test plan
- [x] Existing test suite passes
