### PR TITLE
Relax Sendable constraints using SendableMetatype

### DIFF
--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -8,7 +8,7 @@ import ActomatonEffect
 /// ``EffectManager`` and turns the asynchronous-remainder output from ``MealyMachine`` into
 /// running Swift Concurrency tasks.
 public actor Actomaton<Action, State>
-    where Action: Sendable, State: Sendable
+    where Action: Sendable
 {
     private let machine: MealyMachine<Action, State, Effect<Action>>
 

--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -42,7 +42,7 @@ public final class MealyMachine<Action, State, Output>: SendableMetatype
         state: State,
         reducer: MealyReducer<Action, State, (), Output>,
         willChangeState: @escaping (_ old: State, _ new: State) -> Void = { _, _ in }
-    ) where Action: Sendable
+    )
     {
         self.state = state
         self.reducer = reducer
@@ -55,7 +55,7 @@ public final class MealyMachine<Action, State, Output>: SendableMetatype
         reducer: MealyReducer<Action, State, Environment, Output>,
         environment: Environment,
         willChangeState: @escaping (_ old: State, _ new: State) -> Void = { _, _ in }
-    ) where Action: Sendable, Environment: Sendable
+    ) where Environment: Sendable
     {
         self.init(
             state: state,

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -1,5 +1,5 @@
 /// Effect type to run `async`, `AsyncSequence`, or cancellation.
-public struct Effect<Action>: Sendable where Action: Sendable
+public struct Effect<Action>
 {
     internal let kinds: [Kind]
 }
@@ -95,7 +95,7 @@ extension Effect
     /// `AsyncSequence` side-effect with `EffectContext`.
     public init<S, E: Error>(
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where S: AsyncSequence<Action, E> & Sendable
+    ) where S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
@@ -110,7 +110,7 @@ extension Effect
 
     /// `AsyncSequence` side-effect without `EffectContext`.
     public init<S, E: Error>(sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence<Action, E> & Sendable
+        where S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(sequence: { _ in
             try await sequence()
@@ -122,7 +122,7 @@ extension Effect
     public init<ID, S, E: Error>(
         id: ID? = nil,
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where ID: EffectID, S: AsyncSequence<Action, E> & Sendable
+    ) where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
@@ -138,7 +138,7 @@ extension Effect
     /// `AsyncSequence` side-effect without `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     public init<ID, S, E: Error>(id: ID? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where ID: EffectID, S: AsyncSequence<Action, E> & Sendable
+        where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(id: id, sequence: { _ in
             try await sequence()
@@ -150,7 +150,7 @@ extension Effect
     public init<S, E: Error, Queue>(
         queue: Queue? = nil,
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
+    ) where S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
     {
         self.init(
             kinds: [.sequence(
@@ -166,7 +166,7 @@ extension Effect
     /// `AsyncSequence` side-effect without `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public init<S, E: Error, Queue>(queue: Queue? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
+        where S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
     {
         self.init(queue: queue, sequence: { _ in
             try await sequence()
@@ -180,7 +180,7 @@ extension Effect
         id: ID? = nil,
         queue: Queue? = nil,
         sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where ID: EffectID, S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
+    ) where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
     {
         self.init(
             kinds: [.sequence(
@@ -200,7 +200,7 @@ extension Effect
         id: ID? = nil,
         queue: Queue? = nil,
         sequence: @escaping @Sendable () async throws -> S?
-    ) where ID: EffectID, S: AsyncSequence<Action, E> & Sendable, Queue: EffectQueue
+    ) where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
     {
         self.init(id: id, queue: queue, sequence: { _ in
             try await sequence()
@@ -317,7 +317,6 @@ extension Effect
 
     /// No `async` side-effect, only returning next action.
     public static func nextAction(_ action: Action) -> Effect<Action>
-        where Action: Sendable
     {
         self.init(kinds: [.next(action)])
     }
@@ -481,7 +480,7 @@ extension Effect
 
 extension Effect
 {
-    internal enum Kind: Sendable
+    internal enum Kind
     {
         /// Single async func effect.
         case single(Single)
@@ -550,7 +549,7 @@ extension Effect
     }
 
     /// Wrapper of `async`.
-    internal struct Single: Sendable
+    internal struct Single
     {
         internal let id: _EffectID?
         internal let queue: (any EffectQueue)?
@@ -589,18 +588,24 @@ extension Effect
     }
 
     /// Wrapper of `AsyncSequence`.
-    internal struct _Sequence: Sendable
+    ///
+    /// The wrapped existential is constrained to `SendableMetatype` (not `Sendable`)
+    /// for the same reason as ``MealyMachine``: the produced `AsyncSequence` instance is not
+    /// required to be `Sendable`, but its metatype must be so that the existential can appear in
+    /// `@Sendable` closure signatures (here, the `sequence` factory and `Effect.map`'s open-existential
+    /// helper) — it makes no claim about instance sendability.
+    internal struct _Sequence
     {
         internal let id: _EffectID?
         internal let queue: (any EffectQueue)?
         internal let sequence: @Sendable (EffectContext) async throws
-            -> (any AsyncSequence<Action, any Error> & Sendable)?
+            -> (any AsyncSequence<Action, any Error> & SendableMetatype)?
 
         internal init(
             id: _EffectID? = nil,
             queue: (any EffectQueue)? = nil,
             sequence: @escaping @Sendable (EffectContext) async throws
-                -> (any AsyncSequence<Action, any Error> & Sendable)?
+                -> (any AsyncSequence<Action, any Error> & SendableMetatype)?
         )
         {
             self.id = id
@@ -613,8 +618,8 @@ extension Effect
             // Open Existential
             @Sendable
             func _mapAsyncSequence(
-                _ seq: some AsyncSequence<Action, any Error> & Sendable
-            ) -> any AsyncSequence<Action2, any Error> & Sendable {
+                _ seq: some AsyncSequence<Action, any Error> & SendableMetatype
+            ) -> any AsyncSequence<Action2, any Error> & SendableMetatype {
                 seq.map(f)
             }
 

--- a/Sources/ActomatonEffect/Internal/AsyncSequence+EraseToAnyError.swift
+++ b/Sources/ActomatonEffect/Internal/AsyncSequence+EraseToAnyError.swift
@@ -1,8 +1,8 @@
-extension AsyncSequence where Self: Sendable, Element: Sendable
+extension AsyncSequence where Self: SendableMetatype
 {
     /// Erases the `Failure` associated type to `any Error`,
-    /// returning `any AsyncSequence<Element, any Error> & Sendable`.
-    func eraseToAnyError() -> any AsyncSequence<Element, any Error> & Sendable
+    /// returning `any AsyncSequence<Element, any Error> & SendableMetatype`.
+    func eraseToAnyError() -> any AsyncSequence<Element, any Error> & SendableMetatype
     {
         map { $0 }
     }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -12,7 +12,6 @@ import Foundation
 /// callback supplied at `setUp(...)`-time, which hands `self` back as a parameter — so no
 /// `[weak self]` capture of the (non-Sendable) `self` is needed in the detached task.
 package final class EffectQueueManager<Action, State>: EffectManager
-    where Action: Sendable
 {
     package typealias Output = Effect<Action>
 
@@ -524,7 +523,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
     // MARK: - Nested Types
 
     /// A suspended effect together with its original `send` context.
-    private struct PendingEffect: Sendable
+    private struct PendingEffect
     {
         let kind: Effect<Action>.Kind
         let priority: TaskPriority?

--- a/Sources/ActomatonTesting/TestActomaton.swift
+++ b/Sources/ActomatonTesting/TestActomaton.swift
@@ -21,8 +21,14 @@ import XCTest
 ///     state.isLoading = false
 /// }
 /// ```
-public actor TestActomaton<Action, State, Environment>
-    where Action: Sendable, State: Sendable & Equatable, Environment: Sendable
+///
+/// - Note:
+///   `State: SendableMetatype` is required (in addition to `Equatable`) so that the
+///   `State: Equatable` conformance witness can be sent across isolation when `self` is captured
+///   in `@Sendable` closures (e.g. `effectManager.setUp` callbacks, `TaskGroup.addTask`).
+///   `State` values themselves do NOT need to be `Sendable`.
+public actor TestActomaton<Action, State>
+    where Action: Sendable, State: Equatable & SendableMetatype
 {
     private typealias InternalAction = TestActomatonAction<Action>
     private typealias RuntimeState = TestActomatonRuntimeState<Action, State>
@@ -36,12 +42,12 @@ public actor TestActomaton<Action, State, Environment>
     ///
     /// Unlike the original implementation, async effects are preserved and can be asserted with
     /// ``receive(_:timeout:assert:fileID:file:line:)``.
-    public init(
+    public init<Environment>(
         state: State,
         reducer: MealyReducer<Action, State, Environment, Effect<Action>>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock())
-    )
+    ) where Environment: Sendable
     {
         let receivedActionSignal = AsyncStream.makeStream(of: Void.self)
         self.receivedActionSignal = receivedActionSignal.stream
@@ -483,8 +489,8 @@ private enum TestActomatonAction<Action>: Sendable
     }
 }
 
-private struct TestActomatonRuntimeState<Action, State>: Sendable
-    where Action: Sendable, State: Sendable
+private struct TestActomatonRuntimeState<Action, State>
+    where Action: Sendable
 {
     var current: State
     var latestSentState: State?

--- a/Sources/ActomatonUI/UIKit/HostingViewController.swift
+++ b/Sources/ActomatonUI/UIKit/HostingViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 /// SwiftUI `View` & ``Store`` wrapper view controller that holds `UIHostingController`.
 @MainActor
 open class HostingViewController<Action, State, Environment, Content: SwiftUI.View>: UIViewController
-    where Action: Sendable, State: Sendable, Environment: Sendable
+    where Action: Sendable, State: Sendable
 {
     private let store: Any // `Store` or `RouteStore`.
     private let rootView: AnyView

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -10,27 +10,26 @@ final class TimerTests: MainTestCase
     {
         struct TimerID: EffectID {}
 
-        let timerEffect = Effect(id: TimerID(), sequence: { context in
-            AsyncStream<()> { continuation in
-                let task = Task {
-                    while true {
-                        try await context.clock.sleep(for: .ticks(2))
-                        continuation.yield(())
-                    }
-                }
-
-                continuation.onTermination = { @Sendable _ in
-                    task.cancel()
-                }
-            }
-            .map { Action.tick }
-        })
-
         let actomaton = Actomaton<Action, State>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 switch action {
                 case .start:
+                    let timerEffect = Effect(id: TimerID(), sequence: { context in
+                        AsyncStream<()> { continuation in
+                            let task = Task {
+                                while true {
+                                    try await context.clock.sleep(for: .ticks(2))
+                                    continuation.yield(())
+                                }
+                            }
+
+                            continuation.onTermination = { @Sendable _ in
+                                task.cancel()
+                            }
+                        }
+                        .map { Action.tick }
+                    })
                     return timerEffect
                 case .tick:
                     state += 1


### PR DESCRIPTION
## Summary

Loosen `Sendable` requirements that were stricter than necessary, using `SendableMetatype` where only the metatype needs to cross isolation:

- `Effect`'s `AsyncSequence` existential changes from `& Sendable` to `& SendableMetatype`. The produced sequence *instance* is no longer required to be `Sendable`; only its metatype must be, so the existential can appear in `@Sendable` closure signatures (the `sequence` factory and `Effect.map`'s open-existential helper).
- Drop `State: Sendable` from `Actomaton`, `MealyMachine`, `HostingViewController`, and `TestActomaton`'s type-level constraints. `TestActomaton` now requires `State: SendableMetatype` (in addition to `Equatable`) so the `Equatable` conformance witness can cross isolation when `self` is captured in `@Sendable` closures (`effectManager.setUp` callbacks, `TaskGroup.addTask`). `State` *values* themselves no longer need to be `Sendable`.
- Move `Environment: Sendable` from `MealyMachine`'s and `TestActomaton`'s type-level where clauses down to the convenience initializer where it's actually required.

### Effect — sequence existential

```swift
// Before
public init<S, E: Error>(
    sequence: @escaping @Sendable (EffectContext) async throws -> S?
) where S: AsyncSequence<Action, E> & Sendable

// After
public init<S, E: Error>(
    sequence: @escaping @Sendable (EffectContext) async throws -> S?
) where S: AsyncSequence<Action, E> & SendableMetatype
```

`Effect._Sequence.sequence` returns `(any AsyncSequence<Action, any Error> & SendableMetatype)?` accordingly, and `AsyncSequence.eraseToAnyError()` is rewritten in those terms.

### Actomaton / MealyMachine / TestActomaton / HostingViewController — drop `State: Sendable`

```swift
// Before
public actor Actomaton<Action, State>
    where Action: Sendable, State: Sendable

// After
public actor Actomaton<Action, State>
    where Action: Sendable
```

This removes a constraint that callers had to satisfy without any real benefit — the actor's isolation guarantees safety regardless of `State`'s sendability.

## Test plan

- [x] Local `swift test` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
