### PR TITLE
Make EffectManager ~Copyable and convert EffectQueueManager to struct

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,10 @@ let package = Package(
     targets: [
         .target(
             name: "ActomatonCore",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: [
+                // .define("ACTOMATON_ISOLATED_DEINIT_WORKAROUND"),
+            ]
         ),
         .target(
             name: "ActomatonEffect",

--- a/Sources/ActomatonCore/EffectManager.swift
+++ b/Sources/ActomatonCore/EffectManager.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// The conformer does NOT own the reducer or state — those are managed by ``MealyMachine``.
 /// It only receives the reducer's output and processes it (e.g., creating tasks, managing queues).
-public protocol EffectManager<Action, State, Output>: SendableMetatype
+public protocol EffectManager<Action, State, Output>: ~Copyable, SendableMetatype
 {
     associatedtype Action
     associatedtype State
@@ -24,9 +24,9 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
     /// class.
     ///   - sendAction:
     ///     Closure to send feedback actions back to the owning actor.
-    func setUp(
+    mutating func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, Self) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, inout Self) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -36,7 +36,7 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
     ///
     /// Called by ``MealyMachine/send(_:priority:tracksFeedbacks:)`` before
     /// ``processOutput(_:priority:tracksFeedbacks:)``.
-    func preprocessOutput(
+    mutating func preprocessOutput(
         _ output: Output,
         runReducer: (Action) -> Output
     ) -> Output
@@ -44,12 +44,12 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
     /// Process reducer output, creating and managing tasks as needed.
     ///
     /// Called by ``MealyMachine`` after running the reducer and resolving synchronous actions.
-    func processOutput(
+    mutating func processOutput(
         _ output: Output,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?
 
     /// Cancel all running tasks and drain pending effects.
-    func shutDown()
+    mutating func shutDown()
 }

--- a/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
@@ -15,9 +15,9 @@ public struct ActionEffectManager<Action, State>: EffectManager
 
     // MARK: - EffectManager
 
-    public func setUp(
+    public mutating func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, ActionEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, inout ActionEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -36,7 +36,7 @@ public struct ActionEffectManager<Action, State>: EffectManager
         return remaining
     }
 
-    public func processOutput(
+    public mutating func processOutput(
         _ output: Output,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -45,6 +45,6 @@ public struct ActionEffectManager<Action, State>: EffectManager
         return nil
     }
 
-    public func shutDown()
+    public mutating func shutDown()
     {}
 }

--- a/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
@@ -10,21 +10,21 @@ public struct NoOpEffectManager<Action, State>: EffectManager
 
     // MARK: - EffectManager
 
-    public func setUp(
+    public mutating func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, NoOpEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, inout NoOpEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
     {}
 
-    public func preprocessOutput(
+    public mutating func preprocessOutput(
         _ output: Output,
         runReducer: (Action) -> Output
     )
     {}
 
-    public func processOutput(
+    public mutating func processOutput(
         _ output: Output,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -33,6 +33,6 @@ public struct NoOpEffectManager<Action, State>: EffectManager
         return nil
     }
 
-    public func shutDown()
+    public mutating func shutDown()
     {}
 }

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -30,7 +30,7 @@ public actor MealyMachine<Action, State, Output>
     ///
     /// `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` exists for non-WASI builds compiled by the
     /// Swift.org 6.2.4 toolchain, where `isolated deinit` also crashes during SIL lowering.
-    package nonisolated(unsafe) private(set) var effectManager: any EffectManager<Action, State, Output>
+    package private(set) nonisolated(unsafe) var effectManager: any EffectManager<Action, State, Output>
 #else
     /// Core manages effect lifecycle: task creation, queue policies, and cancellation.
     /// Agnostic about reducer and state mutation.

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -26,7 +26,7 @@ public actor MealyMachine<Action, State, Output>
 
     /// Core manages effect lifecycle: task creation, queue policies, and cancellation.
     /// Agnostic about reducer and state mutation.
-    package let effectManager: any EffectManager<Action, State, Output>
+    package private(set) var effectManager: any EffectManager<Action, State, Output>
 
 #if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
     /// Mirrors `effectManager` so `deinit` can shut it down without relying on
@@ -35,7 +35,7 @@ public actor MealyMachine<Action, State, Output>
     /// `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` exists for non-WASI builds that
     /// are compiled by the Swift.org 6.2.4 toolchain, where `isolated deinit`
     /// also crashes during SIL lowering.
-    private nonisolated(unsafe) let unsafeEffectManager: any EffectManager<Action, State, Output>
+    private nonisolated(unsafe) var unsafeEffectManager: any EffectManager<Action, State, Output>
 #endif
 
     /// Underlying actor that replaces `MealyMachine`'s `unownedExecutor`.
@@ -48,7 +48,7 @@ public actor MealyMachine<Action, State, Output>
     public init(
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
-        effectManager: some EffectManager<Action, State, Output>
+        effectManager: consuming some EffectManager<Action, State, Output>
     ) where Action: Sendable
     {
         self.init(
@@ -64,7 +64,7 @@ public actor MealyMachine<Action, State, Output>
         state: State,
         reducer: MealyReducer<Action, State, Environment, Output>,
         environment: Environment,
-        effectManager: some EffectManager<Action, State, Output>
+        effectManager: consuming some EffectManager<Action, State, Output>
     ) where Action: Sendable, Environment: Sendable
     {
         self.init(
@@ -82,7 +82,7 @@ public actor MealyMachine<Action, State, Output>
     package init<EffM>(
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
-        effectManager: EffM,
+        effectManager: consuming EffM,
         executingActor: any Actor,
         willChangeState: @escaping (
             _ isolation: isolated MealyMachine, _ old: State, _ new: State
@@ -95,9 +95,9 @@ public actor MealyMachine<Action, State, Output>
         self.state = state
 #endif
         self.reducer = reducer
-        self.effectManager = effectManager
+        self.effectManager = copy effectManager
 #if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
-        self.unsafeEffectManager = effectManager
+        self.unsafeEffectManager = copy effectManager
 #endif
         self.executingActor = executingActor
         self.willChangeState = willChangeState
@@ -150,15 +150,21 @@ public actor MealyMachine<Action, State, Output>
         return effectManager.processOutput(output_, priority: priority, tracksFeedbacks: tracksFeedbacks)
     }
 
-    /// Runs a block within `self`'s isolation with `EffM` force-casting.
-    /// This method is a proof that `effectManager` is owned and protected by `self`.
+    /// Runs `f` within `self`'s isolation, projecting the existential `effectManager`
+    /// back to its concrete `EffM` type so conformers can mutate themselves through `inout`.
     ///
     /// Used by ``EffectManager`` conformers to re-enter actor isolation from detached tasks.
     private func performIsolated<EffM>(
-        _ f: @Sendable (isolated any Actor, EffM) -> Void
+        _ f: @Sendable (isolated any Actor, inout EffM) -> Void
     ) where EffM: EffectManager<Action, State, Output>
     {
-        f(self, self.effectManager as! EffM)
+        withUnsafeMutablePointer(to: &self.effectManager) { ptr in
+            // Downcast `inout any EffectManager` to `inout EffM`:
+            // `as! EffM` cannot preserve `inout`, so rebind in place instead.
+            ptr.withMemoryRebound(to: EffM.self, capacity: 1) { typed in
+                f(self, &typed.pointee)
+            }
+        }
     }
 }
 

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -24,18 +24,17 @@ public actor MealyMachine<Action, State, Output>
 
     package let reducer: MealyReducer<Action, State, (), Output>
 
+#if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
+    /// `nonisolated(unsafe)` of `effectManager` so `deinit` can shut it down without relying on
+    /// `isolated deinit`, which currently crashes some Swift 6.2.4 toolchains.
+    ///
+    /// `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` exists for non-WASI builds compiled by the
+    /// Swift.org 6.2.4 toolchain, where `isolated deinit` also crashes during SIL lowering.
+    package nonisolated(unsafe) private(set) var effectManager: any EffectManager<Action, State, Output>
+#else
     /// Core manages effect lifecycle: task creation, queue policies, and cancellation.
     /// Agnostic about reducer and state mutation.
     package private(set) var effectManager: any EffectManager<Action, State, Output>
-
-#if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
-    /// Mirrors `effectManager` so `deinit` can shut it down without relying on
-    /// `isolated deinit`, which currently crashes some Swift 6.2.4 toolchains.
-    ///
-    /// `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` exists for non-WASI builds that
-    /// are compiled by the Swift.org 6.2.4 toolchain, where `isolated deinit`
-    /// also crashes during SIL lowering.
-    private nonisolated(unsafe) var unsafeEffectManager: any EffectManager<Action, State, Output>
 #endif
 
     /// Underlying actor that replaces `MealyMachine`'s `unownedExecutor`.
@@ -95,27 +94,50 @@ public actor MealyMachine<Action, State, Output>
         self.state = state
 #endif
         self.reducer = reducer
-        self.effectManager = copy effectManager
-#if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
-        self.unsafeEffectManager = copy effectManager
-#endif
         self.executingActor = executingActor
         self.willChangeState = willChangeState
 
+        let weakSelfHolder = _WeakSelfHolder<MealyMachine<Action, State, Output>>()
+
         effectManager.setUp(
-            performIsolated: { [weak self] f in
-                await self?.performIsolated(f)
+            performIsolated: { [weakSelfHolder] f in
+                await weakSelfHolder.value?.performIsolated(f)
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks in
-                await self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            sendAction: { [weakSelfHolder] action, priority, tracksFeedbacks in
+                await weakSelfHolder.value?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
             }
         )
+
+        // IMPORTANT:
+        // `self.effectManager` is assigned exactly once, with the already-`setUp` value.
+        //
+        // - The assignment happens AFTER `effectManager.setUp` because `effectManager` is `consuming`:
+        //   this assignment moves it into `self`, after which the local parameter is no longer accessible.
+        //
+        // - We cannot replace this with an early `self.effectManager = copy effectManager` followed by
+        //   in-place `self.effectManager.setUp(...)` for two separate reasons:
+        //
+        //   (1) `self.effectManager` is typed as the existential `any EffectManager<...>`. Mutating
+        //       methods cannot be called on existentials ("Member 'setUp' cannot be used on value of
+        //       type 'any EffectManager<...>'; consider using a generic constraint instead"), since
+        //       `Self` is erased. The `effectManager` parameter (typed as `EffM`) has no such
+        //       restriction, so we set up the parameter instead.
+        //
+        //   (2) Even if (1) were sidestepped by re-assigning after `setUp`, the `[weak self]` capture
+        //       inside `setUp`'s closures escapes `self` and ends the actor's phase-1 free-write
+        //       window. The second `self.effectManager = ...` would then be rejected as "Cannot access
+        //       property 'effectManager' here in nonisolated initializer". `_WeakSelfHolder` exists to
+        //       avoid this transition by routing the capture through a separate class instance, so
+        //       the single store below stays inside phase 1.
+        self.effectManager = effectManager
+
+        weakSelfHolder.value = self
     }
 
 #if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
     deinit
     {
-        unsafeEffectManager.shutDown()
+        effectManager.shutDown()
     }
 #else
     isolated deinit
@@ -158,13 +180,9 @@ public actor MealyMachine<Action, State, Output>
         _ f: @Sendable (isolated any Actor, inout EffM) -> Void
     ) where EffM: EffectManager<Action, State, Output>
     {
-        withUnsafeMutablePointer(to: &self.effectManager) { ptr in
-            // Downcast `inout any EffectManager` to `inout EffM`:
-            // `as! EffM` cannot preserve `inout`, so rebind in place instead.
-            ptr.withMemoryRebound(to: EffM.self, capacity: 1) { typed in
-                f(self, &typed.pointee)
-            }
-        }
+        var typed = self.effectManager as! EffM
+        f(self, &typed)
+        self.effectManager = typed
     }
 }
 
@@ -176,5 +194,15 @@ extension MealyMachine
     }
 }
 
+// MARK: - Private
+
 /// Underlying actor for retrieving its executor to use as `MealyMachine`'s default executor.
 private actor DefaultExecutingActor {}
+
+/// Weak holder used to capture a `MealyMachine` reference inside `EffectManager.setUp` closures
+/// without referencing `self` directly during init — see comment in `MealyMachine.init`.
+private final class _WeakSelfHolder<T>: @unchecked Sendable
+    where T: AnyObject
+{
+    weak var value: T?
+}

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// Handles task creation, queue policies (newest/oldest), effect delays, and pending effect suspension.
 /// Does NOT own the reducer or state — those are managed by ``MealyMachine``.
-package final class EffectQueueManager<Action, State>: EffectManager
+package struct EffectQueueManager<Action, State>: EffectManager
     where Action: Sendable
 {
     package typealias Output = Effect<Action>
@@ -39,7 +39,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// Closure to run a block within the owning actor's isolation for safe bookkeeping updates.
     private var performIsolated: (
         @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, inout EffectQueueManager<Action, State>) -> Void
         ) async -> Void
     )?
 
@@ -52,9 +52,9 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     // MARK: - EffectManager
 
-    package func setUp(
+    package mutating func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, inout EffectQueueManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -88,7 +88,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
         return Effect(kinds: remainingKinds)
     }
 
-    package func processOutput(
+    package mutating func processOutput(
         _ output: Effect<Action>,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -122,7 +122,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
         }
     }
 
-    private func handleTaskCompleted(
+    private mutating func handleTaskCompleted(
         id: _EffectID,
         task: Task<(), any Error>,
         queue: (any EffectQueue)?,
@@ -155,7 +155,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
         }
     }
 
-    package func shutDown()
+    package mutating func shutDown()
     {
         // Cancel all running tasks.
         for (_, tasks) in runningTasks {
@@ -176,7 +176,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     // MARK: - Private
 
-    private func processEffectKind(
+    private mutating func processEffectKind(
         _ kind: Effect<Action>.Kind,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -222,7 +222,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     }
 
     /// Checks queue policy and performs any needed task drops/suspensions.
-    private func checkQueuePolicy(
+    private mutating func checkQueuePolicy(
         effectKind: Effect<Action>.Kind,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -293,7 +293,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     }
 
     /// Creates a detached task for the given effect kind.
-    private func makeTask(
+    private mutating func makeTask(
         effectKind: Effect<Action>.Kind,
         time: AnyClock<Duration>.Instant?,
         priority: TaskPriority?,
@@ -368,7 +368,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     ///
     /// The cleanup task uses `performIsolated` to re-enter actor isolation
     /// for safe bookkeeping updates, avoiding strong capture of the actor.
-    private func enqueueTask(
+    private mutating func enqueueTask(
         _ task: Task<(), any Error>,
         id: _EffectID?,
         queue: (any EffectQueue)?,
@@ -410,7 +410,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     }
 
     /// Cancels running and pending effects matching the predicate.
-    private func cancelEffects(
+    private mutating func cancelEffects(
         predicate: @escaping @Sendable (any EffectID) -> Bool
     )
     {
@@ -439,7 +439,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// Calculates absolute effect start time for queue-based delay scheduling.
     ///
     /// Returns `nil` when the effect should run immediately without additional sleeping.
-    private func calculateEffectTime(queue: (any EffectQueue)?) -> AnyClock<Duration>.Instant?
+    private mutating func calculateEffectTime(queue: (any EffectQueue)?) -> AnyClock<Duration>.Instant?
     {
         guard let queue else { return nil }
 
@@ -471,7 +471,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// are reflected immediately, rather than draining one-at-a-time.
     /// Each dequeued effect uses its original `priority` and `tracksFeedbacks` from the `send` call,
     /// and signals `onComplete` when the task finishes so that the original `send`'s Task completes.
-    private func dequeuePendingIfPossible(
+    private mutating func dequeuePendingIfPossible(
         queue: any EffectQueue
     )
     {

--- a/Tests/ActomatonCoreTests/MealyReducerTests.swift
+++ b/Tests/ActomatonCoreTests/MealyReducerTests.swift
@@ -138,21 +138,21 @@ private struct WrapperAction: Sendable
 }
 
 /// Minimal effect manager for `String` output, used only in `test_map_output`.
-private final class StringEffectManager<Action: Sendable, State>: EffectManager
+private struct StringEffectManager<Action: Sendable, State>: EffectManager
 {
     typealias Output = String
 
     init() {}
 
-    func setUp(
+    mutating func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, StringEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, inout StringEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
     {}
 
-    func preprocessOutput(
+    mutating func preprocessOutput(
         _ output: String,
         runReducer: (Action) -> String
     ) -> String
@@ -160,7 +160,7 @@ private final class StringEffectManager<Action: Sendable, State>: EffectManager
         output
     }
 
-    func processOutput(
+    mutating func processOutput(
         _ output: String,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -169,5 +169,5 @@ private final class StringEffectManager<Action: Sendable, State>: EffectManager
         nil
     }
 
-    func shutDown() {}
+    mutating func shutDown() {}
 }


### PR DESCRIPTION
## Summary
- Add `~Copyable` to `EffectManager` and mark all protocol requirements `mutating`, so conformers can be value types that mutate themselves through `inout`
- Convert `EffectQueueManager` from `final class` to `struct` — task tracking, queue policies, and pending effects are now value-stored
- Update `setUp`'s `performIsolated` callback to take `inout Self` instead of `Self`, enabling in-place bookkeeping mutation from detached cleanup tasks
- Make `MealyMachine`'s init parameters `consuming`. `MealyMachine.init` sets up the consuming parameter and stores it into `self.effectManager` exactly once; closures capture a `_WeakSelfHolder` instead of `[weak self]` to avoid escaping `self` during init, which would end the actor's phase-1 free-write window and block the single store
- `MealyMachine.performIsolated` projects the existential `effectManager` back to its concrete `EffM` via `as! EffM` (copy-out / copy-in). An earlier in-place pointer rebind reinterpreted the existential's storage layout and corrupted memory when the value didn't fit the inline buffer
- Mark `effectManager` `nonisolated(unsafe)` only under `os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND`, so the non-isolated `deinit` on those toolchains can call `shutDown()` directly. Steady-state access still goes through actor-isolated methods
- Add `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` swiftSettings define (commented) for non-WASI builds on Swift 6.2.4 toolchains where `isolated deinit` crashes during SIL lowering
- Update `StringEffectManager` test fixture to match the new protocol shape (struct + `mutating` + `inout Self`)

## Test plan
- [x] Local `swift test` — 66 tests, 0 failures
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
