### PR TITLE
Rename Effect.nextAction to next(action:) and init(sequence:) to sequence(_:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ reducer = Reducer { action, state, environment in
 NOTE: There are 5 ways of creating `Effect` in Actomaton:
 
 1. No side-effects, but next action only
-    - `Effect.nextAction`
+    - `Effect.next(action:)`
 2. Single `async` without next action
     - `Effect.fireAndForget(id:run:)`
 3. Single `async` with next action
     - `Effect.init(id:run:)`
 4. Multiple `async`s (i.e. `AsyncSequence`) with next actions
-    - `Effect.init(id:sequence:)`
+    - `Effect.sequence(id:_:)`
 5. Manual cancellation
     - `Effect.cancel(id:)` / `.cancel(ids:)`
 
@@ -313,7 +313,7 @@ struct Environment {
 
 let environment = Environment(
     timerEffect: { userId in
-        Effect(id: TimerID(), sequence: { _ in
+        Effect.sequence(id: TimerID()) { _ in
             AsyncStream<()> { continuation in
                 let task = Task {
                     while true {
@@ -326,7 +326,7 @@ let environment = Environment(
                     task.cancel()
                 }
             }
-        })
+        }
     }
 )
 
@@ -375,7 +375,7 @@ enum Main {
 }
 ```
 
-In this example, `Effect(id:sequence:)` is used for timer effect, which yields `Action.tick` multiple times.
+In this example, `Effect.sequence(id:)` is used for timer effect, which yields `Action.tick` multiple times.
 
 ### Example 1-4. `EffectQueue`
 

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/01-Counter.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/01-Counter.md
@@ -80,13 +80,13 @@ Keep API clients and other business dependencies in `Environment`.
 NOTE: There are 5 ways of creating ``Effect`` in Actomaton:
 
 1. No side-effects, but forwards next action only
-    - ``Effect/nextAction(_:)``
+    - ``Effect/next(action:)``
 2. Single `async` without next action
     - ``Effect/fireAndForget(id:queue:run:)``
 3. Single `async` with next action
     - ``Effect/init(id:queue:run:)``
 4. Multiple `async`s (i.e. `AsyncSequence`) with next actions
-    - ``Effect/init(id:queue:sequence:)``
+    - ``Effect/sequence(id:queue:_:)``
 5. Manual cancellation
     - ``Effect/cancel(id:)`` / ``Effect/cancel(ids:)``
 

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-Timer.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-Timer.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-In this example, ``Effect``.``Effect/init(id:sequence:)`` is used for timer effect, which yields `Action.tick` multiple times.
+In this example, ``Effect``.``Effect/sequence(id:_:)`` is used for timer effect, which yields `Action.tick` multiple times.
 
 ```swift
 enum Action: Sendable {
@@ -21,7 +21,7 @@ struct Environment: Sendable {
 
 let environment = Environment(
     timerEffect: { userId in
-        Effect(id: TimerID(), sequence: {
+        Effect.sequence(id: TimerID()) {
             AsyncStream<()> { continuation in
                 let task = Task {
                     while true {
@@ -34,7 +34,7 @@ let environment = Environment(
                     task.cancel()
                 }
             }
-        })
+        }
     }
 )
 

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -54,9 +54,10 @@ extension Effect
     // MARK: - AsyncSequence
 
     /// `AsyncSequence` side-effect with `EffectContext`.
-    public init<S, E: Error>(
-        sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where S: AsyncSequence<Action, E> & SendableMetatype
+    public static func sequence<S, E: Error>(
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action>
+        where S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
@@ -71,10 +72,11 @@ extension Effect
 
     /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
-    public init<ID, S, E: Error>(
+    public static func sequence<ID, S, E: Error>(
         id: ID? = nil,
-        sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action>
+        where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
@@ -89,10 +91,11 @@ extension Effect
 
     /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<S, E: Error, Queue>(
+    public static func sequence<S, E: Error, Queue>(
         queue: Queue? = nil,
-        sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action>
+        where Queue: EffectQueue, S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
@@ -108,11 +111,12 @@ extension Effect
     /// `AsyncSequence` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    public init<ID, S, E: Error, Queue>(
+    public static func sequence<ID, S, E: Error, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
-        sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype, Queue: EffectQueue
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action>
+        where ID: EffectID, Queue: EffectQueue, S: AsyncSequence<Action, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
@@ -182,10 +186,10 @@ extension Effect
         })
     }
 
-    // MARK: - nextAction
+    // MARK: - next
 
     /// No `async` side-effect, only returning next action.
-    public static func nextAction(_ action: Action) -> Effect<Action>
+    public static func next(action: Action) -> Effect<Action>
     {
         self.init(kinds: [.next(action)])
     }

--- a/Sources/ActomatonUI/ActomatonUI.docc/Articles/OOP-Tutorial/02-LoginLogout.md
+++ b/Sources/ActomatonUI/ActomatonUI.docc/Articles/OOP-Tutorial/02-LoginLogout.md
@@ -74,13 +74,13 @@ let reducer = Reducer { action, state, environment in
 `Effect` の実装方法は 5 種類があります。特に重要なのが 3. 4. 5. です（3. は 1. と 2. を兼ねます）。
 
 1. 副作用を発生せず、次のアクションのみを転送する
-    - `Effect.nextAction()`
+    - `Effect.next(action:)`
 2. `async` 関数で副作用を発生し、次のアクションは送らない
     - `Effect.fireAndForget(id:queue:run:)`
 3. `async` 関数で副作用を発生し、次のアクションを送る
-    - `Effect.init(id:queue:run:)`
+    - `Effect(id:queue:run:)`
 4. `AsyncSequence` で副作用を発生させつつ次のアクションを送る処理を「複数回」行う
-    - `Effect.init(id:queue:sequence:)`
+    - `Effect.sequence(id:queue:_:)`
 5. `EffectID` を使った手動キャンセル
     - `Effect.cancel(id:)`
     - `Effect.cancel(ids:)`
@@ -121,9 +121,9 @@ let environment = Environment(
 ```swift
 let mockEnvironment = Environment(
     login: { userId in
-        Effect.nextAction(.loginOK) // API 通信をせず、次のアクションだけ送る
+        Effect.next(action: .loginOK) // API 通信をせず、次のアクションだけ送る
     },
-    logout: Effect.nextAction(.logoutOK)
+    logout: Effect.next(action: .logoutOK)
 )
 ```
 

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -223,7 +223,7 @@ public struct SendRouteEnvironment<Environment, Route>: Sendable
     /// ...
     ///
     /// // Inside `RouteStore`'s Reducer:
-    /// Effect(sequence: { _ in
+    /// Effect.sequence { _ in
     ///     /// Send `Route` and get `AsyncStream` from next screen.
     ///     let stream = environment.sendRouteAsyncStream { continuation in
     ///         return Route.showNextScreen(someArg, continuation)
@@ -237,7 +237,7 @@ public struct SendRouteEnvironment<Environment, Route>: Sendable
     ///             return Action._didFinishReceivingValues
     ///         }
     ///     }
-    /// })
+    /// }
     ///
     /// ...
     ///

--- a/Tests/ActomatonTestingTests/TestActomatonTests.swift
+++ b/Tests/ActomatonTestingTests/TestActomatonTests.swift
@@ -139,7 +139,7 @@ final class TestActomatonTests: MainTestCase
                 switch action {
                 case .increment:
                     state.count += 1
-                    return recordEffect + .nextAction(.reset)
+                    return recordEffect + .next(action: .reset)
                 case .decrement:
                     state.count -= 1
                     return recordEffect
@@ -242,7 +242,7 @@ final class TestActomatonTests: MainTestCase
                 switch action {
                 case .increment:
                     state.count += 1
-                    return .nextAction(.reset)
+                    return .next(action: .reset)
                 case .decrement:
                     state.count -= 1
                     return .empty
@@ -363,10 +363,10 @@ private let chainReducer = MealyReducer<ChainAction, ChainState, Void, Effect<Ch
     switch action {
     case .step1:
         state.steps.append("step1")
-        return .nextAction(.step2)
+        return .next(action: .step2)
     case .step2:
         state.steps.append("step2")
-        return .nextAction(.step3)
+        return .next(action: .step3)
     case .step3:
         state.steps.append("step3")
         return .empty

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -42,7 +42,7 @@ final class FeedbackTrackingTaskTests: MainTestCase
                     guard state == ._3 else { return .empty }
 
                     state = ._4(count: 0)
-                    return Effect(sequence: { context in
+                    return Effect.sequence { context in
                         AsyncStream<Action> { continuation in
                             let task = Task<(), any Error> {
                                 for _ in 1 ... 2 {
@@ -61,7 +61,7 @@ final class FeedbackTrackingTaskTests: MainTestCase
                                 task.cancel()
                             }
                         }
-                    })
+                    }
 
                 case ._increment:
                     guard case let ._4(count) = state else { return .empty }

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -15,7 +15,7 @@ final class TimerTests: MainTestCase
             reducer: Reducer { action, state, _ in
                 switch action {
                 case .start:
-                    let timerEffect = Effect(id: TimerID(), sequence: { context in
+                    let timerEffect = Effect.sequence(id: TimerID()) { context in
                         AsyncStream<()> { continuation in
                             let task = Task {
                                 while true {
@@ -29,7 +29,7 @@ final class TimerTests: MainTestCase
                             }
                         }
                         .map { Action.tick }
-                    })
+                    }
                     return timerEffect
                 case .tick:
                     state += 1

--- a/Tests/WasmSmokeTests/WasmSmokeTests.swift
+++ b/Tests/WasmSmokeTests/WasmSmokeTests.swift
@@ -35,7 +35,7 @@ func `actomaton runs synchronous effects on wasm`() async
         switch action {
         case .increment:
             state.count += 1
-            return .nextAction(.reset)
+            return .next(action: .reset)
         case .reset:
             state.count = 0
             return .empty


### PR DESCRIPTION
## Summary

Rename two `Effect` factories so the public surface reads consistently at call sites and aligns with the rest of the API (`fireAndForget`, `cancel`, `updateQueue`), which are all `static func` factories with verb-shaped names.

- `Effect.nextAction(_:)` → `Effect.next(action:)`
- `Effect.init(id:queue:sequence:)` → `Effect.sequence(id:queue:_:)` (init → static factory; closure is now a trailing closure)

Pure rename — no behavior change.

### Why

Two small inconsistencies in the `Effect` API:

1. `nextAction(_:)` packed the argument label into the method name. Reading `Effect.nextAction(.reset)` you can't tell whether `.reset` is an action, a state, or something else. `Effect.next(action: .reset)` makes the role explicit.
2. The `AsyncSequence` variant was the only `Effect` factory still spelled as an `init(...)` with a named `sequence:` parameter — all sibling factories (`fireAndForget`, `next`, `cancel`, `updateQueue`) are `static func`s. As an init it also couldn't take a trailing closure cleanly when `id:`/`queue:` were present.

### Before

```swift
// 1. nextAction
return .nextAction(.reset)

// 2. AsyncSequence init — labelled `sequence:`, no trailing-closure form
Effect(id: TimerID(), sequence: { _ in
    AsyncStream<()> { ... }
})
```

### After

```swift
// 1. next(action:) — argument role explicit at call site
return .next(action: .reset)

// 2. sequence(id:queue:_:) — static factory, trailing closure
Effect.sequence(id: TimerID()) { _ in
    AsyncStream<()> { ... }
}
```

### What changes

In `Sources/ActomatonEffect/Effect.swift`:

- `Effect.nextAction(_:)` is renamed to `Effect.next(action:)`.
- The four `Effect.init(...sequence:)` overloads (plain, `(id:)`, `(queue:)`, `(id:queue:)`) become `static func sequence(...)` factories with an unlabelled trailing-closure parameter.

Call-site updates across the repo:

- Docs: `README.md`, `Examples/01-Counter.md`, `Examples/03-Timer.md`, `OOP-Tutorial/02-LoginLogout.md`
- Sources: `RouteStore.swift` (doc comment only)
- Tests: `TestActomatonTests`, `FeedbackTrackingTaskTests`, `TimerTests`, `WasmSmokeTests`

Net diff: 10 files changed, 44 insertions, 40 deletions.

## Test plan

- [x] Local `swift build` — passes
- [x] Local `swift test` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
