### PR TITLE
Refresh README/DocC examples and fix doc-comment typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ ActomatonCore          -- generic MealyMachine + MealyReducer + EffectManager
 
 `ActomatonCore` is intentionally free of `Effect` and async task management.
 This makes `MealyMachine` usable in contexts where full effect infrastructure is overkill — for example, purely synchronous state machines, game logic, or protocol parsers.
-Built-in `EffectManager` conformers cover common cases:
+The default `EffectManager` conformer ships in `ActomatonEffect`:
 
 | Conformer | Output type | Use case |
 |---|---|---|
-| `EffectQueueManager` (internal) | `Effect<Action>` | Full async effect lifecycle (in `ActomatonEffect`) |
-| `NoOpEffectManager` | `Void` | Pure state transitions, no side-effects |
-| `ActionEffectManager` | `[Action]` | Synchronous action feedback loops |
+| `EffectQueueManager` (package) | `Effect<Action>` | Full async effect lifecycle (in `ActomatonEffect`) |
+
+You can also provide your own `EffectManager` conformer to plug in a custom output type (e.g. `Void` for purely synchronous state machines, or `[Action]` for synchronous action feedback loops).
 
 ## Platform Support
 
@@ -166,9 +166,97 @@ NOTE: There are 5 ways of creating `Effect` in Actomaton:
 5. Manual cancellation
     - `Effect.cancel(id:)` / `.cancel(ids:)`
 
-### Example 1-2. Login-Logout (and ForceLogout)
+### Example 1-2. Timer (using `AsyncSequence`) and `EffectID` cancellation
+
+```swift
+typealias State = Int
+
+enum Action: Sendable {
+    case start, tick, stop
+}
+
+struct TimerID: EffectID {}
+
+struct Environment: Sendable {
+    let timer: @Sendable () -> AsyncStream<Void>
+}
+
+let environment = Environment(
+    timer: {
+        AsyncStream<Void> { continuation in
+            let task = Task {
+                while true {
+                    try await Task.sleep(/* 1 sec */)
+                    continuation.yield(())
+                }
+            }
+
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+)
+
+let reducer = Reducer { action, state, environment in
+    switch action {
+    case .start:
+        return Effect.sequence(id: TimerID()) { _ in
+            environment.timer()
+                .map { _ in Action.tick }
+        }
+    case .tick:
+        state += 1
+        return .empty
+    case .stop:
+        return Effect.cancel(id: TimerID())
+    }
+}
+
+let actomaton = Actomaton<Action, State>(
+    state: 0,
+    reducer: reducer,
+    environment: environment
+)
+
+@main
+enum Main {
+    static func test_timer() async {
+        assertEqual(await actomaton.state, 0)
+
+        await actomaton.send(.start)
+
+        assertEqual(await actomaton.state, 0)
+
+        try await Task.sleep(/* 1 sec */)
+        assertEqual(await actomaton.state, 1)
+
+        try await Task.sleep(/* 1 sec */)
+        assertEqual(await actomaton.state, 2)
+
+        try await Task.sleep(/* 1 sec */)
+        assertEqual(await actomaton.state, 3)
+
+        await actomaton.send(.stop)
+
+        try await Task.sleep(/* long enough */)
+        assertEqual(await actomaton.state, 3,
+                    "Should not increment because timer is stopped.")
+    }
+}
+```
+
+Here we see the notions of `EffectID`, `Environment`, and `Effect.sequence`:
+
+- `EffectID` tags an effect with a `Hashable` identifier so it can be cancelled later via `Effect.cancel(id:)`. In this example, `TimerID` lets `.stop` cancel the running timer.
+- `Environment` holds the raw dependencies (here, an `AsyncStream`-producing closure). The `Reducer` is responsible for wrapping those dependencies in `Effect`. **`Environment` is known as Dependency Injection Container** (using Reader monad).
+- `Effect.sequence(id:_:)` turns an `AsyncSequence` into an `Effect`, yielding `Action.tick` multiple times until cancelled.
+
+### Example 1-3. Login-Logout (and ForceLogout) — `EffectQueue` for automatic cancellation
 
 ![login-diagram](https://user-images.githubusercontent.com/138476/132146518-686deb5f-ff01-489a-abf2-e2ef2a2adb03.png)
+
+`EffectID` (introduced in Example 1-2) only supports *manual* cancellation. When you instead want effects sharing the same identity to be cancelled (or suspended) automatically as new ones arrive, attach an ``EffectQueue``.
 
 ```swift
 enum State: Sendable {
@@ -181,35 +269,26 @@ enum Action: Sendable {
 }
 
 // NOTE:
-// Use same `EffectID` so that if previous effect is still running,
-// next effect with same `EffectID` will automatically cancel the previous one.
-//
-// Note that `EffectID` is also useful for manual cancellation via `Effect.cancel`.
-struct LoginFlowEffectID: EffectID {}
+// By attaching this `EffectQueue` to multiple `Effect`s, they share the same
+// `EffectQueuePolicy` — here, `Newest1EffectQueue` lets only the newest
+// effect survive and automatically cancels older queued effects.
+struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
 struct Environment: Sendable {
-    let loginEffect: (userId: String) -> Effect<Action>
-    let logoutEffect: Effect<Action>
+    let login: @Sendable (_ userId: String) async throws -> Void
+    let logout: @Sendable () async throws -> Void
 }
 
 let environment = Environment(
-    loginEffect: { userId in
-        Effect(id: LoginFlowEffectID()) { _ in
-            let loginRequest = ...
-            let data = try? await URLSession.shared.data(for: loginRequest)
-            if Task.isCancelled { return nil }
-            ...
-            return Action.loginOK // next action
-        }
+    login: { userId in
+        let loginRequest = ...
+        _ = try? await URLSession.shared.data(for: loginRequest)
+        ...
     },
-    logoutEffect: {
-        Effect(id: LoginFlowEffectID()) { _ in
-            let logoutRequest = ...
-            let data = try? await URLSession.shared.data(for: logoutRequest)
-            if Task.isCancelled { return nil }
-            ...
-            return Action.logoutOK // next action
-        }
+    logout: {
+        let logoutRequest = ...
+        _ = try? await URLSession.shared.data(for: logoutRequest)
+        ...
     }
 )
 
@@ -217,7 +296,10 @@ let reducer = Reducer { action, state, environment in
     switch (action, state) {
     case (.login, .loggedOut):
         state = .loggingIn
-        return environment.login(state.userId)
+        return Effect(queue: LoginFlowEffectQueue()) { _ in
+            try await environment.login("user-123")
+            return Action.loginOK
+        }
 
     case (.loginOK, .loggingIn):
         state = .loggedIn
@@ -227,7 +309,10 @@ let reducer = Reducer { action, state, environment in
         (.forceLogout, .loggingIn),
         (.forceLogout, .loggedIn):
         state = .loggingOut
-        return environment.logout()
+        return Effect(queue: LoginFlowEffectQueue()) { _ in
+            try await environment.logout()
+            return Action.logoutOK
+        }
 
     case (.logoutOK, .loggingOut):
         state = .loggedOut
@@ -277,7 +362,7 @@ enum Main {
         assertEqual(await actomaton.state, .loggingIn)
 
         // Wait for a while and interrupt by `forceLogout`.
-        // Login's effect will be automatically cancelled because of same `EffectID.
+        // Login's effect will be automatically cancelled because of same `EffectQueue`.
         try await Task.sleep(/* 1 ms */)
         t = await actomaton.send(.forceLogout)
 
@@ -285,97 +370,16 @@ enum Main {
 
         await t?.value // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
-
     }
 }
 ```
 
-Here we see the notions of `EffectID`, `Environment`, and `let task: Task<(), Error> = actomaton.send(...)`
+Here we see the notions of `EffectQueue` and the `Task<(), Error>` returned from `actomaton.send(...)`:
 
-- `EffectID` is for both manual & automatic cancellation of previous running effects. In this example, `forceLogout` will cancel `login`'s networking effect.
-- `Environment` is useful for injecting effects to be called inside `Reducer` so that they become replaceable. **`Environment` is known as Dependency Injection** (using Reader monad).
+- `EffectQueue` is for automatic cancellation or suspension of effects.
+  In this example, `Newest1EffectQueue` is used so that only the newest 1 effect (`forceLogout`) will survive,
+  and the rest of older queued effects (e.g. an in-flight `login`) will be automatically cancelled.
 - (Optional) `Task<(), Error>` returned from `actomaton.send(action)` is another fancy way of dealing with "all the effects triggered by `action`". We can call `await task.value` to wait for all of them to be completed, or `task.cancel()` to cancel all. Note that `Actomaton` already manages such `task`s for us internally, so we normally don't need to handle them by ourselves (use this as a last resort!).
-
-### Example 1-3. Timer (using `AsyncSequence`) and `EffectID` cancellation
-
-```swift
-typealias State = Int
-
-enum Action: Sendable {
-    case start, tick, stop
-}
-
-struct TimerID: EffectID {}
-
-struct Environment {
-    let timerEffect: Effect<Action>
-}
-
-let environment = Environment(
-    timerEffect: { userId in
-        Effect.sequence(id: TimerID()) { _ in
-            AsyncStream<()> { continuation in
-                let task = Task {
-                    while true {
-                        try await Task.sleep(/* 1 sec */)
-                        continuation.yield(())
-                    }
-                }
-
-                continuation.onTermination = { @Sendable _ in
-                    task.cancel()
-                }
-            }
-        }
-    }
-)
-
-let reducer = Reducer { action, state, environment in
-    switch action {
-    case .start:
-        return environment.timerEffect
-    case .tick:
-        state += 1
-        return .empty
-    case .stop:
-        return Effect.cancel(id: TimerID())
-    }
-}
-
-let actomaton = Actomaton<Action, State>(
-    state: 0,
-    reducer: reducer,
-    environment: environment
-)
-
-@main
-enum Main {
-    static func test_timer() async {
-        assertEqual(await actomaton.state, 0)
-
-        await actomaton.send(.start)
-
-        assertEqual(await actomaton.state, 0)
-
-        try await Task.sleep(/* 1 sec */)
-        assertEqual(await actomaton.state, 1)
-
-        try await Task.sleep(/* 1 sec */)
-        assertEqual(await actomaton.state, 2)
-
-        try await Task.sleep(/* 1 sec */)
-        assertEqual(await actomaton.state, 3)
-
-        await actomaton.send(.stop)
-
-        try await Task.sleep(/* long enough */)
-        assertEqual(await actomaton.state, 3,
-                    "Should not increment because timer is stopped.")
-    }
-}
-```
-
-In this example, `Effect.sequence(id:)` is used for timer effect, which yields `Action.tick` multiple times.
 
 ### Example 1-4. `EffectQueue`
 
@@ -397,7 +401,7 @@ struct DelayedEffectQueue: EffectQueue {
         .runOldest(maxCount: 3, .suspendNew)
     }
 
-    // Adds delay between effect start. (This is useful for throttling / deboucing)
+    // Adds delay between effect start. (This is useful for throttling / debouncing)
     var effectQueueDelay: EffectQueueDelay {
         .random(0.1 ... 0.3)
     }

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples.md
@@ -5,7 +5,7 @@ Quick example code to grasp how Actomaton architecture works.
 ## Examples
 
 - <doc:01-Counter>
-- <doc:02-LoginLogout>
-- <doc:03-Timer>
+- <doc:02-Timer>
+- <doc:03-LoginLogout>
 - <doc:04-EffectQueue>
 - <doc:05-ReducerComposition>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/01-Counter.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/01-Counter.md
@@ -10,7 +10,7 @@ enum Action: Sendable {
     case decrement
 }
 
-enum State: Sendable {
+struct State: Sendable {
     var count: Int = 0
 }
 
@@ -60,7 +60,7 @@ reducer = Reducer { action, state, environment in
     switch action {
     case .increment:
         state.count += 1
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { _ in
             print("increment")
         }
     case .decrement:
@@ -92,4 +92,4 @@ NOTE: There are 5 ways of creating ``Effect`` in Actomaton:
 
 ## Next Step
 
-<doc:02-LoginLogout>
+<doc:02-Timer>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/02-Timer.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/02-Timer.md
@@ -1,10 +1,10 @@
-# Example 3: Timer 
+# Example 2: Timer
 
 `AsyncStream`-based timer example.
 
 ## Overview
 
-In this example, ``Effect``.``Effect/sequence(id:_:)`` is used for timer effect, which yields `Action.tick` multiple times.
+In this example, ``Effect/sequence(id:_:)`` is used for timer effect, which yields `Action.tick` multiple times.
 
 ```swift
 enum Action: Sendable {
@@ -16,23 +16,21 @@ typealias State = Int
 struct TimerID: EffectID {}
 
 struct Environment: Sendable {
-    let timerEffect: Effect<Action>
+    let timer: @Sendable () -> AsyncStream<Void>
 }
 
 let environment = Environment(
-    timerEffect: { userId in
-        Effect.sequence(id: TimerID()) {
-            AsyncStream<()> { continuation in
-                let task = Task {
-                    while true {
-                        try await Task.sleep(/* 1 sec */)
-                        continuation.yield(())
-                    }
+    timer: {
+        AsyncStream<Void> { continuation in
+            let task = Task {
+                while true {
+                    try await Task.sleep(/* 1 sec */)
+                    continuation.yield(())
                 }
+            }
 
-                continuation.onTermination = { @Sendable _ in
-                    task.cancel()
-                }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
             }
         }
     }
@@ -41,7 +39,10 @@ let environment = Environment(
 let reducer = Reducer { action, state, environment in
     switch action {
     case .start:
-        return environment.timerEffect
+        return Effect.sequence(id: TimerID()) { _ in
+            environment.timer()
+                .map { _ in Action.tick }
+        }
     case .tick:
         state += 1
         return .empty
@@ -85,4 +86,4 @@ enum Main {
 
 ## Next Step
 
-<doc:04-EffectQueue>
+<doc:03-LoginLogout>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-LoginLogout.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/03-LoginLogout.md
@@ -1,11 +1,15 @@
-# Example 2: Auth state
+# Example 3: Auth state
 
-Auth screen (login, logout, and force-logout) example.
+Auth screen (login, logout, and force-logout) example, demonstrating `EffectQueue` for automatic cancellation.
 
 ## Overview
 
 This example illustrates Auth state management where `login`, `logout`, and `forceLogout` 
 will trigger side-effects (such as API requests) then sends `loginOK` or `logoutOK` on completion.
+
+``EffectID`` (introduced in <doc:02-Timer>) only supports *manual* cancellation via ``Effect/cancel(id:)``.
+When you instead want effects sharing the same identity to be cancelled (or suspended) automatically as new ones arrive,
+attach an ``EffectQueue``.
 
 ![login-diagram](login-logout.png)
 
@@ -20,37 +24,26 @@ enum State: Sendable {
 }
 
 // NOTE:
-// By attaching this EffectQueue to multiple `Effect`s,
-// they will incorporate with each other under the same `EffectQueuePolicy`,
-// in this case: `Newest1EffectQueue`.
-// 
-// This policy will only allow at most newest 1 effect to survive,
-// and rest of the queued running effects will be automatically cancelled.
+// By attaching this `EffectQueue` to multiple `Effect`s, they share the same
+// `EffectQueuePolicy` — here, `Newest1EffectQueue` lets only the newest
+// effect survive and automatically cancels older queued effects.
 struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
 struct Environment: Sendable {
-    let loginEffect: @Sendable (userId: String) -> Effect<Action>
-    let logoutEffect: Effect<Action>
+    let login: @Sendable (_ userId: String) async throws -> Void
+    let logout: @Sendable () async throws -> Void
 }
 
 let environment = Environment(
-    loginEffect: { userId in
-        Effect(queue: LoginFlowEffectQueue()) {
-            let loginRequest = ...
-            let data = try? await URLSession.shared.data(for: loginRequest)
-            if Task.isCancelled { return nil }
-            ...
-            return Action.loginOK // next action
-        }
+    login: { userId in
+        let loginRequest = ...
+        _ = try? await URLSession.shared.data(for: loginRequest)
+        ...
     },
-    logoutEffect: {
-        Effect(queue: LoginFlowEffectQueue()) {
-            let logoutRequest = ...
-            let data = try? await URLSession.shared.data(for: logoutRequest)
-            if Task.isCancelled { return nil }
-            ...
-            return Action.logoutOK // next action
-        }
+    logout: {
+        let logoutRequest = ...
+        _ = try? await URLSession.shared.data(for: logoutRequest)
+        ...
     }
 )
 
@@ -58,7 +51,10 @@ let reducer = Reducer { action, state, environment in
     switch (action, state) {
     case (.login, .loggedOut):
         state = .loggingIn
-        return environment.login(state.userId)
+        return Effect(queue: LoginFlowEffectQueue()) { _ in
+            try await environment.login("user-123")
+            return Action.loginOK
+        }
 
     case (.loginOK, .loggingIn):
         state = .loggedIn
@@ -68,14 +64,17 @@ let reducer = Reducer { action, state, environment in
         (.forceLogout, .loggingIn),
         (.forceLogout, .loggedIn):
         state = .loggingOut
-        return environment.logout()
+        return Effect(queue: LoginFlowEffectQueue()) { _ in
+            try await environment.logout()
+            return Action.logoutOK
+        }
 
     case (.logoutOK, .loggingOut):
         state = .loggedOut
         return .empty
 
     default:
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { _ in
             print("State transition failed...")
         }
     }
@@ -134,7 +133,7 @@ Here we see the notions of `EffectQueue`, `Environment`, and `let task: Task<(),
 
 - `EffectQueue` is for automatic cancellation or suspension of effects. 
   In this example, `Newest1EffectQueue` is used so that only the newest 1 effect (`forceLogout`) will survive,
-  and rest of old queued effects (e.g. previous `login`) will be automatically cancelled.
+  and the rest of older queued effects (e.g. an in-flight `login`) will be automatically cancelled.
 - `Environment` is useful for injecting effects to be called inside `Reducer` so that they become replaceable. 
   **`Environment` is known as Dependency Injection Container** (using Reader monad).
 - (Optional) `Task<(), Error>` returned from ``Actomaton/Actomaton/send(_:priority:tracksFeedbacks:)`` 
@@ -145,4 +144,4 @@ Here we see the notions of `EffectQueue`, `Environment`, and `let task: Task<(),
 
 ## Next Step
 
-<doc:03-Timer>
+<doc:04-EffectQueue>

--- a/Sources/Actomaton/Actomaton.docc/Articles/Examples/04-EffectQueue.md
+++ b/Sources/Actomaton/Actomaton.docc/Articles/Examples/04-EffectQueue.md
@@ -30,7 +30,7 @@ struct DelayedEffectQueue: EffectQueue {
         .runOldest(maxCount: 3, .suspendNew)
     }
 
-    // Adds delay between effect start. (This is useful for throttling / deboucing)
+    // Adds delay between effect start. (This is useful for throttling / debouncing)
     var effectQueueDelay: EffectQueueDelay {
         .random(0.1 ... 0.3)
     }

--- a/Sources/Actomaton/Reducer+Effect.swift
+++ b/Sources/Actomaton/Reducer+Effect.swift
@@ -1,7 +1,7 @@
 import ActomatonCore
 import CasePaths
 
-/// `Effect`-specific `ActomatonCore.Reducer` extensions: monoid, contramap(action:), map(id:), map(queue:).
+/// `Effect`-specific `MealyReducer` extensions: monoid, contramap(action:), map(id:), map(queue:).
 extension MealyReducer where Output == Effect<Action>
 {
     // MARK: - Monoid

--- a/Sources/ActomatonDebugging/Reducer+Debugging.swift
+++ b/Sources/ActomatonDebugging/Reducer+Debugging.swift
@@ -75,7 +75,7 @@ extension Reducer where Output == Effect<Action>
         return Self { action, state, environment in
             let currentState = state // Needs copy to not carry `inout`.
 
-            /// Effect for  Action & State `.simple` or `.all` printing.
+            // Effect for Action & State `.simple` or `.all` printing.
             let preEffect = Effect<Action>.fireAndForget { _ in
                 let name = format.name.map { "[\($0)]" } ?? ""
 

--- a/Sources/ActomatonEffect/EffectManager.swift
+++ b/Sources/ActomatonEffect/EffectManager.swift
@@ -14,7 +14,8 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
 
     /// Set up communication callbacks bridging the conformer to the parent safe container.
     ///
-    /// Called once by ``MealyMachine`` from inside its `setUp(...)`.
+    /// Called once by the wrapping safe container (e.g. ``Actomaton``, `MealyDriver`, `Store`,
+    /// `TestActomaton`, `DistributedActomaton`) during its initialization.
     ///
     /// - Parameters:
     ///   - withSendability:

--- a/Sources/ActomatonEffect/EffectQueueDelay.swift
+++ b/Sources/ActomatonEffect/EffectQueueDelay.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// ``EffectQueue``'s  delaying strategy.
+/// ``EffectQueue``'s delaying strategy.
 public enum EffectQueueDelay: Hashable, Sendable
 {
     case constant(TimeInterval)

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -193,7 +193,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
             }
 
         case .next:
-            // Should not appear — Actomaton resolves .next before passing to EffectQueueManager.
+            // Should not appear — MealyMachine.send resolves .next before passing to EffectQueueManager.
             return []
 
         case let .cancel(predicate):

--- a/Sources/ActomatonTesting/TestActomatonTask.swift
+++ b/Sources/ActomatonTesting/TestActomatonTask.swift
@@ -1,4 +1,4 @@
-/// A test task returned from ``TestActomaton/send(_:assert:fileID:file:line:)``.
+/// A test task returned from ``TestActomaton/send(_:assert:timeout:fileID:file:line:)``.
 ///
 /// Use this value to wait for all effects triggered by the sent action to finish, or to cancel
 /// them explicitly.

--- a/Sources/ActomatonUI/ActomatonUI.docc/Articles/OOP-Tutorial/02-LoginLogout.md
+++ b/Sources/ActomatonUI/ActomatonUI.docc/Articles/OOP-Tutorial/02-LoginLogout.md
@@ -42,7 +42,10 @@ let reducer = Reducer { action, state, environment in
     switch (action, state) {
     case (.login, .loggedOut):
         state = .loggingIn
-        return login(state.userId) // ログイン処理（副作用）
+        return Effect { _ in // ログイン処理（副作用）
+            try await environment.login("user-123")
+            return Action.loginOK
+        }
 
     case (.loginOK, .loggingIn):
         state = .loggedIn
@@ -52,14 +55,17 @@ let reducer = Reducer { action, state, environment in
         (.forceLogout, .loggingIn),
         (.forceLogout, .loggedIn):
         state = .loggingOut
-        return logout() // ログアウト処理（副作用）
+        return Effect { _ in // ログアウト処理（副作用）
+            try await environment.logout()
+            return Action.logoutOK
+        }
 
     case (.logoutOK, .loggingOut):
         state = .loggedOut
         return .empty
 
     default:
-        return Effect.fireAndForget {
+        return Effect.fireAndForget { _ in
             print("State transition failed...")
         }
     }
@@ -93,41 +99,37 @@ let reducer = Reducer { action, state, environment in
 
 ```swift
 struct Environment: Sendable {
-    let login: @Sendable (userId: String) -> Effect<Action>
-    let logout: Effect<Action>
+    let login: @Sendable (_ userId: String) async throws -> Void
+    let logout: @Sendable () async throws -> Void
 }
 
 let environment = Environment(
     login: { userId in
-        Effect {
-            let loginRequest = ...
-            let data = try? await URLSession.shared.data(for: loginRequest) // API 通信
-            ...
-            return Action.loginOK // 次のアクション
-        }
-    },
-    logout: Effect {
-        let logoutRequest = ...
-        let data = try? await URLSession.shared.data(for: logoutRequest) // API 通信
+        let loginRequest = ...
+        _ = try? await URLSession.shared.data(for: loginRequest) // API 通信
         ...
-        return Action.logoutOK // 次のアクション
+    },
+    logout: {
+        let logoutRequest = ...
+        _ = try? await URLSession.shared.data(for: logoutRequest) // API 通信
+        ...
     }
 )
 ```
 
 ここで `struct Environment` がはじめて使われていますが、これは依存注入コンテナ (Dependency Injection Container) と考えるのが分かりやすいです。
+`Environment` には `Effect` ではなく、 API 通信などの **生の依存（async 関数や AsyncStream など）** を保持し、 `Effect` への組み立ては `Reducer` 側で行います。
+
 例えば、モックに差し替えたい場合は、
 
 ```swift
 let mockEnvironment = Environment(
-    login: { userId in
-        Effect.next(action: .loginOK) // API 通信をせず、次のアクションだけ送る
-    },
-    logout: Effect.next(action: .logoutOK)
+    login: { _ in /* API 通信をしない */ },
+    logout: { /* API 通信をしない */ }
 )
 ```
 
-のように、`Effect` 内部で API 通信などの副作用を実行せず次のアクションのみを送る処理に変更できます。
+のように、 API 通信を行わないダミー実装に置き換えるだけで済みます。
 この方法を使うことで、 **副作用を発生しないユニットテスト** が手軽に実行できます。
 
 ## EffectID と EffectQueue による副作用管理
@@ -142,22 +144,35 @@ let mockEnvironment = Environment(
 ### 1. EffectID による手動キャンセル
 
 `Effect` の初期化時に識別子として `EffectID` を付与し、 `Effect.cancel(id:)` を手動で呼ぶ方法です。
-具体的には `protocol EffectID` を使い、 `Hashable` な識別子を `Effect` の初期化時に渡します。
+具体的には `protocol EffectID` を使い、 `Hashable` な識別子を `Reducer` 側で `Effect` の初期化時に渡します。
 
 ```swift
 struct LoginFlowEffectID: EffectID {} // 空実装で OK
 
-let environment = Environment(
-    login: { userId in
-        Effect(id: LoginFlowEffectID()) { // EffectID 追加
-            ... // 実際のログイン処理
+let reducer = Reducer { action, state, environment in
+    switch (action, state) {
+    case (.login, .loggedOut):
+        state = .loggingIn
+        return Effect(id: LoginFlowEffectID()) { _ in // EffectID 追加
+            try await environment.login("user-123")
+            return Action.loginOK
         }
-    },
-    logout: Effect.cancel(id: LoginFlowEffectID()) // 事前にキャンセル処理
-        + Effect { // Effect の足し算
-            ... // 実際のログアウト処理
-        }
-)
+
+    case (.logout, .loggedIn),
+        (.forceLogout, .loggingIn),
+        (.forceLogout, .loggedIn):
+        state = .loggingOut
+        return Effect.cancel(id: LoginFlowEffectID()) // 事前にキャンセル処理
+            + Effect { _ in // Effect の足し算
+                try await environment.logout()
+                return Action.logoutOK
+            }
+
+    // ... 他の case は省略 ...
+    default:
+        return .empty
+    }
+}
 ```
 
 このように、「実際のログアウト処理」の前に「キャンセル」を呼ぶことができます。
@@ -176,16 +191,29 @@ let environment = Environment(
 ```swift
 struct LoginFlowEffectQueue: Newest1EffectQueue {} // 空実装で OK
 
-let environment = Environment(
-    login: { userId in
-        Effect(queue: LoginFlowEffectQueue()) { // EffectQueue に追加
-            ... // 実際のログイン処理
+let reducer = Reducer { action, state, environment in
+    switch (action, state) {
+    case (.login, .loggedOut):
+        state = .loggingIn
+        return Effect(queue: LoginFlowEffectQueue()) { _ in // EffectQueue に追加
+            try await environment.login("user-123")
+            return Action.loginOK
         }
-    },
-    logout: Effect(queue: LoginFlowEffectQueue()) { // EffectQueue に追加
-        ... // 実際のログアウト処理
+
+    case (.logout, .loggedIn),
+        (.forceLogout, .loggingIn),
+        (.forceLogout, .loggedIn):
+        state = .loggingOut
+        return Effect(queue: LoginFlowEffectQueue()) { _ in // EffectQueue に追加
+            try await environment.logout()
+            return Action.logoutOK
+        }
+
+    // ... 他の case は省略 ...
+    default:
+        return .empty
     }
-)
+}
 ```
 
 このように `login` と `logout` が同じキューに登録されることを明記することで、

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -30,7 +30,7 @@
 /// use Combine's `map`, `compactMap`, and `removeDuplicates`.
 ///
 /// ```swift
-/// let store: Store<State, Action, Environment>
+/// let store: Store<Action, State, Environment>
 /// ...
 /// func viewDidLoad() {
 ///     super.viewDidLoad()
@@ -363,8 +363,8 @@ extension Store
     ///     {
     ///         Screen1View(store: screen1Store) // Show Screen1 if `currentScreen = .screen1`.
     ///     }
-    ///     else if screen2Store = currentStore
-    ///         .caseMap(state: /Screen.screen1)
+    ///     else if let screen2Store = currentStore
+    ///         .caseMap(state: /Screen.screen2)
     ///         .optionalize()
     ///     {
     ///         Screen2View(store: screen2Store) // Show Screen2 if `currentScreen = .screen2`.

--- a/Tests/ReadMeTests/ReadMeTests.swift
+++ b/Tests/ReadMeTests/ReadMeTests.swift
@@ -57,7 +57,7 @@ private func readMe1_4() async throws
             .runOldest(maxCount: 3, .suspendNew)
         }
 
-        // Adds delay between effect start. (This is useful for throttling / deboucing)
+        // Adds delay between effect start. (This is useful for throttling / debouncing)
         var effectQueueDelay: EffectQueueDelay {
             .random(0.1 ... 0.3)
         }


### PR DESCRIPTION
## Summary

Docs-only refresh — no API or behavior changes. This PR re-organizes the Examples section so each `Effect` concept gets its own example, syncs README and DocC so they no longer drift, and fixes a handful of doc-comment typos and stale references that have accumulated.

### Examples reorganization

`EffectID` (manual cancellation) and `EffectQueue` (automatic cancellation) were previously conflated inside the Login-Logout example, with Timer relegated to the end. They are now split:

- **`Example 1-2. Timer`** introduces `EffectID` + `Effect.sequence` cleanly with the timer.
- **`Example 1-3. Login-Logout`** focuses on `EffectQueue` for automatic cancellation, building on the `EffectID` knowledge from 1-2.

The matching DocC articles are renamed/swapped so the order is the same in both surfaces:

```
03-Timer.md       → 02-Timer.md
02-LoginLogout.md → 03-LoginLogout.md
```

### Example-code sync

The Login-Logout example used the older "`Environment` returns `Effect`" shape, which was already replaced by "`Environment` holds raw async deps; `Reducer` builds the `Effect`" in newer parts of the codebase. README, the Actomaton DocC article, and the ActomatonUI OOP tutorial are all updated to the latter shape, so all three tell the same story:

```swift
// Before — Environment returns prebuilt Effect
struct Environment {
    let loginEffect: (userId: String) -> Effect<Action>
}

// After — Environment exposes raw async dep; Reducer builds the Effect
struct Environment: Sendable {
    let login: @Sendable (_ userId: String) async throws -> Void
}
```

### Doc-comment / typo fixes

- `Store.swift` doc-comment: generics order corrected to `Store<Action, State, Environment>` (was reversed); `else if let screen2Store = ...` fixed (missing `let`); `.caseMap(state: /Screen.screen2)` corrected (was `.screen1`).
- `Reducer+Effect.swift`: refers to `MealyReducer` (was the stale `ActomatonCore.Reducer`).
- `EffectManager.swift`: `setUp(...)` doc updated — the caller is the wrapping safe container (`Actomaton`, `MealyDriver`, `Store`, `TestActomaton`, `DistributedActomaton`), not `MealyMachine` directly.
- `EffectQueueManager.swift`: `.next` comment now references `MealyMachine.send`.
- `TestActomatonTask.swift`: DocC reference updated to include `timeout:`.
- `Reducer+Debugging.swift`: stray `///` inside a closure body changed to `//` (was not attached to any symbol).
- `02-Timer.md`: DocC link simplified from ``Effect``.``Effect/sequence(id:_:)`` to ``Effect/sequence(id:_:)``.
- Misc: `deboucing` → `debouncing`, double spaces removed, `Dependency Injection` → `Dependency Injection Container` for consistency with the DocC articles.

## Test plan

- [x] `swift build` — passes locally
- [x] `swift test` — `ReadMeTests` still passes after README sample updates
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
- [x] DocC preview renders 02-Timer / 03-LoginLogout in the new order with no broken `<doc:...>` links
