### PR TITLE
Add MealyDriver — non-actor sibling of Actomaton using Mutex

### DIFF
--- a/Sources/Actomaton/MealyDriver+Init.swift
+++ b/Sources/Actomaton/MealyDriver+Init.swift
@@ -1,0 +1,37 @@
+import ActomatonCore
+import ActomatonEffect
+
+/// Convenience initializers that default to ``EffectQueueManager``.
+extension MealyDriver
+{
+    /// Initializer without `environment`.
+    public convenience init(
+        state: State,
+        reducer: Reducer<Action, State, ()>,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
+    )
+    {
+        self.init(
+            state: state,
+            reducer: reducer,
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
+        )
+    }
+
+    /// Initializer with `environment`.
+    public convenience init<Environment>(
+        state: State,
+        reducer: Reducer<Action, State, Environment>,
+        environment: Environment,
+        effectContext: EffectContext = .init(clock: ContinuousClock())
+    ) where Environment: Sendable
+    {
+        self.init(
+            state: state,
+            reducer: Reducer<Action, State, ()> { action, state, _ in
+                reducer.run(action, &state, environment)
+            },
+            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
+        )
+    }
+}

--- a/Sources/Actomaton/MealyDriver.swift
+++ b/Sources/Actomaton/MealyDriver.swift
@@ -1,0 +1,103 @@
+import ActomatonCore
+import ActomatonEffect
+import Synchronization
+
+/// Non-actor driver for ``MealyMachine`` with `Output == Effect<Action>`, providing
+/// synchronous `send(_:)`, `state` and `withState(_:)` for callers that cannot enter an
+/// actor isolation — for example, a type conforming to `DistributedActorSystem` whose
+/// protocol surface is largely synchronous.
+///
+/// `MealyDriver` is the "non-actor" sibling of ``Actomaton`` referenced by
+/// ``MealyMachine``'s docstring. Both wrappers share the same internals (`MealyMachine` +
+/// an ``EffectManager``); they differ only in how they provide the serial-access invariant
+/// that ``MealyMachine`` requires:
+///
+/// - ``Actomaton`` uses Swift actor isolation.
+/// - ``MealyDriver`` uses an internal `Mutex` from the `Synchronization` framework.
+///
+/// The class is marked `@unchecked Sendable` because ``MealyMachine`` and the underlying
+/// ``EffectManager`` are both intentionally non-`Sendable`; the mutex supplies the
+/// serial-access invariant they require.
+public final class MealyDriver<Action, State>: @unchecked Sendable
+    where Action: Sendable
+{
+    private let machine: MealyMachine<Action, State, Effect<Action>>
+
+    private let effectManager: any EffectManager<Action, State, Effect<Action>>
+
+    private let mutex = Mutex<Void>(())
+
+    /// Designated initializer that takes an explicit ``EffectManager``.
+    public init(
+        state: State,
+        reducer: Reducer<Action, State, ()>,
+        effectManager: some EffectManager<Action, State, Effect<Action>>
+    )
+    {
+        self.machine = MealyMachine(state: state, reducer: reducer)
+        self.effectManager = effectManager
+
+        effectManager.setUp(
+            withSendability: { [weak self] runEffectManager in
+                self?.runIsolatedEffectManager(runEffectManager)
+            },
+            sendAction: { [weak self] action, priority, tracksFeedbacks in
+                self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            }
+        )
+    }
+
+    /// Synchronous snapshot of the current `state`. The returned value is a copy taken
+    /// under the mutex; mutating it does not affect the driver's internal state.
+    public var state: State {
+        mutex.withLock { _ in machine.state }
+    }
+
+    /// Run `body` against the current `state` while holding the driver's mutex. Use this
+    /// when you need to read multiple fields atomically.
+    public func withState<R>(_ body: (State) -> R) -> R {
+        mutex.withLock { _ in body(machine.state) }
+    }
+
+    /// Sends `action` to the underlying ``MealyMachine`` and forwards the resulting output
+    /// to ``EffectManager/processOutput(_:priority:tracksFeedbacks:)``.
+    ///
+    /// The reducer is run synchronously under the mutex; the asynchronous-remainder output
+    /// (`Effect<Action>`) is handed to the effect manager *after* the mutex is released, so
+    /// the manager's task scheduling never re-enters the mutex from the same call stack.
+    ///
+    /// - Parameters:
+    ///   - priority:
+    ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
+    ///   - tracksFeedbacks:
+    ///     If `true`, the returned `Task` will also track feedback effects triggered by
+    ///     subsequent actions, so that wait-for-all and cancellation are possible.
+    ///     Default is `false`.
+    ///
+    /// - Returns:
+    ///   Unified task that can handle (wait for or cancel) all combined effects triggered
+    ///   by `action` in the reducer.
+    @discardableResult
+    public func send(
+        _ action: Action,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    ) -> Task<(), any Error>?
+    {
+        let output = mutex.withLock { _ in machine.send(action) }
+        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+    }
+
+    /// Runs `runEffectManager` under the driver's mutex, supplying the underlying
+    /// ``EffectManager`` so that conformers can mutate their own bookkeeping safely from
+    /// detached tasks without capturing `self` themselves.
+    private func runIsolatedEffectManager<EffM>(
+        _ runEffectManager: (EffM) -> Void
+    ) where EffM: EffectManager<Action, State, Effect<Action>>
+    {
+        mutex.withLock { _ in
+            // Safe downcast from the existential storage to the conformer's concrete `Self`.
+            runEffectManager(effectManager as! EffM)
+        }
+    }
+}

--- a/Tests/ActomatonTests/MealyDriverTests.swift
+++ b/Tests/ActomatonTests/MealyDriverTests.swift
@@ -1,0 +1,74 @@
+import Actomaton
+import XCTest
+
+/// Smoke test for ``MealyDriver`` — the non-actor counterpart of ``Actomaton``.
+final class MealyDriverTests: MainTestCase
+{
+    fileprivate var driver: MealyDriver<Action, State>!
+
+    override func setUp() async throws
+    {
+        let driver = MealyDriver<Action, State>(
+            state: State(),
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+                    return Effect.fireAndForget {
+                        print("increment")
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return Effect.fireAndForget {
+                        print("decrement")
+                    }
+                }
+            },
+            effectContext: effectContext
+        )
+        self.driver = driver
+    }
+
+    func test_synchronous_send_and_state() throws
+    {
+        XCTAssertEqual(driver.state.count, 0)
+
+        driver.send(.increment)
+        XCTAssertEqual(driver.state.count, 1)
+
+        driver.send(.increment)
+        XCTAssertEqual(driver.state.count, 2)
+
+        driver.send(.decrement)
+        XCTAssertEqual(driver.state.count, 1)
+
+        driver.send(.decrement)
+        XCTAssertEqual(driver.state.count, 0)
+
+        driver.send(.decrement)
+        XCTAssertEqual(driver.state.count, -1)
+    }
+
+    func test_withState_reads_under_lock() throws
+    {
+        driver.send(.increment)
+        driver.send(.increment)
+        driver.send(.increment)
+
+        let count = driver.withState { $0.count }
+        XCTAssertEqual(count, 3)
+    }
+}
+
+// MARK: - Private
+
+private enum Action: Sendable
+{
+    case increment
+    case decrement
+}
+
+private struct State: Sendable
+{
+    var count: Int = 0
+}


### PR DESCRIPTION
## Summary

Introduce `MealyDriver<Action, State>` — the non-actor counterpart to `Actomaton`. Same internals (`MealyMachine` + owned `EffectManager`), but the serial-access invariant that `MealyMachine` requires is provided by an internal `Mutex` (from the `Synchronization` framework) instead of Swift actor isolation.

This shape is needed by callers that cannot enter actor isolation — for example, a type conforming to `DistributedActorSystem` whose protocol surface is largely synchronous and therefore cannot funnel through `await actomaton.send(...)`.

### Sibling of `Actomaton`

```swift
// Actomaton — actor isolation provides the serial-access invariant.
public actor Actomaton<Action, State> where Action: Sendable { ... }

// MealyDriver — internal Mutex provides the same invariant.
public final class MealyDriver<Action, State>: @unchecked Sendable
    where Action: Sendable
{ ... }
```

Both wrap a `MealyMachine<Action, State, Effect<Action>>` and an `EffectManager`. They differ only in how serial access is enforced. `MealyDriver` is `@unchecked Sendable` because `MealyMachine` and `EffectManager` are intentionally non-`Sendable`; the mutex supplies the serial-access invariant they require.

### Synchronous surface

```swift
public var state: State {
    mutex.withLock { _ in machine.state }
}

public func withState<R>(_ body: (State) -> R) -> R {
    mutex.withLock { _ in body(machine.state) }
}

@discardableResult
public func send(
    _ action: Action,
    priority: TaskPriority? = nil,
    tracksFeedbacks: Bool = false
) -> Task<(), any Error>? {
    let output = mutex.withLock { _ in machine.send(action) }
    return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
}
```

The reducer runs synchronously under the mutex; the asynchronous-remainder `Effect<Action>` is handed to the effect manager **after** the mutex is released, so the manager's task scheduling never re-enters the mutex from the same call stack.

### What's added

- `Sources/Actomaton/MealyDriver.swift` — the class.
- `Sources/Actomaton/MealyDriver+Init.swift` — `Reducer`-based convenience inits matching `Actomaton`'s.
- `Tests/ActomatonTests/MealyDriverTests.swift` — smoke test (synchronous `send` updates state under the lock; `withState` reads atomically).

## Test plan

- [x] Local `swift build` — passes
- [x] Local `swift test --filter MealyDriverTests` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
