### PR TITLE
Revert ~Copyable EffectManager and struct EffectQueueManager from #129

### DIFF
--- a/Sources/ActomatonCore/EffectManager.swift
+++ b/Sources/ActomatonCore/EffectManager.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// The conformer does NOT own the reducer or state — those are managed by ``MealyMachine``.
 /// It only receives the reducer's output and processes it (e.g., creating tasks, managing queues).
-public protocol EffectManager<Action, State, Output>: ~Copyable, SendableMetatype
+public protocol EffectManager<Action, State, Output>: SendableMetatype
 {
     associatedtype Action
     associatedtype State
@@ -24,9 +24,9 @@ public protocol EffectManager<Action, State, Output>: ~Copyable, SendableMetatyp
     /// class.
     ///   - sendAction:
     ///     Closure to send feedback actions back to the owning actor.
-    mutating func setUp(
+    func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, inout Self) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, Self) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -36,7 +36,7 @@ public protocol EffectManager<Action, State, Output>: ~Copyable, SendableMetatyp
     ///
     /// Called by ``MealyMachine/send(_:priority:tracksFeedbacks:)`` before
     /// ``processOutput(_:priority:tracksFeedbacks:)``.
-    mutating func preprocessOutput(
+    func preprocessOutput(
         _ output: Output,
         runReducer: (Action) -> Output
     ) -> Output
@@ -44,12 +44,12 @@ public protocol EffectManager<Action, State, Output>: ~Copyable, SendableMetatyp
     /// Process reducer output, creating and managing tasks as needed.
     ///
     /// Called by ``MealyMachine`` after running the reducer and resolving synchronous actions.
-    mutating func processOutput(
+    func processOutput(
         _ output: Output,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?
 
     /// Cancel all running tasks and drain pending effects.
-    mutating func shutDown()
+    func shutDown()
 }

--- a/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
@@ -15,9 +15,9 @@ public struct ActionEffectManager<Action, State>: EffectManager
 
     // MARK: - EffectManager
 
-    public mutating func setUp(
+    public func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, inout ActionEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, ActionEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -36,7 +36,7 @@ public struct ActionEffectManager<Action, State>: EffectManager
         return remaining
     }
 
-    public mutating func processOutput(
+    public func processOutput(
         _ output: Output,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -45,6 +45,6 @@ public struct ActionEffectManager<Action, State>: EffectManager
         return nil
     }
 
-    public mutating func shutDown()
+    public func shutDown()
     {}
 }

--- a/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
@@ -10,21 +10,21 @@ public struct NoOpEffectManager<Action, State>: EffectManager
 
     // MARK: - EffectManager
 
-    public mutating func setUp(
+    public func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, inout NoOpEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, NoOpEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
     {}
 
-    public mutating func preprocessOutput(
+    public func preprocessOutput(
         _ output: Output,
         runReducer: (Action) -> Output
     )
     {}
 
-    public mutating func processOutput(
+    public func processOutput(
         _ output: Output,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -33,6 +33,6 @@ public struct NoOpEffectManager<Action, State>: EffectManager
         return nil
     }
 
-    public mutating func shutDown()
+    public func shutDown()
     {}
 }

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -30,11 +30,11 @@ public actor MealyMachine<Action, State, Output>
     ///
     /// `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` exists for non-WASI builds compiled by the
     /// Swift.org 6.2.4 toolchain, where `isolated deinit` also crashes during SIL lowering.
-    package private(set) nonisolated(unsafe) var effectManager: any EffectManager<Action, State, Output>
+    package nonisolated(unsafe) let effectManager: any EffectManager<Action, State, Output>
 #else
     /// Core manages effect lifecycle: task creation, queue policies, and cancellation.
     /// Agnostic about reducer and state mutation.
-    package private(set) var effectManager: any EffectManager<Action, State, Output>
+    package let effectManager: any EffectManager<Action, State, Output>
 #endif
 
     /// Underlying actor that replaces `MealyMachine`'s `unownedExecutor`.
@@ -47,7 +47,7 @@ public actor MealyMachine<Action, State, Output>
     public init(
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
-        effectManager: consuming some EffectManager<Action, State, Output>
+        effectManager: some EffectManager<Action, State, Output>
     ) where Action: Sendable
     {
         self.init(
@@ -63,7 +63,7 @@ public actor MealyMachine<Action, State, Output>
         state: State,
         reducer: MealyReducer<Action, State, Environment, Output>,
         environment: Environment,
-        effectManager: consuming some EffectManager<Action, State, Output>
+        effectManager: some EffectManager<Action, State, Output>
     ) where Action: Sendable, Environment: Sendable
     {
         self.init(
@@ -81,7 +81,7 @@ public actor MealyMachine<Action, State, Output>
     package init<EffM>(
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
-        effectManager: consuming EffM,
+        effectManager: EffM,
         executingActor: any Actor,
         willChangeState: @escaping (
             _ isolation: isolated MealyMachine, _ old: State, _ new: State
@@ -94,44 +94,18 @@ public actor MealyMachine<Action, State, Output>
         self.state = state
 #endif
         self.reducer = reducer
+        self.effectManager = effectManager
         self.executingActor = executingActor
         self.willChangeState = willChangeState
 
-        let weakSelfHolder = _WeakSelfHolder<MealyMachine<Action, State, Output>>()
-
         effectManager.setUp(
-            performIsolated: { [weakSelfHolder] f in
-                await weakSelfHolder.value?.performIsolated(f)
+            performIsolated: { [weak self] f in
+                await self?.performIsolated(f)
             },
-            sendAction: { [weakSelfHolder] action, priority, tracksFeedbacks in
-                await weakSelfHolder.value?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            sendAction: { [weak self] action, priority, tracksFeedbacks in
+                await self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
             }
         )
-
-        // IMPORTANT:
-        // `self.effectManager` is assigned exactly once, with the already-`setUp` value.
-        //
-        // - The assignment happens AFTER `effectManager.setUp` because `effectManager` is `consuming`:
-        //   this assignment moves it into `self`, after which the local parameter is no longer accessible.
-        //
-        // - We cannot replace this with an early `self.effectManager = copy effectManager` followed by
-        //   in-place `self.effectManager.setUp(...)` for two separate reasons:
-        //
-        //   (1) `self.effectManager` is typed as the existential `any EffectManager<...>`. Mutating
-        //       methods cannot be called on existentials ("Member 'setUp' cannot be used on value of
-        //       type 'any EffectManager<...>'; consider using a generic constraint instead"), since
-        //       `Self` is erased. The `effectManager` parameter (typed as `EffM`) has no such
-        //       restriction, so we set up the parameter instead.
-        //
-        //   (2) Even if (1) were sidestepped by re-assigning after `setUp`, the `[weak self]` capture
-        //       inside `setUp`'s closures escapes `self` and ends the actor's phase-1 free-write
-        //       window. The second `self.effectManager = ...` would then be rejected as "Cannot access
-        //       property 'effectManager' here in nonisolated initializer". `_WeakSelfHolder` exists to
-        //       avoid this transition by routing the capture through a separate class instance, so
-        //       the single store below stays inside phase 1.
-        self.effectManager = effectManager
-
-        weakSelfHolder.value = self
     }
 
 #if os(WASI) || ACTOMATON_ISOLATED_DEINIT_WORKAROUND
@@ -172,17 +146,15 @@ public actor MealyMachine<Action, State, Output>
         return effectManager.processOutput(output_, priority: priority, tracksFeedbacks: tracksFeedbacks)
     }
 
-    /// Runs `f` within `self`'s isolation, projecting the existential `effectManager`
-    /// back to its concrete `EffM` type so conformers can mutate themselves through `inout`.
+    /// Runs a block within `self`'s isolation with `EffM` force-casting.
+    /// This method is a proof that `effectManager` is owned and protected by `self`.
     ///
     /// Used by ``EffectManager`` conformers to re-enter actor isolation from detached tasks.
     private func performIsolated<EffM>(
-        _ f: @Sendable (isolated any Actor, inout EffM) -> Void
+        _ f: @Sendable (isolated any Actor, EffM) -> Void
     ) where EffM: EffectManager<Action, State, Output>
     {
-        var typed = self.effectManager as! EffM
-        f(self, &typed)
-        self.effectManager = typed
+        f(self, self.effectManager as! EffM)
     }
 }
 
@@ -198,11 +170,3 @@ extension MealyMachine
 
 /// Underlying actor for retrieving its executor to use as `MealyMachine`'s default executor.
 private actor DefaultExecutingActor {}
-
-/// Weak holder used to capture a `MealyMachine` reference inside `EffectManager.setUp` closures
-/// without referencing `self` directly during init — see comment in `MealyMachine.init`.
-private final class _WeakSelfHolder<T>: @unchecked Sendable
-    where T: AnyObject
-{
-    weak var value: T?
-}

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// Handles task creation, queue policies (newest/oldest), effect delays, and pending effect suspension.
 /// Does NOT own the reducer or state — those are managed by ``MealyMachine``.
-package struct EffectQueueManager<Action, State>: EffectManager
+package final class EffectQueueManager<Action, State>: EffectManager
     where Action: Sendable
 {
     package typealias Output = Effect<Action>
@@ -39,7 +39,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     /// Closure to run a block within the owning actor's isolation for safe bookkeeping updates.
     private var performIsolated: (
         @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, inout EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
         ) async -> Void
     )?
 
@@ -52,9 +52,9 @@ package struct EffectQueueManager<Action, State>: EffectManager
 
     // MARK: - EffectManager
 
-    package mutating func setUp(
+    package func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, inout EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -88,7 +88,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
         return Effect(kinds: remainingKinds)
     }
 
-    package mutating func processOutput(
+    package func processOutput(
         _ output: Effect<Action>,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -122,7 +122,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
         }
     }
 
-    private mutating func handleTaskCompleted(
+    private func handleTaskCompleted(
         id: _EffectID,
         task: Task<(), any Error>,
         queue: (any EffectQueue)?,
@@ -155,7 +155,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
         }
     }
 
-    package mutating func shutDown()
+    package func shutDown()
     {
         // Cancel all running tasks.
         for (_, tasks) in runningTasks {
@@ -176,7 +176,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
 
     // MARK: - Private
 
-    private mutating func processEffectKind(
+    private func processEffectKind(
         _ kind: Effect<Action>.Kind,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -222,7 +222,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     }
 
     /// Checks queue policy and performs any needed task drops/suspensions.
-    private mutating func checkQueuePolicy(
+    private func checkQueuePolicy(
         effectKind: Effect<Action>.Kind,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -293,7 +293,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     }
 
     /// Creates a detached task for the given effect kind.
-    private mutating func makeTask(
+    private func makeTask(
         effectKind: Effect<Action>.Kind,
         time: AnyClock<Duration>.Instant?,
         priority: TaskPriority?,
@@ -368,7 +368,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     ///
     /// The cleanup task uses `performIsolated` to re-enter actor isolation
     /// for safe bookkeeping updates, avoiding strong capture of the actor.
-    private mutating func enqueueTask(
+    private func enqueueTask(
         _ task: Task<(), any Error>,
         id: _EffectID?,
         queue: (any EffectQueue)?,
@@ -410,7 +410,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     }
 
     /// Cancels running and pending effects matching the predicate.
-    private mutating func cancelEffects(
+    private func cancelEffects(
         predicate: @escaping @Sendable (any EffectID) -> Bool
     )
     {
@@ -439,7 +439,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     /// Calculates absolute effect start time for queue-based delay scheduling.
     ///
     /// Returns `nil` when the effect should run immediately without additional sleeping.
-    private mutating func calculateEffectTime(queue: (any EffectQueue)?) -> AnyClock<Duration>.Instant?
+    private func calculateEffectTime(queue: (any EffectQueue)?) -> AnyClock<Duration>.Instant?
     {
         guard let queue else { return nil }
 
@@ -471,7 +471,7 @@ package struct EffectQueueManager<Action, State>: EffectManager
     /// are reflected immediately, rather than draining one-at-a-time.
     /// Each dequeued effect uses its original `priority` and `tracksFeedbacks` from the `send` call,
     /// and signals `onComplete` when the task finishes so that the original `send`'s Task completes.
-    private mutating func dequeuePendingIfPossible(
+    private func dequeuePendingIfPossible(
         queue: any EffectQueue
     )
     {

--- a/Tests/ActomatonCoreTests/MealyReducerTests.swift
+++ b/Tests/ActomatonCoreTests/MealyReducerTests.swift
@@ -138,21 +138,21 @@ private struct WrapperAction: Sendable
 }
 
 /// Minimal effect manager for `String` output, used only in `test_map_output`.
-private struct StringEffectManager<Action: Sendable, State>: EffectManager
+private final class StringEffectManager<Action: Sendable, State>: EffectManager
 {
     typealias Output = String
 
     init() {}
 
-    mutating func setUp(
+    func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, inout StringEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (isolated any Actor, StringEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
     {}
 
-    mutating func preprocessOutput(
+    func preprocessOutput(
         _ output: String,
         runReducer: (Action) -> String
     ) -> String
@@ -160,7 +160,7 @@ private struct StringEffectManager<Action: Sendable, State>: EffectManager
         output
     }
 
-    mutating func processOutput(
+    func processOutput(
         _ output: String,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -169,5 +169,5 @@ private struct StringEffectManager<Action: Sendable, State>: EffectManager
         nil
     }
 
-    mutating func shutDown() {}
+    func shutDown() {}
 }


### PR DESCRIPTION
## Summary

Reverts the protocol-level `~Copyable` machinery and value-type `EffectQueueManager`
introduced in #129, returning to non-mutating protocol requirements and a
`final class`-based default conformer, while keeping two incidental improvements.

### Why revert

- **No perf improvement in Actomaton's case.** The hot per-`send` path goes through
  existential dispatch + `inout` projection, both already efficient under the
  original Copyable design. `~Copyable` saved at most one retain/release pair per
  `performIsolated` callback — well below the noise floor.
- **The protocol's `~Copyable` was vestigial — it claimed a capability the framework
  couldn't actually deliver.** The protocol declared `: ~Copyable`, but every
  concrete conformer stayed Copyable, and every consumer site
  (`MealyMachine.init`, `performIsolated`) carried an implicit `Copyable` constraint.
  A user-defined `~Copyable` conformer was rejected with
  `requires that '...' conform to 'Copyable'`. Closing that gap by sprinkling
  `& ~Copyable` at consumer sites broke `MealyMachine.performIsolated`'s
  `as! EffM` projection — Swift forbids conditional casts on noncopyable
  existentials, and the only fix is to drop type erasure on the `effectManager`
  storage, which is off the table for this codebase.
- **The complexity cost was real.** `_WeakSelfHolder`, the `as! EffM` cast-out /
  `inout` mutate / write-back dance, and the long explanatory comment block in
  `MealyMachine.init` all go away with this revert.

### What's reverted

- Drop `~Copyable` and `mutating` keywords from the `EffectManager` protocol;
  `setUp`'s `performIsolated` callback takes `Self` again, not `inout Self`.
- `EffectQueueManager` returns to `final class`.
- `MealyMachine.init` drops `consuming` parameters; `[weak self]` capture replaces
  `_WeakSelfHolder`; the single-store ordering comment block is removed.
- `MealyMachine.performIsolated` returns to the simple
  `f(self, self.effectManager as! EffM)` form.
- `NoOpEffectManager`, `ActionEffectManager`, and the `StringEffectManager` test
  fixture revert to non-`mutating` impls and `Self` (not `inout Self`) callbacks.

### What's kept from #129

- **Single `effectManager` field** with conditional `nonisolated(unsafe)` (instead
  of the separate `effectManager` + `unsafeEffectManager` fields). Cleaner shape,
  independent of the `~Copyable` direction.
- **`Package.swift` `swiftSettings` stub** with the commented-out
  `ACTOMATON_ISOLATED_DEINIT_WORKAROUND` define, as a discoverable hint for users
  hitting the Swift 6.2.4 `isolated deinit` SIL crash.

## Test plan
- [x] Local `swift test` — 66 tests, 0 failures
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
