### PR TITLE
Add Effect.stream for emitting Actions via send closure

### DIFF
--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -255,7 +255,8 @@ extension Effect
                     if autoFinish {
                         continuation.finish()
                     }
-                } catch {
+                }
+                catch {
                     continuation.finish(throwing: error)
                 }
             }

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -129,6 +129,142 @@ extension Effect
         )
     }
 
+    // MARK: - Finite/Infinite Stream
+
+    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
+    ///
+    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
+    ///   returns — for bridging long-lived observers (delegates, callbacks, notifications)
+    ///   where the closure stores `send` into an outer reference (e.g. captured by a
+    ///   handler) and keeps emitting until cancelled externally. `true` finishes the
+    ///   stream on closure return — for self-terminating producers driven entirely inline.
+    /// - Parameter bufferingPolicy: Buffering policy of the underlying
+    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
+    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    public static func stream(
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action>
+    {
+        .sequence {
+            _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
+        }
+    }
+
+    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
+    ///
+    /// - Parameter id: Cancellation identifier.
+    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
+    ///   returns — for bridging long-lived observers that hold `send` and keep emitting
+    ///   until cancelled externally. `true` finishes the stream on closure return —
+    ///   for self-terminating producers driven entirely inline.
+    /// - Parameter bufferingPolicy: Buffering policy of the underlying
+    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
+    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    public static func stream<ID>(
+        id: ID? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action>
+        where ID: EffectID
+    {
+        .sequence(id: id) {
+            _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
+        }
+    }
+
+    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
+    ///
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
+    ///   returns — for bridging long-lived observers that hold `send` and keep emitting
+    ///   until cancelled externally. `true` finishes the stream on closure return —
+    ///   for self-terminating producers driven entirely inline.
+    /// - Parameter bufferingPolicy: Buffering policy of the underlying
+    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
+    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    public static func stream<Queue>(
+        queue: Queue? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action>
+        where Queue: EffectQueue
+    {
+        .sequence(queue: queue) {
+            _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
+        }
+    }
+
+    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
+    ///
+    /// - Parameter id: Cancellation identifier.
+    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
+    ///   returns — for bridging long-lived observers that hold `send` and keep emitting
+    ///   until cancelled externally. `true` finishes the stream on closure return —
+    ///   for self-terminating producers driven entirely inline.
+    /// - Parameter bufferingPolicy: Buffering policy of the underlying
+    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
+    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    public static func stream<ID, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action>
+        where ID: EffectID, Queue: EffectQueue
+    {
+        .sequence(id: id, queue: queue) {
+            _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
+        }
+    }
+
+    /// Bridges the user's `(send, context) async throws -> Void` closure into an
+    /// `AsyncThrowingStream` whose continuation is finished when the closure returns
+    /// or throws, and whose termination cancels the running task.
+    private static func _makeStream(
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void,
+        context: EffectContext,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy,
+        autoFinish: Bool
+    ) -> AsyncThrowingStream<Action, any Error>
+    {
+        AsyncThrowingStream<Action, any Error>(bufferingPolicy: bufferingPolicy) { continuation in
+            let task = Task<Void, any Error> {
+                do {
+                    try await stream({ continuation.yield($0) }, context)
+                    if autoFinish {
+                        continuation.finish()
+                    }
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
     // MARK: - fireAndForget
 
     /// Single-`async` side-effect without returning next action, with `EffectContext`.

--- a/Tests/ActomatonTests/EffectStreamTests.swift
+++ b/Tests/ActomatonTests/EffectStreamTests.swift
@@ -11,8 +11,13 @@ final class EffectStreamTests: MainTestCase
         var didCancel = false
         var didCancelPrevious = false
 
-        func markCancelled() { didCancel = true }
-        func markPreviousCancelled() { didCancelPrevious = true }
+        func markCancelled() {
+            didCancel = true
+        }
+
+        func markPreviousCancelled() {
+            didCancelPrevious = true
+        }
     }
 
     override func setUp() async throws

--- a/Tests/ActomatonTests/EffectStreamTests.swift
+++ b/Tests/ActomatonTests/EffectStreamTests.swift
@@ -1,0 +1,431 @@
+import Actomaton
+import XCTest
+
+/// Tests for `Effect.stream`.
+final class EffectStreamTests: MainTestCase
+{
+    private var flags = Flags()
+
+    private actor Flags
+    {
+        var didCancel = false
+        var didCancelPrevious = false
+
+        func markCancelled() { didCancel = true }
+        func markPreviousCancelled() { didCancelPrevious = true }
+    }
+
+    override func setUp() async throws
+    {
+        flags = Flags()
+    }
+
+    // MARK: - stream (no id, no queue)
+
+    func test_stream_emitsMultipleActions() async throws
+    {
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .start:
+                    return .stream { send, context in
+                        for _ in 0 ..< 3 {
+                            try await context.clock.sleep(for: .ticks(1))
+                            send(.tick)
+                        }
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .empty
+                }
+            },
+            effectContext: effectContext
+        )
+
+        assertEqual(await actomaton.state, 0)
+
+        await actomaton.send(.start)
+        assertEqual(await actomaton.state, 0)
+
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 1)
+
+        await clock.advance(by: .ticks(1))
+        assertEqual(await actomaton.state, 2)
+
+        await clock.advance(by: .ticks(1))
+        assertEqual(await actomaton.state, 3)
+
+        await clock.advance(by: .ticks(5))
+        assertEqual(
+            await actomaton.state,
+            3,
+            "Closure already finished, so no more ticks."
+        )
+    }
+
+    // MARK: - stream (id)
+
+    /// Also exercises the `onTermination → task.cancel()` path: cancelling the effect
+    /// terminates the underlying `AsyncThrowingStream`, which propagates `CancellationError`
+    /// into the producer closure via `task.cancel()`.
+    func test_stream_id_canBeCancelledById() async throws
+    {
+        struct TimerID: EffectID {}
+
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { [flags] action, state, _ in
+                switch action {
+                case .start:
+                    return .stream(id: TimerID()) { send, context in
+                        do {
+                            while true {
+                                try await context.clock.sleep(for: .ticks(1))
+                                send(.tick)
+                            }
+                        }
+                        catch is CancellationError {
+                            await flags.markCancelled()
+                            throw CancellationError()
+                        }
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .cancel(id: TimerID())
+                }
+            },
+            effectContext: effectContext
+        )
+
+        await actomaton.send(.start)
+
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 1)
+
+        await clock.advance(by: .ticks(1))
+        assertEqual(await actomaton.state, 2)
+
+        await actomaton.send(.stop)
+
+        await clock.advance(by: .ticks(5))
+        assertEqual(
+            await actomaton.state,
+            2,
+            "Should not increment because stream is cancelled."
+        )
+
+        let didCancel = await flags.didCancel
+        XCTAssertTrue(
+            didCancel,
+            "Inner closure should observe CancellationError when stream is cancelled."
+        )
+    }
+
+    // MARK: - stream (queue)
+
+    func test_stream_queue_autoCancelsPreviousStream() async throws
+    {
+        struct TestNewest1Queue: Newest1EffectQueue {}
+
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { [flags] action, state, _ in
+                switch action {
+                case .start:
+                    return .stream(queue: TestNewest1Queue()) { send, context in
+                        do {
+                            while true {
+                                try await context.clock.sleep(for: .ticks(1))
+                                send(.tick)
+                            }
+                        }
+                        catch is CancellationError {
+                            await flags.markPreviousCancelled()
+                            throw CancellationError()
+                        }
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .empty
+                }
+            },
+            effectContext: effectContext
+        )
+
+        await actomaton.send(.start)
+
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 1)
+
+        // Start a new stream — previous one should be auto-cancelled by `Newest1EffectQueue`.
+        await actomaton.send(.start)
+
+        // Give the queue a moment to swap streams.
+        await settle()
+
+        let didCancelPrevious = await flags.didCancelPrevious
+        XCTAssertTrue(
+            didCancelPrevious,
+            "Previous stream should be cancelled by Newest1EffectQueue."
+        )
+
+        // New stream continues to emit.
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 2)
+
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 3)
+    }
+
+    // MARK: - stream (id + queue)
+
+    func test_stream_idAndQueue_canBeCancelledById() async throws
+    {
+        struct TimerID: EffectID {}
+        struct TestNewest1Queue: Newest1EffectQueue {}
+
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { [flags] action, state, _ in
+                switch action {
+                case .start:
+                    return .stream(id: TimerID(), queue: TestNewest1Queue()) { send, context in
+                        do {
+                            while true {
+                                try await context.clock.sleep(for: .ticks(1))
+                                send(.tick)
+                            }
+                        }
+                        catch is CancellationError {
+                            await flags.markCancelled()
+                            throw CancellationError()
+                        }
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .cancel(id: TimerID())
+                }
+            },
+            effectContext: effectContext
+        )
+
+        await actomaton.send(.start)
+
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 1)
+
+        await actomaton.send(.stop)
+        await clock.advance(by: .ticks(5))
+
+        assertEqual(
+            await actomaton.state,
+            1,
+            "Should not increment because stream is cancelled."
+        )
+
+        let didCancel = await flags.didCancel
+        XCTAssertTrue(didCancel)
+    }
+
+    // MARK: - continuation finish
+
+    /// `autoFinish: true` — closure return finishes the stream, so the unified `send`
+    /// task completes without explicit cancellation.
+    func test_stream_autoFinishTrue_unifiedTaskCompletesWhenClosureReturns() async throws
+    {
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .start:
+                    return .stream(autoFinish: true) { send, context in
+                        for _ in 0 ..< 2 {
+                            try await context.clock.sleep(for: .ticks(1))
+                            send(.tick)
+                        }
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .empty
+                }
+            },
+            effectContext: effectContext
+        )
+
+        let task = await actomaton.send(.start)
+        XCTAssertNotNil(task)
+
+        await clock.advance(by: .ticks(2.6))
+
+        // Should NOT hang — `autoFinish: true` calls `continuation.finish()` on closure return.
+        try await task?.value
+
+        assertEqual(await actomaton.state, 2)
+    }
+
+    /// `autoFinish: false` — `send` captured into an outer reference (here a detached
+    /// `Task`) can still emit `Action`s after the producer closure has returned.
+    /// This is the long-lived-observer bridging pattern the docstring promises.
+    func test_stream_autoFinishFalse_canEmitAfterClosureReturns() async throws
+    {
+        struct TimerID: EffectID {}
+
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { [clock] action, state, _ in
+                switch action {
+                case .start:
+                    return .stream(id: TimerID()) { send, _ in
+                        // Hand `send` off to a detached task, then return immediately.
+                        // The continuation must stay open so the detached task can emit.
+                        Task { @Sendable in
+                            for _ in 0 ..< 3 {
+                                try await clock.sleep(for: .ticks(1))
+                                send(.tick)
+                            }
+                        }
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .cancel(id: TimerID())
+                }
+            },
+            effectContext: effectContext
+        )
+
+        await actomaton.send(.start)
+
+        await clock.advance(by: .ticks(1.3))
+        assertEqual(await actomaton.state, 1)
+
+        await clock.advance(by: .ticks(1))
+        assertEqual(await actomaton.state, 2)
+
+        await clock.advance(by: .ticks(1))
+        assertEqual(
+            await actomaton.state,
+            3,
+            "Detached task should keep emitting via `send` even after the producer closure returned."
+        )
+
+        await actomaton.send(.stop)
+    }
+
+    /// `autoFinish: false` (default) — closure return does NOT finish the stream,
+    /// so the effect stays alive until explicitly cancelled.
+    func test_stream_autoFinishFalse_keepsRunningAfterClosureReturns() async throws
+    {
+        struct TimerID: EffectID {}
+
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .start:
+                    return .stream(id: TimerID()) { send, context in
+                        for _ in 0 ..< 2 {
+                            try await context.clock.sleep(for: .ticks(1))
+                            send(.tick)
+                        }
+                        // Closure returns here — but stream stays open because `autoFinish` is false.
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .cancel(id: TimerID())
+                }
+            },
+            effectContext: effectContext
+        )
+
+        let task = await actomaton.send(.start)
+        XCTAssertNotNil(task)
+
+        await clock.advance(by: .ticks(2.6))
+        assertEqual(await actomaton.state, 2)
+
+        // Stream did not finish on its own — `task.value` would hang here.
+        XCTAssertFalse(task?.isCancelled ?? true)
+
+        // Explicit cancellation is required to complete the effect.
+        await actomaton.send(.stop)
+
+        do {
+            try await task?.value
+        }
+        catch is CancellationError {
+            // Cancellation is one acceptable outcome.
+        }
+
+        assertEqual(await actomaton.state, 2)
+    }
+
+    /// Verifies that the underlying `AsyncThrowingStream` continuation finishes
+    /// with the thrown error, so the unified `send` task rethrows that error
+    /// (rather than hanging on the inner `for try await` loop).
+    func test_stream_unifiedTaskRethrowsClosureError() async throws
+    {
+        struct StreamError: Error, Equatable {}
+
+        let actomaton = Actomaton<Action, State>(
+            state: 0,
+            reducer: Reducer { action, state, _ in
+                switch action {
+                case .start:
+                    return .stream { send, context in
+                        try await context.clock.sleep(for: .ticks(1))
+                        send(.tick)
+                        throw StreamError()
+                    }
+                case .tick:
+                    state += 1
+                    return .empty
+                case .stop:
+                    return .empty
+                }
+            },
+            effectContext: effectContext
+        )
+
+        let task = await actomaton.send(.start)
+        XCTAssertNotNil(task)
+
+        await clock.advance(by: .ticks(1.3))
+
+        do {
+            try await task?.value
+            XCTFail("Should rethrow StreamError from the closure.")
+        }
+        catch is StreamError {
+            // Expected — `continuation.finish(throwing:)` propagated the error.
+        }
+
+        assertEqual(await actomaton.state, 1)
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case start
+    case tick
+    case stop
+}
+
+private typealias State = Int


### PR DESCRIPTION
## Summary

Add `Effect.stream(...)` — a stream-style factory that bridges a `(send, context) async throws -> Void` closure to an `AsyncThrowingStream`, so reducers can emit multiple `Action`s over time without hand-rolling an `AsyncStream` and feeding it to `Effect.sequence`.

This fills the gap between `Effect.fireAndForget` (one-shot, returns nothing) and `Effect.sequence` (consumer of a pre-built `AsyncSequence`). It mirrors TCA's `.run { send in ... }` ergonomics while keeping `EffectContext` plumbing intact.

### Before

Emitting N actions from a single side-effect required constructing an `AsyncStream` and threading its continuation through `Effect.sequence`:

```swift
return .sequence { context in
    AsyncStream<Action> { continuation in
        let task = Task {
            for _ in 0 ..< 3 {
                try await context.clock.sleep(for: .seconds(1))
                continuation.yield(.tick)
            }
            continuation.finish()
        }
        continuation.onTermination = { _ in task.cancel() }
    }
}
```

### After

```swift
return .stream(autoFinish: true) { send, context in
    for _ in 0 ..< 3 {
        try await context.clock.sleep(for: .seconds(1))
        send(.tick)
    }
}
```

### What's added

In `Sources/ActomatonEffect/Effect.swift`:

- Four `Effect.stream(...)` overloads matching `Effect.sequence`'s shape: plain, `(id:)`, `(queue:)`, `(id:queue:)`.
- A private `_makeStream(...)` helper that wraps the user closure into an `AsyncThrowingStream`, finishes the continuation when the closure throws, and cancels the running task on stream termination.
- `autoFinish: Bool = false` parameter:
  - `false` (default) — keeps the stream alive after the closure returns. Intended for bridging long-lived observers (delegates, callbacks, `NotificationCenter`) where the closure stores `send` into an outer reference and keeps emitting until cancelled externally.
  - `true` — finishes the stream on closure return, so awaiting the unified `send` task completes naturally for self-terminating producers.
- `bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded` — pass `.bufferingNewest(n)` or `.bufferingOldest(n)` to apply backpressure for high-frequency producers.

The `send` closure is typed `@Sendable (sending Action) -> Void`, forwarding to `AsyncThrowingStream.Continuation.yield(_: sending)` so non-`Sendable` actions can cross isolation boundaries via region-based isolation.

### Tests

`Tests/ActomatonTests/EffectStreamTests.swift` — 8 cases:

- `test_stream_emitsMultipleActions` — basic emit loop.
- `test_stream_id_canBeCancelledById` — `.cancel(id:)` terminates the stream; the producer observes `CancellationError`. Also exercises the `onTermination → task.cancel()` path.
- `test_stream_queue_autoCancelsPreviousStream` — `Newest1EffectQueue` cancels the previous stream when a new one starts.
- `test_stream_idAndQueue_canBeCancelledById` — id + queue combined.
- `test_stream_autoFinishTrue_unifiedTaskCompletesWhenClosureReturns` — `autoFinish: true` lets `task.value` complete without explicit cancellation.
- `test_stream_autoFinishFalse_keepsRunningAfterClosureReturns` — default `autoFinish: false` keeps the effect alive until externally cancelled.
- `test_stream_autoFinishFalse_canEmitAfterClosureReturns` — locks in the long-lived-observer pattern: `send` captured into a detached `Task` continues to emit `Action`s after the producer closure has returned.
- `test_stream_unifiedTaskRethrowsClosureError` — closure errors propagate via `continuation.finish(throwing:)` to the unified `send` task.

## Test plan

- [x] Local `swift build` — passes
- [x] Local `swift test --filter EffectStreamTests` — 8 tests pass
- [x] Local `swift test` — 75 tests pass
- [ ] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
