### PR TITLE
Add DistributedActomaton

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
             name: "ActomatonTesting",
             targets: ["ActomatonTesting"]
         ),
+        .library(
+            name: "DistributedActomaton",
+            targets: ["DistributedActomaton"]
+        ),
     ],
     dependencies: {
         var deps: [Package.Dependency] = [
@@ -88,6 +92,14 @@ let package = Package(
             ]
         ),
         .target(
+            name: "DistributedActomaton",
+            dependencies: [
+                "ActomatonCore",
+                "ActomatonEffect",
+                "Actomaton",
+            ]
+        ),
+        .target(
             name: "TestFixtures",
             dependencies: [
                 "Actomaton",
@@ -111,6 +123,12 @@ let package = Package(
         .testTarget(
             name: "ActomatonTestingTests",
             dependencies: ["ActomatonTesting", "TestFixtures"]
+        ),
+        .testTarget(
+            name: "DistributedActomatonTests",
+            dependencies: [
+                "DistributedActomaton",
+            ]
         ),
         .testTarget(
             name: "WasmSmokeTests",

--- a/Sources/DistributedActomaton/DistributedActomaton+Init.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton+Init.swift
@@ -1,7 +1,7 @@
 import Actomaton
 import ActomatonEffect
-import Foundation
 import Distributed
+import Foundation
 
 /// Convenience initializers that default to ``EffectQueueManager``.
 extension DistributedActomaton

--- a/Sources/DistributedActomaton/DistributedActomaton+Init.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton+Init.swift
@@ -1,0 +1,43 @@
+import Actomaton
+import ActomatonEffect
+import Foundation
+import Distributed
+
+/// Convenience initializers that default to ``EffectQueueManager``.
+extension DistributedActomaton
+{
+    /// Initializer without `environment`.
+    public init(
+        state: State,
+        reducer: Reducer<Action, State, ()>,
+        effectContext: EffectContext = .init(clock: ContinuousClock()),
+        actorSystem: ActorSystem
+    )
+    {
+        self.init(
+            state: state,
+            reducer: reducer,
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext),
+            actorSystem: actorSystem
+        )
+    }
+
+    /// Initializer with `environment`.
+    public init<Environment>(
+        state: State,
+        reducer: Reducer<Action, State, Environment>,
+        environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock()),
+        actorSystem: ActorSystem
+    ) where Environment: Sendable
+    {
+        self.init(
+            state: state,
+            reducer: Reducer<Action, State, ()> { action, state, _ in
+                reducer.run(action, &state, environment)
+            },
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext),
+            actorSystem: actorSystem
+        )
+    }
+}

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -1,0 +1,105 @@
+import Actomaton
+import ActomatonEffect
+import Distributed
+
+/// `DistributedActomaton` wraps a ``MealyMachine`` specialized with `Output == Effect<Action>` inside a
+/// Swift distributed actor, providing serial isolation for `send(_:)` and `state` access. It owns the
+/// ``EffectManager`` and turns the asynchronous-remainder output from ``MealyMachine`` into
+/// running Swift Concurrency tasks.
+public distributed actor DistributedActomaton<Action, State, ActorSystem>
+    where Action: Sendable, State: Sendable, ActorSystem: DistributedActorSystem
+{
+    private let machine: MealyMachine<Action, State, Effect<Action>>
+
+    private let effectManager: any EffectManager<Action, State, Effect<Action>>
+
+    public distributed var state: State
+    {
+        machine.state
+    }
+
+    /// Designated initializer that takes an explicit ``EffectManager``.
+    public init(
+        state: State,
+        reducer: MealyReducer<Action, State, (), Effect<Action>>,
+        effectManager: some EffectManager<Action, State, Effect<Action>>,
+        actorSystem: ActorSystem
+    )
+    {
+        self.machine = MealyMachine(
+            state: state,
+            reducer: reducer
+        )
+        self.effectManager = effectManager
+        self.actorSystem = actorSystem
+
+        effectManager.setUp(
+            withSendability: { [weak self] runEffM in
+                await self?.whenLocal { self_ in
+                    self_.runIsolatedEffectManager(runEffM)
+                }
+            },
+            sendAction: { [weak self] action, priority, tracksFeedbacks in
+                return await self?.whenLocal { self_ in
+                    self_.sendLocal(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+                } ?? nil
+            }
+        )
+    }
+
+    /// Sends `action` to the underlying ``MealyMachine`` and forwards the resulting output
+    /// to ``EffectManager/processOutput(_:priority:tracksFeedbacks:)``.
+    ///
+    /// The return type is `Void` (rather than `Task<(), any Error>?` like ``Actomaton/send(_:priority:tracksFeedbacks:)``)
+    /// because a `distributed func`'s return type must satisfy the actor system's
+    /// `SerializationRequirement` (typically `Codable`), and `Task` is not `Codable`.
+    /// For local-only access to the launched effect task, use ``sendLocal(_:priority:tracksFeedbacks:)``
+    /// via `whenLocal { ... }`.
+    ///
+    /// - Parameters:
+    ///   - priority:
+    ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
+    ///   - tracksFeedbacks:
+    ///     If `true`, the underlying effect task will also track its feedback effects that are
+    ///     triggered by next actions, so that wait-for-all and cancellations are possible
+    ///     (observable only through the local API).
+    ///     Default is `false`.
+    public distributed func send(
+        _ action: Action,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    )
+    {
+        sendLocal(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+    }
+
+    /// Local-only variant of ``send(_:priority:tracksFeedbacks:)`` that returns the launched
+    /// effect `Task`. Use through `whenLocal { local in local.sendLocal(...) }` when the caller
+    /// needs to `await` or cancel the resulting effects.
+    @discardableResult
+    public func sendLocal(
+        _ action: Action,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    ) -> Task<(), any Error>?
+    {
+        let output = machine.send(action)
+        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+    }
+
+    /// Runs `runEffM` within this actor's isolation, supplying the underlying ``EffectManager``
+    /// so that conformers can mutate their own bookkeeping safely from detached tasks without
+    /// capturing `self` themselves.
+    fileprivate func runIsolatedEffectManager<EffM>(
+        _ runEffM: (EffM) -> Void
+    ) where EffM: EffectManager<Action, State, Effect<Action>>
+    {
+        // Safe downcast from the existential storage to the conformer's concrete `Self`.
+        runEffM(effectManager as! EffM)
+    }
+
+    isolated deinit
+    {
+        effectManager.shutDown()
+    }
+}

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -50,7 +50,8 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
     /// Sends `action` to the underlying ``MealyMachine`` and forwards the resulting output
     /// to ``EffectManager/processOutput(_:priority:tracksFeedbacks:)``.
     ///
-    /// The return type is `Void` (rather than `Task<(), any Error>?` like ``Actomaton/send(_:priority:tracksFeedbacks:)``)
+    /// The return type is `Void` (rather than `Task<(), any Error>?` like
+    /// ``Actomaton/send(_:priority:tracksFeedbacks:)``)
     /// because a `distributed func`'s return type must satisfy the actor system's
     /// `SerializationRequirement` (typically `Codable`), and `Task` is not `Codable`.
     /// For local-only access to the launched effect task, use ``sendLocal(_:priority:tracksFeedbacks:)``

--- a/Sources/DistributedActomaton/_exported.swift
+++ b/Sources/DistributedActomaton/_exported.swift
@@ -1,0 +1,1 @@
+@_exported import Actomaton

--- a/Tests/DistributedActomatonTests/DistributedMealyMachineSmokeTests.swift
+++ b/Tests/DistributedActomatonTests/DistributedMealyMachineSmokeTests.swift
@@ -1,0 +1,50 @@
+import Distributed
+import DistributedActomaton
+import XCTest
+
+final class DistributedActomatonSmokeTests: XCTestCase
+{
+    func test_send_runsReducer_overLocalTestingActorSystem() async throws
+    {
+        let recorder = Recorder()
+
+        let actomaton = DistributedActomaton<Int, Int, LocalTestingDistributedActorSystem>(
+            state: 0,
+            reducer: Reducer { action, state, _ in
+                state += action
+                let snapshot = state
+                return Effect.fireAndForget {
+                    await recorder.append(snapshot)
+                }
+            },
+            actorSystem: LocalTestingDistributedActorSystem()
+        )
+
+        await actomaton.whenLocal { local in
+            local.send(1)
+            local.send(2)
+            local.send(3)
+        }
+
+        await recorder.waitForCount(3)
+        let values = await recorder.values
+        XCTAssertEqual(values, [1, 3, 6])
+    }
+}
+
+private actor Recorder
+{
+    private(set) var values: [Int] = []
+
+    func append(_ value: Int)
+    {
+        values.append(value)
+    }
+
+    func waitForCount(_ count: Int) async
+    {
+        while values.count < count {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduce `DistributedActomaton<Action, State, ActorSystem>` — the distributed-actor counterpart to `Actomaton`. Same wiring (a `MealyMachine` + owned `EffectManager`), but `send(_:)` is `distributed` so it can be invoked across a `DistributedActorSystem`.

### `distributed func send(_:)` returns `Void` (not `Task<(), any Error>?`)

```swift
public distributed func send(
    _ action: Action,
    priority: TaskPriority? = nil,
    tracksFeedbacks: Bool = false
) {
    sendLocal(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
}
```

A `distributed func`'s return type must satisfy the actor system's `SerializationRequirement` (typically `Codable`). `Task<(), any Error>?` is **not** `Codable`, so reusing `Actomaton.send`'s signature would compile but crash at runtime inside `executeDistributedTarget` with `Swift runtime failure: type cast failed` the moment the receiver tries to hand the return value to `onReturn<Success: Codable>`.

For callers that still want the launched effect `Task` (cancellation, awaiting feedbacks), a local-only `sendLocal(_:)` is exposed and reached via `whenLocal { local in local.sendLocal(...) }`.

### What's added

- `Sources/DistributedActomaton/DistributedActomaton.swift` — the actor.
- `Sources/DistributedActomaton/DistributedActomaton+Init.swift` — `Reducer`-based convenience inits matching `Actomaton`'s.
- `Tests/DistributedActomatonTests/DistributedMealyMachineSmokeTests.swift` — smoke test over `LocalTestingDistributedActorSystem`.
- New `DistributedActomaton` library product + target in `Package.swift`.

## Test plan
- [x] Local `swift test --filter DistributedActomatonSmokeTests` — passes
- [x] Two-CLI `DistributedActorChat` example exchanges messages over Bonjour without `type cast failed` crash
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
