### PR TITLE
Move shutDown into EffectQueueManager's deinit

### DIFF
--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -76,9 +76,4 @@ public actor Actomaton<Action, State>
         // Safe downcast from the existential storage to the conformer's concrete `Self`.
         runEffM(effectManager as! EffM)
     }
-
-    isolated deinit
-    {
-        effectManager.shutDown()
-    }
 }

--- a/Sources/ActomatonEffect/EffectManager.swift
+++ b/Sources/ActomatonEffect/EffectManager.swift
@@ -46,7 +46,4 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
         priority: TaskPriority?,
         tracksFeedbacks: Bool
     ) -> Task<(), any Error>?
-
-    /// Cancel all running tasks and drain pending effects.
-    func shutDown()
 }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -57,6 +57,11 @@ package final class EffectQueueManager<Action, State>: EffectManager
         self.effectContext = effectContext
     }
 
+    deinit
+    {
+        shutDown()
+    }
+
     // MARK: - EffectManager
 
     package func setUp(
@@ -137,7 +142,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
         }
     }
 
-    package func shutDown()
+    private func shutDown()
     {
         // Cancel all running tasks.
         for (_, tasks) in runningTasks {

--- a/Sources/ActomatonTesting/TestActomaton.swift
+++ b/Sources/ActomatonTesting/TestActomaton.swift
@@ -117,11 +117,6 @@ public actor TestActomaton<Action, State>
         return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
     }
 
-    isolated deinit
-    {
-        effectManager.shutDown()
-    }
-
     /// Sends an action and asserts how state changes before any feedback action is received.
     ///
     /// Feedback actions emitted from `.next`, `async`, or `AsyncSequence` effects must be asserted

--- a/Sources/ActomatonUI/Store/Internal/StoreCore.swift
+++ b/Sources/ActomatonUI/Store/Internal/StoreCore.swift
@@ -67,7 +67,6 @@ internal final class StoreCore<Action, State, Environment>
     isolated deinit
     {
         Debug.print("[deinit] StoreCore \(String(format: "%p", ObjectIdentifier(self).hashValue))")
-        effectManager.shutDown()
     }
 
     internal var state: CurrentValuePublisher<State>

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -98,9 +98,4 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
         // Safe downcast from the existential storage to the conformer's concrete `Self`.
         runEffM(effectManager as! EffM)
     }
-
-    isolated deinit
-    {
-        effectManager.shutDown()
-    }
 }


### PR DESCRIPTION
## Summary

`EffectManager.shutDown()` was a protocol requirement that wrappers had to forward to from their own `isolated deinit`. Since `EffectQueueManager` is the only concrete `EffectManager` and is owned exclusively by its wrapper, the wrapper's deinit dropping the last strong reference already triggers `EffectQueueManager`'s deinit — so the cleanup can live there directly, and the protocol no longer needs `shutDown()`.

### Before

```swift
public protocol EffectManager: ... {
    ...
    /// Cancel all running tasks and drain pending effects.
    func shutDown()
}

public actor Actomaton<Action, State> {
    ...
    isolated deinit
    {
        effectManager.shutDown()
    }
}
```

…and the same `isolated deinit { effectManager.shutDown() }` in `TestActomaton`, `StoreCore`, and `DistributedActomaton`.

### After

```swift
public protocol EffectManager: ... {
    ...
    // shutDown() requirement removed
}

// In EffectQueueManager:
deinit
{
    shutDown()
}

private func shutDown() { ... }   // was `package func shutDown()`
```

Each wrapper loses its `isolated deinit` block; cleanup happens automatically when `EffectQueueManager` is deallocated.

## Test plan
- [x] Local `swift test` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
