### PR TITLE
Remove Effect constructors that ignore EffectContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ reducer = Reducer { action, state, environment in
     switch action {
     case .increment:
         state.count += 1
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { _ in
             print("increment")
         }
     case .decrement:
@@ -194,7 +194,7 @@ struct Environment: Sendable {
 
 let environment = Environment(
     loginEffect: { userId in
-        Effect(id: LoginFlowEffectID()) {
+        Effect(id: LoginFlowEffectID()) { _ in
             let loginRequest = ...
             let data = try? await URLSession.shared.data(for: loginRequest)
             if Task.isCancelled { return nil }
@@ -203,7 +203,7 @@ let environment = Environment(
         }
     },
     logoutEffect: {
-        Effect(id: LoginFlowEffectID()) {
+        Effect(id: LoginFlowEffectID()) { _ in
             let logoutRequest = ...
             let data = try? await URLSession.shared.data(for: logoutRequest)
             if Task.isCancelled { return nil }
@@ -234,7 +234,7 @@ let reducer = Reducer { action, state, environment in
         return .empty
 
     default:
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { _ in
             print("State transition failed...")
         }
     }
@@ -313,7 +313,7 @@ struct Environment {
 
 let environment = Environment(
     timerEffect: { userId in
-        Effect(id: TimerID(), sequence: {
+        Effect(id: TimerID(), sequence: { _ in
             AsyncStream<()> { continuation in
                 let task = Task {
                     while true {
@@ -406,7 +406,7 @@ struct DelayedEffectQueue: EffectQueue {
 let reducer = Reducer<Action, State, Environment> { action, state, environment in
     switch action {
     case let .fetch(id):
-        return Effect(queue: DelayedEffectQueue()) {
+        return Effect(queue: DelayedEffectQueue()) { _ in
             let data = try await environment.fetch(id)
             return ._didFetch(data)
         }

--- a/Sources/ActomatonDebugging/Reducer+Debugging.swift
+++ b/Sources/ActomatonDebugging/Reducer+Debugging.swift
@@ -76,7 +76,7 @@ extension Reducer where Output == Effect<Action>
             let currentState = state // Needs copy to not carry `inout`.
 
             /// Effect for  Action & State `.simple` or `.all` printing.
-            let preEffect = Effect<Action>.fireAndForget {
+            let preEffect = Effect<Action>.fireAndForget { _ in
                 let name = format.name.map { "[\($0)]" } ?? ""
 
                 if let actionLogFormat = format.actionLogFormat {
@@ -115,7 +115,7 @@ extension Reducer where Output == Effect<Action>
             let nextState = state // Needs copy to not carry `inout`.
 
             /// Effect for State's `.diff` printing.
-            let postEffect = Effect<Action>.fireAndForget {
+            let postEffect = Effect<Action>.fireAndForget { _ in
                 if let stateLogFormat = format.stateLogFormat {
                     switch stateLogFormat.format {
                     case .simple, .all:

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -18,14 +18,6 @@ extension Effect
         self.init(kinds: [.single(Single(id: nil, queue: nil, run: run))])
     }
 
-    /// Single-`async` side-effect without `EffectContext`.
-    public init(run: @escaping @Sendable () async throws -> Action?)
-    {
-        self.init(run: { _ in
-            try await run()
-        })
-    }
-
     /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     public init<ID>(
@@ -35,16 +27,6 @@ extension Effect
         where ID: EffectID
     {
         self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: nil, run: run))])
-    }
-
-    /// Single-`async` side-effect without `EffectContext`.
-    /// - Parameter id: Cancellation identifier.
-    public init<ID>(id: ID? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where ID: EffectID
-    {
-        self.init(id: id, run: { _ in
-            try await run()
-        })
     }
 
     /// Single-`async` side-effect with `EffectContext`.
@@ -57,16 +39,6 @@ extension Effect
         self.init(kinds: [.single(Single(id: nil, queue: queue, run: run))])
     }
 
-    /// Single-`async` side-effect without `EffectContext`.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<Queue>(queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where Queue: EffectQueue
-    {
-        self.init(queue: queue, run: { _ in
-            try await run()
-        })
-    }
-
     /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
@@ -77,17 +49,6 @@ extension Effect
     ) where ID: EffectID, Queue: EffectQueue
     {
         self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: queue, run: run))])
-    }
-
-    /// Single-`async` side-effect without `EffectContext`.
-    /// - Parameter id: Cancellation identifier.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<ID, Queue>(id: ID? = nil, queue: Queue? = nil, run: @escaping @Sendable () async throws -> Action?)
-        where ID: EffectID, Queue: EffectQueue
-    {
-        self.init(id: id, queue: queue, run: { _ in
-            try await run()
-        })
     }
 
     // MARK: - AsyncSequence
@@ -108,15 +69,6 @@ extension Effect
         )
     }
 
-    /// `AsyncSequence` side-effect without `EffectContext`.
-    public init<S, E: Error>(sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence<Action, E> & SendableMetatype
-    {
-        self.init(sequence: { _ in
-            try await sequence()
-        })
-    }
-
     /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     public init<ID, S, E: Error>(
@@ -133,16 +85,6 @@ extension Effect
                 )
             )]
         )
-    }
-
-    /// `AsyncSequence` side-effect without `EffectContext`.
-    /// - Parameter id: Cancellation identifier.
-    public init<ID, S, E: Error>(id: ID? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
-    {
-        self.init(id: id, sequence: { _ in
-            try await sequence()
-        })
     }
 
     /// `AsyncSequence` side-effect with `EffectContext`.
@@ -163,16 +105,6 @@ extension Effect
         )
     }
 
-    /// `AsyncSequence` side-effect without `EffectContext`.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<S, E: Error, Queue>(queue: Queue? = nil, sequence: @escaping @Sendable () async throws -> S?)
-        where S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
-    {
-        self.init(queue: queue, sequence: { _ in
-            try await sequence()
-        })
-    }
-
     /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
@@ -193,20 +125,6 @@ extension Effect
         )
     }
 
-    /// `AsyncSequence` side-effect without `EffectContext`.
-    /// - Parameter id: Cancellation identifier.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<ID, S, E: Error, Queue>(
-        id: ID? = nil,
-        queue: Queue? = nil,
-        sequence: @escaping @Sendable () async throws -> S?
-    ) where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
-    {
-        self.init(id: id, queue: queue, sequence: { _ in
-            try await sequence()
-        })
-    }
-
     // MARK: - fireAndForget
 
     /// Single-`async` side-effect without returning next action, with `EffectContext`.
@@ -217,14 +135,6 @@ extension Effect
         self.init(run: { context in
             try await run(context)
             return nil
-        })
-    }
-
-    /// Single-`async` side-effect without returning next action, without `EffectContext`.
-    public static func fireAndForget(run: @escaping @Sendable () async throws -> ()) -> Effect<Action>
-    {
-        self.fireAndForget(run: { _ in
-            try await run()
         })
     }
 
@@ -242,19 +152,6 @@ extension Effect
         })
     }
 
-    /// Single-`async` side-effect without returning next action, without `EffectContext`.
-    /// - Parameter id: Cancellation identifier.
-    public static func fireAndForget<ID>(
-        id: ID? = nil,
-        run: @escaping @Sendable () async throws -> ()
-    ) -> Effect<Action>
-        where ID: EffectID
-    {
-        self.fireAndForget(id: id, run: { _ in
-            try await run()
-        })
-    }
-
     /// Single-`async` side-effect without returning next action, with `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func fireAndForget<Queue>(
@@ -266,19 +163,6 @@ extension Effect
         self.init(queue: queue, run: { context in
             try await run(context)
             return nil
-        })
-    }
-
-    /// Single-`async` side-effect without returning next action, without `EffectContext`.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public static func fireAndForget<Queue>(
-        queue: Queue? = nil,
-        run: @escaping @Sendable () async throws -> ()
-    ) -> Effect<Action>
-        where Queue: EffectQueue
-    {
-        self.fireAndForget(queue: queue, run: { _ in
-            try await run()
         })
     }
 
@@ -295,21 +179,6 @@ extension Effect
         self.init(id: id, queue: queue, run: { context in
             try await run(context)
             return nil
-        })
-    }
-
-    /// Single-`async` side-effect without returning next action, without `EffectContext`.
-    /// - Parameter id: Cancellation identifier.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public static func fireAndForget<ID, Queue>(
-        id: ID? = nil,
-        queue: Queue? = nil,
-        run: @escaping @Sendable () async throws -> ()
-    ) -> Effect<Action>
-        where ID: EffectID, Queue: EffectQueue
-    {
-        self.fireAndForget(id: id, queue: queue, run: { _ in
-            try await run()
         })
     }
 

--- a/Sources/ActomatonTesting/TestActomaton.swift
+++ b/Sources/ActomatonTesting/TestActomaton.swift
@@ -71,7 +71,7 @@ public actor TestActomaton<Action, State>
                     )
                 )
 
-                return Effect.fireAndForget {
+                return Effect.fireAndForget { _ in
                     receivedActionSignal.continuation.yield()
                 } + mappedEffect
             }

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -223,7 +223,7 @@ public struct SendRouteEnvironment<Environment, Route>: Sendable
     /// ...
     ///
     /// // Inside `RouteStore`'s Reducer:
-    /// Effect(sequence: {
+    /// Effect(sequence: { _ in
     ///     /// Send `Route` and get `AsyncStream` from next screen.
     ///     let stream = environment.sendRouteAsyncStream { continuation in
     ///         return Route.showNextScreen(someArg, continuation)

--- a/Tests/ActomatonTestingTests/TestActomatonTests.swift
+++ b/Tests/ActomatonTestingTests/TestActomatonTests.swift
@@ -132,7 +132,7 @@ final class TestActomatonTests: MainTestCase
             state: CounterState(count: 0),
             reducer: MealyReducer<CounterAction, CounterState, ResultsCollector<CounterAction>, Effect<CounterAction>> {
                 action, state, recorder in
-                let recordEffect = Effect<CounterAction>.fireAndForget {
+                let recordEffect = Effect<CounterAction>.fireAndForget { _ in
                     await recorder.append(action)
                 }
 
@@ -211,7 +211,7 @@ final class TestActomatonTests: MainTestCase
                 switch action {
                 case .increment:
                     state.count += 1
-                    return Effect {
+                    return Effect { _ in
                         .reset
                     }
                 case .decrement:
@@ -271,7 +271,7 @@ final class TestActomatonTests: MainTestCase
                 switch action {
                 case .increment:
                     state.count = 1
-                    return Effect {
+                    return Effect { _ in
                         await Task.yield()
                         return .reset
                     }

--- a/Tests/ActomatonTests/CounterTests.swift
+++ b/Tests/ActomatonTests/CounterTests.swift
@@ -13,12 +13,12 @@ final class CounterTests: MainTestCase
                 switch action {
                 case .increment:
                     state.count += 1
-                    return Effect.fireAndForget {
+                    return Effect.fireAndForget { _ in
                         print("increment")
                     }
                 case .decrement:
                     state.count -= 1
-                    return Effect.fireAndForget {
+                    return Effect.fireAndForget { _ in
                         print("decrement")
                     }
                 }

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -58,7 +58,7 @@ final class EffectQueueDelayTests: MainTestCase
                 case let ._didFetch(id):
                     state.finishedIDs.insert(id)
 
-                    return Effect.fireAndForget {
+                    return Effect.fireAndForget { _ in
                         print("Finished: \(id)")
                     }
                 }

--- a/Tests/ActomatonTests/MealyDriverTests.swift
+++ b/Tests/ActomatonTests/MealyDriverTests.swift
@@ -14,12 +14,12 @@ final class MealyDriverTests: MainTestCase
                 switch action {
                 case .increment:
                     state.count += 1
-                    return Effect.fireAndForget {
+                    return Effect.fireAndForget { _ in
                         print("increment")
                     }
                 case .decrement:
                     state.count -= 1
-                    return Effect.fireAndForget {
+                    return Effect.fireAndForget { _ in
                         print("decrement")
                     }
                 }

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -75,10 +75,10 @@ final class PendingEffectCancellationTests: MainTestCase
                     }
 
                 case ._didFetch1:
-                    return Effect.fireAndForget { await flags.mark(result1: .completed) }
+                    return Effect.fireAndForget { _ in await flags.mark(result1: .completed) }
 
                 case ._didFetch2:
-                    return Effect.fireAndForget { await flags.mark(result2: .completed) }
+                    return Effect.fireAndForget { _ in await flags.mark(result2: .completed) }
 
                 case .cancelAll:
                     return Effect.cancel(ids: { $0 is CancelEffectID })

--- a/Tests/DistributedActomatonTests/DistributedMealyMachineSmokeTests.swift
+++ b/Tests/DistributedActomatonTests/DistributedMealyMachineSmokeTests.swift
@@ -13,7 +13,7 @@ final class DistributedActomatonSmokeTests: XCTestCase
             reducer: Reducer { action, state, _ in
                 state += action
                 let snapshot = state
-                return Effect.fireAndForget {
+                return Effect.fireAndForget { _ in
                     await recorder.append(snapshot)
                 }
             },

--- a/Tests/ReadMeTests/ReadMeTests.swift
+++ b/Tests/ReadMeTests/ReadMeTests.swift
@@ -66,7 +66,7 @@ private func readMe1_4() async throws
     let reducer = Reducer<Action, State, Environment> { action, _, environment in
         switch action {
         case let .fetch(id):
-            return Effect(queue: DelayedEffectQueue()) {
+            return Effect(queue: DelayedEffectQueue()) { _ in
                 let data = try await environment.fetch(id)
                 return ._didFetch(data)
             }


### PR DESCRIPTION
## Summary

**Breaking change.** Remove the 12 convenience `Effect` constructors whose closures took no `EffectContext` argument. Callers must now write the closure as `{ _ in ... }` (or `{ context in ... }`) explicitly when the context is unused.

The two parallel `Effect.init(...)` / `Effect.fireAndForget(...)` ladders that differed only in whether the closure accepted an `EffectContext` doubled the public surface for no real benefit — the no-context overloads simply discarded the context that callers may later want (e.g. for `EffectContext.clock`).

### What's removed

From `Sources/ActomatonEffect/Effect.swift`:

- `Effect.init(run:)` — 4 overloads (plain, `(id:)`, `(queue:)`, `(id:queue:)`)
- `Effect.init(sequence:)` — 4 overloads
- `Effect.fireAndForget(run:)` — 4 overloads

All 12 dropped initializers had closure type `() async throws -> Action?` / `() async throws -> ()` / `() async throws -> S?`. The context-aware versions (`(EffectContext) async throws -> ...`) are unchanged.

### Migration

```swift
// Before
Effect.fireAndForget {
    print("hi")
}

Effect(queue: MyQueue()) {
    return await fetch()
}

Effect(id: TimerID(), sequence: {
    AsyncStream { ... }
})

// After
Effect.fireAndForget { _ in
    print("hi")
}

Effect(queue: MyQueue()) { _ in
    return await fetch()
}

Effect(id: TimerID(), sequence: { _ in
    AsyncStream { ... }
})
```

### Call-site updates in this repo

- Sources: `Reducer+Debugging.swift`, `TestActomaton.swift`, `RouteStore.swift` (doc comment)
- Tests: `CounterTests`, `MealyDriverTests`, `PendingEffectCancellationTests`, `EffectQueueDelayTests`, `TestActomatonTests`, `DistributedMealyMachineSmokeTests`, `ReadMeTests`
- `README.md` sample code

Net diff: 12 files changed, 22 insertions, 153 deletions.

## Test plan

- [x] Local `swift build` — passes
- [x] Local `swift test` — 67 XCTest + 3 Swift Testing all pass
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
