### PR TITLE
Drop unused isolated Actor parameter from EffectManager performIsolated callback

### DIFF
--- a/Sources/ActomatonCore/EffectManager.swift
+++ b/Sources/ActomatonCore/EffectManager.swift
@@ -26,7 +26,7 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
     ///     Closure to send feedback actions back to the owning actor.
     func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, Self) -> Void
+            _ runEffM: @escaping @Sendable (Self) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )

--- a/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/ActionEffectManager.swift
@@ -17,7 +17,7 @@ public struct ActionEffectManager<Action, State>: EffectManager
 
     public func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, ActionEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (ActionEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )

--- a/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
+++ b/Sources/ActomatonCore/EffectManagers/NoOpEffectManager.swift
@@ -12,7 +12,7 @@ public struct NoOpEffectManager<Action, State>: EffectManager
 
     public func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, NoOpEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (NoOpEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -151,10 +151,10 @@ public actor MealyMachine<Action, State, Output>
     ///
     /// Used by ``EffectManager`` conformers to re-enter actor isolation from detached tasks.
     private func performIsolated<EffM>(
-        _ f: @Sendable (isolated any Actor, EffM) -> Void
+        _ f: @Sendable (EffM) -> Void
     ) where EffM: EffectManager<Action, State, Output>
     {
-        f(self, self.effectManager as! EffM)
+        f(self.effectManager as! EffM)
     }
 }
 

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -39,7 +39,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// Closure to run a block within the owning actor's isolation for safe bookkeeping updates.
     private var performIsolated: (
         @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (EffectQueueManager<Action, State>) -> Void
         ) async -> Void
     )?
 
@@ -54,7 +54,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     package func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (EffectQueueManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )
@@ -397,7 +397,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
             Debug.print("[enqueueTask] Task completed, removing id-task: \(effectID)")
 
             // Re-enter actor isolation for safe bookkeeping updates.
-            await performIsolated? { _, self_ in
+            await performIsolated? { self_ in
                 self_.handleTaskCompleted(
                     id: effectID,
                     task: task,

--- a/Tests/ActomatonCoreTests/MealyReducerTests.swift
+++ b/Tests/ActomatonCoreTests/MealyReducerTests.swift
@@ -146,7 +146,7 @@ private final class StringEffectManager<Action: Sendable, State>: EffectManager
 
     func setUp(
         performIsolated: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (isolated any Actor, StringEffectManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (StringEffectManager<Action, State>) -> Void
         ) async -> Void,
         sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
     )


### PR DESCRIPTION
## Summary
- Drop the `isolated any Actor` first parameter from `EffectManager.setUp`'s `performIsolated` callback. All conformers (`ActionEffectManager`, `NoOpEffectManager`, `EffectQueueManager`, and the `StringEffectManager` test fixture) ignored it via `_` at the call site
- Update `MealyMachine.performIsolated` to match: the helper now takes `@Sendable (EffM) -> Void` instead of `@Sendable (isolated any Actor, EffM) -> Void`, and calls `f(self.effectManager as! EffM)` directly

## Test plan
- [x] Local `swift test` passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
