### PR TITLE
Add typed Emission side-channel via SendResult and per-effect priority

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,7 @@ let package = Package(
             dependencies: [
                 "ActomatonCore",
                 "ActomatonEffect",
+                "Actomaton",
                 .product(name: "CustomDump", package: "swift-custom-dump"),
             ]
         ),

--- a/Sources/Actomaton/Actomaton+Init.swift
+++ b/Sources/Actomaton/Actomaton+Init.swift
@@ -7,31 +7,35 @@ extension Actomaton
     /// Initializer without `environment`.
     public init(
         state: State,
-        reducer: Reducer<Action, State, ()>,
+        reducer: Reducer<Action, State, (), Emission>,
         effectContext: EffectContext = .init(clock: ContinuousClock())
     )
     {
         self.init(
             state: state,
             reducer: reducer,
-            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
+            effectManager: EffectQueueManager<Action, State, Emission>(
+                effectContext: effectContext
+            )
         )
     }
 
     /// Initializer with `environment`.
     public init<Environment>(
         state: State,
-        reducer: Reducer<Action, State, Environment>,
+        reducer: Reducer<Action, State, Environment, Emission>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock())
     ) where Environment: Sendable
     {
         self.init(
             state: state,
-            reducer: Reducer<Action, State, ()> { action, state, _ in
+            reducer: Reducer<Action, State, (), Emission> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
+            effectManager: EffectQueueManager<Action, State, Emission>(
+                effectContext: effectContext
+            )
         )
     }
 }

--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -3,16 +3,20 @@ import ActomatonEffect
 
 /// Actor + Automaton = Actomaton.
 ///
-/// `Actomaton` wraps a ``MealyMachine`` specialized with `Output == Effect<Action>` inside a
-/// Swift actor, providing serial isolation for `send(_:)` and `state` access. It owns the
+/// `Actomaton` wraps a ``MealyMachine`` specialized with `Output == Effect<Action, Emission>`
+/// inside a Swift actor, providing serial isolation for `send(_:)` and `state` access. It owns the
 /// ``EffectManager`` and turns the asynchronous-remainder output from ``MealyMachine`` into
 /// running Swift Concurrency tasks.
-public actor Actomaton<Action, State>
-    where Action: Sendable
+///
+/// `Emission` is the typed side-channel value: each `send(_:)` call returns a ``SendResult``
+/// whose `AsyncSequence` of `Emission` values is produced by the triggered effects'
+/// synchronous `.emit` kinds and async `Outcome` emissions.
+public actor Actomaton<Action, State, Emission>
+    where Action: Sendable, Emission: Sendable
 {
-    private let machine: MealyMachine<Action, State, Effect<Action>>
+    private let machine: MealyMachine<Action, State, Effect<Action, Emission>>
 
-    private let effectManager: any EffectManager<Action, State, Effect<Action>>
+    private let effectManager: any EffectManager<Action, State, Effect<Action, Emission>>
 
     public var state: State
     {
@@ -22,8 +26,8 @@ public actor Actomaton<Action, State>
     /// Designated initializer that takes an explicit ``EffectManager``.
     public init(
         state: State,
-        reducer: MealyReducer<Action, State, (), Effect<Action>>,
-        effectManager: some EffectManager<Action, State, Effect<Action>>
+        reducer: MealyReducer<Action, State, (), Effect<Action, Emission>>,
+        effectManager: some EffectManager<Action, State, Effect<Action, Emission>>
     )
     {
         self.machine = MealyMachine(
@@ -36,8 +40,13 @@ public actor Actomaton<Action, State>
             withSendability: { [weak self] runEffM in
                 await self?.runIsolatedEffectManager(runEffM)
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks in
-                await self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            sendAction: { [weak self] action, priority, tracksFeedbacks, emit in
+                await self?.sendInternal(
+                    action,
+                    priority: priority,
+                    tracksFeedbacks: tracksFeedbacks,
+                    emit: emit
+                )
             }
         )
     }
@@ -49,29 +58,60 @@ public actor Actomaton<Action, State>
     ///   - priority:
     ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
     ///   - tracksFeedbacks:
-    ///     If `true`, returned `Task` will also track its feedback effects that are triggered by next actions,
-    ///     so that their wait-for-all and cancellations are possible.
+    ///     If `true`, the returned ``SendResult`` will also track feedback effects triggered by
+    ///     next actions — so its `AsyncSequence` stays open until those downstream chains
+    ///     complete, and recursive ``Effect/Outcome/emit`` values flow into the same stream.
     ///     Default is `false`.
     ///
     /// - Returns:
-    ///   Unified task that can handle (wait for or cancel) all combined effects triggered by `action` in `Reducer`.
+    ///   A ``SendResult`` exposing both a non-throwing `AsyncSequence` of
+    ///   `Result<Emission, any Error>` elements (effect errors are surfaced in-band as `.failure`
+    ///   without cancelling sibling effects) and a `cancel()` handle that aborts the entire chain.
     @discardableResult
     public func send(
         _ action: Action,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
-    ) -> Task<(), any Error>?
+    ) -> SendResult<Emission>
     {
         let output = machine.send(action)
-        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks
+        )
+    }
+
+    /// Reducer-side dispatch used internally by the recursive feedback path threaded through
+    /// ``EffectManager``'s `sendAction` callback. The `emit` parameter is the original caller's
+    /// emission sink, so all `Emission` values produced by downstream effects flow into the
+    /// single ``SendResult`` returned by the public `send`.
+    private func sendInternal(
+        _ action: Action,
+        priority: TaskPriority?,
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
+    ) -> Task<(), any Error>?
+    {
+        // `MealyMachine.send` recursively resolves synchronous `.next(Action)` feedbacks
+        // because `Effect<Action, Emission>: MealyOutput` exposes `MealyOutput.Action == Action`.
+        // The returned `output` contains only the asynchronous remainder plus any synchronous
+        // `.emit` kinds (which ride along unchanged).
+        let output = machine.send(action)
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks,
+            emit: emit
+        )
     }
 
     /// Runs `runEffM` within this actor's isolation, supplying the underlying ``EffectManager``
-    /// so that conformers can mutate their own bookkeeping safely from detached tasks without
+    /// so that conformers can mutate their own bookkeeping safely from unstructured tasks without
     /// capturing `self` themselves.
     fileprivate func runIsolatedEffectManager<EffM>(
         _ runEffM: (EffM) -> Void
-    ) where EffM: EffectManager<Action, State, Effect<Action>>
+    ) where EffM: EffectManager<Action, State, Effect<Action, Emission>>
     {
         // Safe downcast from the existential storage to the conformer's concrete `Self`.
         runEffM(effectManager as! EffM)

--- a/Sources/Actomaton/EffectManager+SendResult.swift
+++ b/Sources/Actomaton/EffectManager+SendResult.swift
@@ -1,0 +1,64 @@
+import ActomatonEffect
+
+// MARK: - SendResult helper
+
+extension EffectManager
+{
+    /// Process the reducer output and wrap its emitted side-channel values in ``SendResult``.
+    ///
+    /// This convenience helper is for top-level `send` entry points. Recursive feedback paths
+    /// should continue to call the primitive `emit`-threading overload so all downstream
+    /// emissions flow into the original caller's single ``SendResult`` stream.
+    package func processOutput(
+        _ output: Output,
+        priority: TaskPriority?,
+        tracksFeedbacks: Bool
+    ) -> SendResult<Output.Emission>
+        where Output.Emission: Sendable
+    {
+        let (stream, continuation) = AsyncStream<Result<Output.Emission, any Error>>.makeStream()
+        let emit: @Sendable (Result<Output.Emission, any Error>) -> Void = { continuation.yield($0) }
+
+        let task = self.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks,
+            emit: emit
+        )
+
+        // Stream-finishing supervisor.
+        //
+        // Effect errors are surfaced in-band as `.failure` elements by each effect task itself
+        // (see `EffectQueueManager.makeTask`), so `task` only ever throws `CancellationError`
+        // (on explicit `SendResult.cancel()`). The supervisor therefore just awaits the chain
+        // and finishes the stream:
+        //
+        // - `task` completes (success or in-band failures already delivered) -> finish cleanly.
+        // - `task` is cancelled via `SendResult.cancel()` -> propagate cancellation to `task`
+        //   so the effect chain unwinds, then finish cleanly.
+        // - Any unexpected non-cancellation error (defensive) -> deliver as a final `.failure`.
+        let supervisor = Task<Void, Never>(priority: priority) { @concurrent in
+            await withTaskCancellationHandler {
+                do {
+                    try await task?.value
+                }
+                catch is CancellationError {
+                    // Cancellation finishes cleanly; it is not an in-band failure.
+                }
+                catch {
+                    continuation.yield(.failure(error))
+                }
+
+                // Call `finish` regardless of successful / failure completions.
+                continuation.finish()
+            } onCancel: {
+                task?.cancel()
+            }
+        }
+
+        return SendResult(
+            stream: stream,
+            supervisor: supervisor
+        )
+    }
+}

--- a/Sources/Actomaton/MealyDriver+Init.swift
+++ b/Sources/Actomaton/MealyDriver+Init.swift
@@ -7,31 +7,31 @@ extension MealyDriver
     /// Initializer without `environment`.
     public convenience init(
         state: State,
-        reducer: Reducer<Action, State, ()>,
+        reducer: Reducer<Action, State, (), Emission>,
         effectContext: EffectContext = .init(clock: ContinuousClock())
     )
     {
         self.init(
             state: state,
             reducer: reducer,
-            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
+            effectManager: EffectQueueManager<Action, State, Emission>(effectContext: effectContext)
         )
     }
 
     /// Initializer with `environment`.
     public convenience init<Environment>(
         state: State,
-        reducer: Reducer<Action, State, Environment>,
+        reducer: Reducer<Action, State, Environment, Emission>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock())
     ) where Environment: Sendable
     {
         self.init(
             state: state,
-            reducer: Reducer<Action, State, ()> { action, state, _ in
+            reducer: Reducer<Action, State, (), Emission> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext)
+            effectManager: EffectQueueManager<Action, State, Emission>(effectContext: effectContext)
         )
     }
 }

--- a/Sources/Actomaton/MealyDriver.swift
+++ b/Sources/Actomaton/MealyDriver.swift
@@ -2,15 +2,15 @@ import ActomatonCore
 import ActomatonEffect
 import Synchronization
 
-/// Non-actor driver for ``MealyMachine`` with `Output == Effect<Action>`, providing
+/// Non-actor driver for ``MealyMachine`` with `Output == Effect<Action, Emission>`, providing
 /// synchronous `send(_:)`, `state` and `withState(_:)` for callers that cannot enter an
 /// actor isolation — for example, a type conforming to `DistributedActorSystem` whose
 /// protocol surface is largely synchronous.
 ///
 /// `MealyDriver` is the "non-actor" sibling of ``Actomaton`` referenced by
-/// ``MealyMachine``'s docstring. Both wrappers share the same internals (`MealyMachine` +
-/// an ``EffectManager``); they differ only in how they provide the serial-access invariant
-/// that ``MealyMachine`` requires:
+/// ``MealyMachine``'s docstring. Both wrappers share the same internals (``MealyMachine`` +
+/// an ``EffectManager``) and the same typed side-channel `Emission` semantics; they differ
+/// only in how they provide the serial-access invariant that ``MealyMachine`` requires:
 ///
 /// - ``Actomaton`` uses Swift actor isolation.
 /// - ``MealyDriver`` uses an internal `Mutex` from the `Synchronization` framework.
@@ -18,20 +18,20 @@ import Synchronization
 /// The class is marked `@unchecked Sendable` because ``MealyMachine`` and the underlying
 /// ``EffectManager`` are both intentionally non-`Sendable`; the mutex supplies the
 /// serial-access invariant they require.
-public final class MealyDriver<Action, State>: @unchecked Sendable
-    where Action: Sendable
+public final class MealyDriver<Action, State, Emission>: @unchecked Sendable
+    where Action: Sendable, Emission: Sendable
 {
-    private let machine: MealyMachine<Action, State, Effect<Action>>
+    private let machine: MealyMachine<Action, State, Effect<Action, Emission>>
 
-    private let effectManager: any EffectManager<Action, State, Effect<Action>>
+    private let effectManager: any EffectManager<Action, State, Effect<Action, Emission>>
 
     private let mutex = Mutex<Void>(())
 
     /// Designated initializer that takes an explicit ``EffectManager``.
     public init(
         state: State,
-        reducer: Reducer<Action, State, ()>,
-        effectManager: some EffectManager<Action, State, Effect<Action>>
+        reducer: Reducer<Action, State, (), Emission>,
+        effectManager: some EffectManager<Action, State, Effect<Action, Emission>>
     )
     {
         self.machine = MealyMachine(state: state, reducer: reducer)
@@ -41,8 +41,13 @@ public final class MealyDriver<Action, State>: @unchecked Sendable
             withSendability: { [weak self] runEffectManager in
                 self?.runIsolatedEffectManager(runEffectManager)
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks in
-                self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            sendAction: { [weak self] action, priority, tracksFeedbacks, emit in
+                self?.sendInternal(
+                    action,
+                    priority: priority,
+                    tracksFeedbacks: tracksFeedbacks,
+                    emit: emit
+                )
             }
         )
     }
@@ -63,37 +68,63 @@ public final class MealyDriver<Action, State>: @unchecked Sendable
     /// to ``EffectManager/processOutput(_:priority:tracksFeedbacks:)``.
     ///
     /// The reducer is run synchronously under the mutex; the asynchronous-remainder output
-    /// (`Effect<Action>`) is handed to the effect manager *after* the mutex is released, so
-    /// the manager's task scheduling never re-enters the mutex from the same call stack.
+    /// is handed to the effect manager *after* the mutex is released, so the manager's
+    /// task scheduling never re-enters the mutex from the same call stack.
     ///
     /// - Parameters:
     ///   - priority:
     ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
     ///   - tracksFeedbacks:
-    ///     If `true`, the returned `Task` will also track feedback effects triggered by
-    ///     subsequent actions, so that wait-for-all and cancellation are possible.
+    ///     If `true`, the returned ``SendResult`` will also track feedback effects triggered by
+    ///     next actions — so its `AsyncSequence` stays open until those downstream chains
+    ///     complete, and recursive ``Effect/Outcome/emit`` values flow into the same stream.
     ///     Default is `false`.
     ///
     /// - Returns:
-    ///   Unified task that can handle (wait for or cancel) all combined effects triggered
-    ///   by `action` in the reducer.
+    ///   A ``SendResult`` exposing both a non-throwing `AsyncSequence` of
+    ///   `Result<Emission, any Error>` elements (effect errors are surfaced in-band as `.failure`
+    ///   without cancelling sibling effects) and a `cancel()` handle that aborts the entire chain.
     @discardableResult
     public func send(
         _ action: Action,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
+    ) -> SendResult<Emission>
+    {
+        let output = mutex.withLock { _ in machine.send(action) }
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks
+        )
+    }
+
+    /// Reducer-side dispatch used internally by the recursive feedback path threaded through
+    /// ``EffectManager``'s `sendAction` callback. The `emit` parameter is the original caller's
+    /// emission sink, so all `Emission` values produced by downstream effects flow into the
+    /// single ``SendResult`` returned by the public `send`.
+    private func sendInternal(
+        _ action: Action,
+        priority: TaskPriority?,
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> Task<(), any Error>?
     {
         let output = mutex.withLock { _ in machine.send(action) }
-        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks,
+            emit: emit
+        )
     }
 
     /// Runs `runEffectManager` under the driver's mutex, supplying the underlying
     /// ``EffectManager`` so that conformers can mutate their own bookkeeping safely from
-    /// detached tasks without capturing `self` themselves.
+    /// unstructured tasks without capturing `self` themselves.
     private func runIsolatedEffectManager<EffM>(
         _ runEffectManager: (EffM) -> Void
-    ) where EffM: EffectManager<Action, State, Effect<Action>>
+    ) where EffM: EffectManager<Action, State, Effect<Action, Emission>>
     {
         mutex.withLock { _ in
             // Safe downcast from the existential storage to the conformer's concrete `Self`.

--- a/Sources/Actomaton/Reducer+Effect.swift
+++ b/Sources/Actomaton/Reducer+Effect.swift
@@ -2,38 +2,51 @@ import ActomatonCore
 import CasePaths
 
 /// `Effect`-specific `MealyReducer` extensions: monoid, contramap(action:), map(id:), map(queue:).
-extension MealyReducer where Output == Effect<Action>
-{
-    // MARK: - Monoid
+///
+/// `Emission` is exposed as a method-level generic so these helpers cover every
+/// `Effect<Action, Emission>` reducer output shape. Use `Emission == Never` for wrappers
+/// that do not expose a side-channel result stream, and a concrete `Emission` for
+/// `Actomaton` / `MealyDriver` callers that do.
 
-    public static var empty: Self
+// MARK: - Monoid
+
+extension MealyReducer
+{
+    public static func empty<Emission>() -> Self where Output == Effect<Action, Emission>
     {
         .init { _, _, _ in .empty }
     }
 
-    public static func + (l: Self, r: Self) -> Self
+    public static func + <Emission>(l: Self, r: Self) -> Self
+        where Output == Effect<Action, Emission>
     {
         .init { action, state, environment in
             l.run(action, &state, environment) + r.run(action, &state, environment)
         }
     }
 
-    public static func combine(_ reducers: [Self]) -> Self
+    public static func combine<Emission>(_ reducers: [Self]) -> Self
+        where Output == Effect<Action, Emission>
     {
-        reducers.reduce(into: .empty, { $0 = $0 + $1 })
+        reducers.reduce(into: .empty(), { $0 = $0 + $1 })
     }
 
-    public static func combine(_ reducers: Self...) -> Self
+    public static func combine<Emission>(_ reducers: Self...) -> Self
+        where Output == Effect<Action, Emission>
     {
-        self.combine(reducers)
+        combine(reducers)
     }
+}
 
-    // MARK: - Contravariant Functor (Action)
+// MARK: - Contravariant Functor (Action)
 
+extension MealyReducer
+{
     /// Transforms `Action` using `CasePath`.
-    public func contramap<GlobalAction>(
+    public func contramap<GlobalAction, Emission>(
         action toLocalAction: CasePath<GlobalAction, Action>
-    ) -> MealyReducer<GlobalAction, State, Environment, Effect<GlobalAction>>
+    ) -> MealyReducer<GlobalAction, State, Environment, Effect<GlobalAction, Emission>>
+        where Output == Effect<Action, Emission>
     {
         .init { action, state, environment in
             guard let localAction = toLocalAction.extract(from: action) else { return .empty }
@@ -44,15 +57,16 @@ extension MealyReducer where Output == Effect<Action>
                     &state,
                     environment
                 )
-                .map { toLocalAction.embed($0) }
+                .map(action: { toLocalAction.embed($0) })
         }
     }
 
     /// Transforms `State` using `CasePath`.
     /// - Note: Overrides the generic version to provide `.empty` fallback.
-    public func contramap<GlobalState>(
+    public func contramap<GlobalState, Emission>(
         state toLocalState: CasePath<GlobalState, State>
-    ) -> MealyReducer<Action, GlobalState, Environment, Effect<Action>>
+    ) -> MealyReducer<Action, GlobalState, Environment, Effect<Action, Emission>>
+        where Output == Effect<Action, Emission>
     {
         .init { action, state, environment in
             guard var localState = toLocalState.extract(from: state) else { return .empty }
@@ -66,28 +80,29 @@ extension MealyReducer where Output == Effect<Action>
             return effect
         }
     }
+}
 
-    // MARK: - Functor
+// MARK: - Functor (EffectID / EffectQueue)
 
+extension MealyReducer
+{
     /// Changes `EffectID`.
-    public func map<ID>(id f: @escaping @Sendable ((any EffectID)?) -> ID?) -> Self
-        where ID: EffectID
+    public func map<ID, Emission>(id f: @escaping @Sendable ((any EffectID)?) -> ID?) -> Self
+        where ID: EffectID, Output == Effect<Action, Emission>
     {
         .init { action, state, environment in
-            let effect = self.run(action, &state, environment)
+            self.run(action, &state, environment)
                 .map(id: f)
-            return effect
         }
     }
 
     /// Changes `EffectQueue`.
-    public func map<Queue>(queue f: @escaping @Sendable ((any EffectQueue)?) -> Queue?) -> Self
-        where Queue: EffectQueue
+    public func map<Queue, Emission>(queue f: @escaping @Sendable ((any EffectQueue)?) -> Queue?) -> Self
+        where Queue: EffectQueue, Output == Effect<Action, Emission>
     {
         .init { action, state, environment in
-            let effect = self.run(action, &state, environment)
+            self.run(action, &state, environment)
                 .map(queue: f)
-            return effect
         }
     }
 }

--- a/Sources/Actomaton/Reducer.swift
+++ b/Sources/Actomaton/Reducer.swift
@@ -1,4 +1,8 @@
 import ActomatonCore
 
-/// `Reducer` is `MealyReducer` specialized with `Output == Effect<Action>`.
-public typealias Reducer<Action, State, Environment> = MealyReducer<Action, State, Environment, Effect<Action>>
+/// `Reducer` is `MealyReducer` specialized with `Output == Effect<Action, Emission>`.
+///
+/// `Emission` denotes the side-channel value type yielded back to `send` callers via
+/// ``SendResult``. Use `Never` when no side-channel is needed.
+public typealias Reducer<Action, State, Environment, Emission>
+    = MealyReducer<Action, State, Environment, Effect<Action, Emission>>

--- a/Sources/Actomaton/SendResult.swift
+++ b/Sources/Actomaton/SendResult.swift
@@ -1,0 +1,128 @@
+/// Result of an effect-producing `send(_:)` call, exposing:
+///
+/// 1. An `AsyncSequence` of `Result<Emission, any Error>` values produced by the triggered
+///    effect chain (sync `.emit` plus async `Outcome` emissions, including recursive feedbacks
+///    when `tracksFeedbacks: true`). Each element is either:
+///    - `.success(Emission)`: a value emitted by an effect, or
+///    - `.failure(any Error)`: a **non-cancellation** error thrown by a single effect.
+///
+/// 2. A ``cancel()`` handle that aborts the entire chain.
+///
+/// ## Why errors are in-band
+///
+/// Multiple effects triggered by one `send` run concurrently and independently. A throwing
+/// `AsyncSequence` (or a fail-fast `TaskGroup`) would tear the whole chain down the moment one
+/// effect throws — cancelling unrelated sibling effects and dropping the values they would have
+/// emitted. Instead, each effect's failure is surfaced as a `.failure` **element** and that
+/// single effect ends, while its siblings keep emitting until the entire chain completes.
+///
+/// Iteration therefore never throws; it ends cleanly on both normal completion and cancellation.
+/// Use ``isCancelled`` to disambiguate the two clean-finish cases. Cancellation is **not** reported
+/// as a `.failure` element.
+///
+public struct SendResult<Emission>: AsyncSequence, Sendable
+    where Emission: Sendable
+{
+    public typealias Element = Result<Emission, any Error>
+    public typealias AsyncIterator = AsyncStream<Result<Emission, any Error>>.AsyncIterator
+    public typealias Failure = Never
+
+    private let stream: AsyncStream<Result<Emission, any Error>>
+
+    /// The supervisor that owns the effect chain's lifecycle.
+    /// Cancelling it propagates cancellation downward into the in-flight effect tasks
+    /// and finishes the underlying stream.
+    private let supervisor: Task<Void, Never>
+
+    init(
+        stream: AsyncStream<Result<Emission, any Error>>,
+        supervisor: Task<Void, Never>
+    )
+    {
+        self.stream = stream
+        self.supervisor = supervisor
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator
+    {
+        stream.makeAsyncIterator()
+    }
+
+    /// Cancels the underlying effect-driving task. The async sequence terminates after the
+    /// in-flight effects observe cancellation and buffered values are drained.
+    public func cancel()
+    {
+        supervisor.cancel()
+    }
+
+    /// Whether the chain was cancelled. After iteration ends, this is the only way to
+    /// distinguish normal completion from cancellation (both finish the stream cleanly).
+    public var isCancelled: Bool
+    {
+        supervisor.isCancelled
+    }
+
+    // MARK: - Non-throwing accessors (in-band errors)
+
+    /// Drains every element — both `.success` and `.failure` — awaiting completion of the
+    /// entire effect chain. Never throws.
+    public var allResults: [Result<Emission, any Error>]
+    {
+        get async {
+            var result: [Result<Emission, any Error>] = []
+            for await element in self {
+                result.append(element)
+            }
+            return result
+        }
+    }
+
+    /// Returns the first element (`.success` or `.failure`), or `nil` if the chain completes
+    /// without producing any. Never throws.
+    ///
+    /// After this returns, the rest of the stream is abandoned.
+    public var firstResult: Result<Emission, any Error>?
+    {
+        get async {
+            for await element in self {
+                return element
+            }
+            return nil
+        }
+    }
+
+    /// Drains all `.success` payloads, ignoring any `.failure` elements. Never throws.
+    public var emissions: [Emission]
+    {
+        get async {
+            var values: [Emission] = []
+            for await element in self {
+                if case let .success(value) = element {
+                    values.append(value)
+                }
+            }
+            return values
+        }
+    }
+
+    /// Drains all `.failure` errors, ignoring any `.success` elements. Never throws.
+    public var errors: [any Error]
+    {
+        get async {
+            var errors: [any Error] = []
+            for await element in self {
+                if case let .failure(error) = element {
+                    errors.append(error)
+                }
+            }
+            return errors
+        }
+    }
+
+    /// Awaits completion of the effect chain without collecting anything. Never throws —
+    /// effect errors are reported in-band as `.failure` elements, not by throwing.
+    public func completion() async
+    {
+        for await _ in self {}
+    }
+}

--- a/Sources/ActomatonDebugging/Reducer+Debugging.swift
+++ b/Sources/ActomatonDebugging/Reducer+Debugging.swift
@@ -3,15 +3,15 @@ import CustomDump
 
 // MARK: - debug (logging on `#if DEBUG`)
 
-extension Reducer where Output == Effect<Action>
+extension MealyReducer
 {
     /// Debug-logging `Action` and `State` during `self`'s reducer's run, only in DEBUG configuration.
-    public func debug(
+    public func debug<Emission>(
         _ name: String? = nil,
         action actionLogFormat: ActionLogFormat? = .all(maxDepth: .max),
         state stateLogFormat: StateLogFormat? = .diff
     ) -> Self
-        where Action: Sendable, State: Sendable
+        where Action: Sendable, State: Sendable, Output == Effect<Action, Emission>
     {
 #if DEBUG
         self.log(format: LogFormat(name: name, action: actionLogFormat, state: stateLogFormat))
@@ -23,16 +23,17 @@ extension Reducer where Output == Effect<Action>
     /// Convenient constructor for debug-logging `Action` and `State` during target reducer's run,
     /// by replacing `targetReducer = Reducer.init { ... }` with `Reducer.debug { ... }`,
     /// only in DEBUG configuration.
-    public static func debug(
+    public static func debug<Emission>(
         _ name: String? = nil,
         action actionLogFormat: ActionLogFormat? = .all(maxDepth: .max),
         state stateLogFormat: StateLogFormat? = .diff,
-        _ nextRun: @escaping @Sendable (Action, inout State, Environment) -> Effect<Action> = Self.empty.run
+        _ nextRun: @escaping @Sendable (Action, inout State, Environment) -> Effect<Action, Emission>
+            = MealyReducer<Action, State, Environment, Effect<Action, Emission>>.empty().run
     ) -> Self
-        where Action: Sendable, State: Sendable
+        where Action: Sendable, State: Sendable, Output == Effect<Action, Emission>
     {
 #if DEBUG
-        self.log(
+        log(
             format: LogFormat(name: name, action: actionLogFormat, state: stateLogFormat),
             nextRun
         )
@@ -44,14 +45,14 @@ extension Reducer where Output == Effect<Action>
 
 // MARK: - log
 
-extension Reducer where Output == Effect<Action>
+extension MealyReducer
 {
     /// Debug-logging `Action` and `State` during `self`'s reducer's run, using ``LogFormat``.
     ///
     /// - Parameters:
     ///   - format: ``LogFormat`` that formats console-logging. No logging if `format = nil`.
-    public func log(format: LogFormat?) -> Self
-        where Action: Sendable, State: Sendable
+    public func log<Emission>(format: LogFormat?) -> Self
+        where Action: Sendable, State: Sendable, Output == Effect<Action, Emission>
     {
         Self.log(format: format, self.run)
     }
@@ -61,11 +62,12 @@ extension Reducer where Output == Effect<Action>
     ///
     /// - Parameters:
     ///   - format: ``LogFormat`` that formats console-logging. No logging if `format = nil`.
-    public static func log(
+    public static func log<Emission>(
         format: LogFormat?,
-        _ nextRun: @escaping @Sendable (Action, inout State, Environment) -> Effect<Action> = Self.empty.run
+        _ nextRun: @escaping @Sendable (Action, inout State, Environment) -> Effect<Action, Emission>
+            = MealyReducer<Action, State, Environment, Effect<Action, Emission>>.empty().run
     ) -> Self
-        where Action: Sendable, State: Sendable
+        where Action: Sendable, State: Sendable, Output == Effect<Action, Emission>
     {
         // Return normal reducer without logging.
         guard let format else {
@@ -76,7 +78,7 @@ extension Reducer where Output == Effect<Action>
             let currentState = state // Needs copy to not carry `inout`.
 
             // Effect for Action & State `.simple` or `.all` printing.
-            let preEffect = Effect<Action>.fireAndForget { _ in
+            let preEffect = Effect<Action, Emission>.fireAndForget { _ in
                 let name = format.name.map { "[\($0)]" } ?? ""
 
                 if let actionLogFormat = format.actionLogFormat {
@@ -115,7 +117,7 @@ extension Reducer where Output == Effect<Action>
             let nextState = state // Needs copy to not carry `inout`.
 
             /// Effect for State's `.diff` printing.
-            let postEffect = Effect<Action>.fireAndForget { _ in
+            let postEffect = Effect<Action, Emission>.fireAndForget { _ in
                 if let stateLogFormat = format.stateLogFormat {
                     switch stateLogFormat.format {
                     case .simple, .all:

--- a/Sources/ActomatonEffect/Effect+MealyOutput.swift
+++ b/Sources/ActomatonEffect/Effect+MealyOutput.swift
@@ -3,18 +3,22 @@ import ActomatonCore
 /// ``Effect`` exposes synchronous feedback as ``Effect/Kind/next`` kinds. Conforming to
 /// ``MealyOutput`` lets ``MealyMachine`` drive the synchronous-feedback loop directly,
 /// without going through an ``EffectManager``.
+///
+/// Synchronous side-channel emissions (``Effect/Kind/emit``) are NOT consumed by the
+/// recursion; they ride along in the remainder so that the downstream ``EffectManager``
+/// can deliver them to the caller's top-level result stream.
 extension Effect: MealyOutput
 {
-    public func splitSynchronousActions() -> (actions: [Action], remainder: Effect<Action>)
+    public func splitSynchronousActions() -> (actions: [Action], remainder: Effect<Action, Emission>)
     {
         var actions: [Action] = []
-        var remainingKinds: [Effect<Action>.Kind] = []
+        var remainingKinds: [Effect<Action, Emission>.Kind] = []
 
         for kind in kinds {
-            if case let .next(action) = kind {
+            switch kind {
+            case let .next(action):
                 actions.append(action)
-            }
-            else {
+            case .single, .sequence, .emission, .cancel, .updateQueue:
                 remainingKinds.append(kind)
             }
         }
@@ -24,3 +28,8 @@ extension Effect: MealyOutput
 
     // `static func + (lhs:rhs:)` is already provided by `Effect`'s monoid extension.
 }
+
+/// ``Effect`` exposes its side-channel value type via ``EffectOutput`` so that
+/// ``EffectManager`` can carry it as a single `Output: EffectOutput` constraint —
+/// `Output.Emission` is derived from the concrete `Effect`'s second generic parameter.
+extension Effect: EffectOutput {}

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -1,69 +1,101 @@
 /// Effect type to run `async`, `AsyncSequence`, or cancellation.
-public struct Effect<Action>
+///
+/// `Effect` carries two channels:
+///
+/// - **`Action`**: synchronous (`.next`) and asynchronous (`.single` / `.sequence` / `.stream`)
+///   feedback actions, recursively re-fed into the reducer through ``MealyMachine/send(_:)``.
+/// - **`Emission`**: side-channel values yielded back to top-level `send` callers.
+///   Use `Never` when no side-channel is needed.
+///
+/// Async-effect steps produce ``Outcome`` values that may carry an action, an emission, or both.
+public struct Effect<Action, Emission>
 {
     internal let kinds: [Kind]
 }
 
-// MARK: - Public Initializers
+// MARK: - Public Initializers (canonical: Outcome)
+
+// NOTE: The canonical inits are marked `@_disfavoredOverload` so that, when `Emission == Never`,
+// Swift overload resolution prefers the more specialized `init(run: -> Action?)` (and friends)
+// defined later in the `extension Effect where Emission == Never` block. This keeps existing
+// `Effect { context in return .someAction }` call sites unambiguous when `Emission == Never`,
+// while non-`Never` users still get the same Outcome-returning init via `Effect { context in
+// return .action(.foo) }` / `.emission(...)` / `.both(...)`.
 
 extension Effect
 {
     // MARK: - Single async
 
     /// Single-`async` side-effect with `EffectContext`.
+    ///
+    /// The closure returns an ``Outcome`` describing either a feedback action, an emitted
+    /// `Emission`, or both. Return `nil` to produce no output.
+    @_disfavoredOverload
     public init(
-        run: @escaping @Sendable (EffectContext) async throws -> Action?
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Outcome?
     )
     {
-        self.init(kinds: [.single(Single(id: nil, queue: nil, run: run))])
+        self.init(kinds: [.single(Single(id: nil, queue: nil, priority: priority, run: run))])
     }
 
     /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
+    @_disfavoredOverload
     public init<ID>(
         id: ID? = nil,
-        run: @escaping @Sendable (EffectContext) async throws -> Action?
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Outcome?
     )
         where ID: EffectID
     {
-        self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: nil, run: run))])
+        self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: nil, priority: priority, run: run))])
     }
 
     /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    @_disfavoredOverload
     public init<Queue>(
         queue: Queue? = nil,
-        run: @escaping @Sendable (EffectContext) async throws -> Action?
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Outcome?
     ) where Queue: EffectQueue
     {
-        self.init(kinds: [.single(Single(id: nil, queue: queue, run: run))])
+        self.init(kinds: [.single(Single(id: nil, queue: queue, priority: priority, run: run))])
     }
 
     /// Single-`async` side-effect with `EffectContext`.
     /// - Parameter id: Cancellation identifier.
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
+    @_disfavoredOverload
     public init<ID, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
-        run: @escaping @Sendable (EffectContext) async throws -> Action?
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Outcome?
     ) where ID: EffectID, Queue: EffectQueue
     {
-        self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: queue, run: run))])
+        self.init(kinds: [.single(Single(id: id.map(_EffectID.init), queue: queue, priority: priority, run: run))])
     }
 
     // MARK: - AsyncSequence
 
     /// `AsyncSequence` side-effect with `EffectContext`.
+    ///
+    /// Each element produced by the underlying `AsyncSequence` is an ``Outcome`` describing
+    /// a feedback action, an emission, or both.
     public static func sequence<S, E: Error>(
+        priority: TaskPriority? = nil,
         _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) -> Effect<Action>
-        where S: AsyncSequence<Action, E> & SendableMetatype
+    ) -> Effect<Action, Emission>
+        where S: AsyncSequence<Outcome, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: nil,
                     queue: nil,
+                    priority: priority,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
             )]
@@ -74,15 +106,17 @@ extension Effect
     /// - Parameter id: Cancellation identifier.
     public static func sequence<ID, S, E: Error>(
         id: ID? = nil,
+        priority: TaskPriority? = nil,
         _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) -> Effect<Action>
-        where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
+    ) -> Effect<Action, Emission>
+        where ID: EffectID, S: AsyncSequence<Outcome, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: id.map(_EffectID.init),
                     queue: nil,
+                    priority: priority,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
             )]
@@ -93,15 +127,17 @@ extension Effect
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func sequence<S, E: Error, Queue>(
         queue: Queue? = nil,
+        priority: TaskPriority? = nil,
         _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) -> Effect<Action>
-        where Queue: EffectQueue, S: AsyncSequence<Action, E> & SendableMetatype
+    ) -> Effect<Action, Emission>
+        where Queue: EffectQueue, S: AsyncSequence<Outcome, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: nil,
                     queue: queue,
+                    priority: priority,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
             )]
@@ -114,15 +150,17 @@ extension Effect
     public static func sequence<ID, S, E: Error, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
+        priority: TaskPriority? = nil,
         _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
-    ) -> Effect<Action>
-        where ID: EffectID, Queue: EffectQueue, S: AsyncSequence<Action, E> & SendableMetatype
+    ) -> Effect<Action, Emission>
+        where ID: EffectID, Queue: EffectQueue, S: AsyncSequence<Outcome, E> & SendableMetatype
     {
         self.init(
             kinds: [.sequence(
                 _Sequence(
                     id: id.map(_EffectID.init),
                     queue: queue,
+                    priority: priority,
                     sequence: { context in try await sequence(context)?.eraseToAnyError() }
                 )
             )]
@@ -131,106 +169,78 @@ extension Effect
 
     // MARK: - Finite/Infinite Stream
 
-    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
+    /// Stream-style side-effect that emits ``Outcome``s via `send`, with `EffectContext`.
     ///
     /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
-    ///   returns — for bridging long-lived observers (delegates, callbacks, notifications)
-    ///   where the closure stores `send` into an outer reference (e.g. captured by a
-    ///   handler) and keeps emitting until cancelled externally. `true` finishes the
-    ///   stream on closure return — for self-terminating producers driven entirely inline.
-    /// - Parameter bufferingPolicy: Buffering policy of the underlying
-    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
-    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    ///   returns; `true` finishes it on return.
+    /// - Parameter priority: Priority of the task that runs this effect.
+    /// - Parameter bufferingPolicy: Buffering policy of the underlying `AsyncThrowingStream`.
     public static func stream(
-        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Outcome, any Error>.Continuation.BufferingPolicy = .unbounded,
         autoFinish: Bool = false,
         _ stream: @escaping @Sendable (
-            _ send: @escaping @Sendable (sending Action) -> Void,
+            _ send: @escaping @Sendable (sending Outcome) -> Void,
             EffectContext
         ) async throws -> Void
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
     {
-        .sequence {
+        .sequence(priority: priority) {
             _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
         }
     }
 
-    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
-    ///
-    /// - Parameter id: Cancellation identifier.
-    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
-    ///   returns — for bridging long-lived observers that hold `send` and keep emitting
-    ///   until cancelled externally. `true` finishes the stream on closure return —
-    ///   for self-terminating producers driven entirely inline.
-    /// - Parameter bufferingPolicy: Buffering policy of the underlying
-    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
-    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    /// Stream-style side-effect with cancellation identifier.
     public static func stream<ID>(
         id: ID? = nil,
-        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Outcome, any Error>.Continuation.BufferingPolicy = .unbounded,
         autoFinish: Bool = false,
         _ stream: @escaping @Sendable (
-            _ send: @escaping @Sendable (sending Action) -> Void,
+            _ send: @escaping @Sendable (sending Outcome) -> Void,
             EffectContext
         ) async throws -> Void
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
         where ID: EffectID
     {
-        .sequence(id: id) {
+        .sequence(id: id, priority: priority) {
             _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
         }
     }
 
-    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
-    ///
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
-    ///   returns — for bridging long-lived observers that hold `send` and keep emitting
-    ///   until cancelled externally. `true` finishes the stream on closure return —
-    ///   for self-terminating producers driven entirely inline.
-    /// - Parameter bufferingPolicy: Buffering policy of the underlying
-    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
-    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    /// Stream-style side-effect with effect-management queue.
     public static func stream<Queue>(
         queue: Queue? = nil,
-        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Outcome, any Error>.Continuation.BufferingPolicy = .unbounded,
         autoFinish: Bool = false,
         _ stream: @escaping @Sendable (
-            _ send: @escaping @Sendable (sending Action) -> Void,
+            _ send: @escaping @Sendable (sending Outcome) -> Void,
             EffectContext
         ) async throws -> Void
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
         where Queue: EffectQueue
     {
-        .sequence(queue: queue) {
+        .sequence(queue: queue, priority: priority) {
             _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
         }
     }
 
-    /// Stream-style side-effect that emits `Action`s via `send`, with `EffectContext`.
-    ///
-    /// - Parameter id: Cancellation identifier.
-    /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
-    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
-    ///   returns — for bridging long-lived observers that hold `send` and keep emitting
-    ///   until cancelled externally. `true` finishes the stream on closure return —
-    ///   for self-terminating producers driven entirely inline.
-    /// - Parameter bufferingPolicy: Buffering policy of the underlying
-    ///   `AsyncThrowingStream`. Defaults to `.unbounded`; pass `.bufferingNewest(n)` or
-    ///   `.bufferingOldest(n)` to apply backpressure for high-frequency producers.
+    /// Stream-style side-effect with cancellation identifier and effect-management queue.
     public static func stream<ID, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
-        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Outcome, any Error>.Continuation.BufferingPolicy = .unbounded,
         autoFinish: Bool = false,
         _ stream: @escaping @Sendable (
-            _ send: @escaping @Sendable (sending Action) -> Void,
+            _ send: @escaping @Sendable (sending Outcome) -> Void,
             EffectContext
         ) async throws -> Void
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
         where ID: EffectID, Queue: EffectQueue
     {
-        .sequence(id: id, queue: queue) {
+        .sequence(id: id, queue: queue, priority: priority) {
             _makeStream(stream, context: $0, bufferingPolicy: bufferingPolicy, autoFinish: autoFinish)
         }
     }
@@ -240,15 +250,15 @@ extension Effect
     /// or throws, and whose termination cancels the running task.
     private static func _makeStream(
         _ stream: @escaping @Sendable (
-            _ send: @escaping @Sendable (sending Action) -> Void,
+            _ send: @escaping @Sendable (sending Outcome) -> Void,
             EffectContext
         ) async throws -> Void,
         context: EffectContext,
-        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy,
+        bufferingPolicy: AsyncThrowingStream<Outcome, any Error>.Continuation.BufferingPolicy,
         autoFinish: Bool
-    ) -> AsyncThrowingStream<Action, any Error>
+    ) -> AsyncThrowingStream<Outcome, any Error>
     {
-        AsyncThrowingStream<Action, any Error>(bufferingPolicy: bufferingPolicy) { continuation in
+        AsyncThrowingStream<Outcome, any Error>(bufferingPolicy: bufferingPolicy) { continuation in
             let task = Task<Void, any Error> {
                 do {
                     try await stream({ continuation.yield($0) }, context)
@@ -270,10 +280,11 @@ extension Effect
 
     /// Single-`async` side-effect without returning next action, with `EffectContext`.
     public static func fireAndForget(
+        priority: TaskPriority? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
     {
-        self.init(run: { context in
+        self.init(priority: priority, run: { context in
             try await run(context)
             return nil
         })
@@ -283,11 +294,12 @@ extension Effect
     /// - Parameter id: Cancellation identifier.
     public static func fireAndForget<ID>(
         id: ID? = nil,
+        priority: TaskPriority? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
         where ID: EffectID
     {
-        self.init(id: id, run: { context in
+        self.init(id: id, priority: priority, run: { context in
             try await run(context)
             return nil
         })
@@ -297,11 +309,12 @@ extension Effect
     /// - Parameter queue: Effect management queue to discard or suspend existing or new tasks.
     public static func fireAndForget<Queue>(
         queue: Queue? = nil,
+        priority: TaskPriority? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
         where Queue: EffectQueue
     {
-        self.init(queue: queue, run: { context in
+        self.init(queue: queue, priority: priority, run: { context in
             try await run(context)
             return nil
         })
@@ -313,34 +326,43 @@ extension Effect
     public static func fireAndForget<ID, Queue>(
         id: ID? = nil,
         queue: Queue? = nil,
+        priority: TaskPriority? = nil,
         run: @escaping @Sendable (EffectContext) async throws -> ()
-    ) -> Effect<Action>
+    ) -> Effect<Action, Emission>
         where ID: EffectID, Queue: EffectQueue
     {
-        self.init(id: id, queue: queue, run: { context in
+        self.init(id: id, queue: queue, priority: priority, run: { context in
             try await run(context)
             return nil
         })
     }
 
-    // MARK: - next
+    // MARK: - next (sync feedback action only)
 
-    /// No `async` side-effect, only returning next action.
-    public static func next(action: Action) -> Effect<Action>
+    /// No `async` side-effect, only returning next action (synchronous reducer feedback).
+    public static func next(action: Action) -> Effect<Action, Emission>
     {
         self.init(kinds: [.next(action)])
+    }
+
+    // MARK: - emit (sync side-channel emission only)
+
+    /// No `async` side-effect, only emitting an `Emission` value to the `send` caller.
+    public static func emit(_ emission: Emission) -> Effect<Action, Emission>
+    {
+        self.init(kinds: [.emission(emission)])
     }
 
     // MARK: - cancel
 
     /// Cancels running `async`s by specifying `ids`.
-    public static func cancel(ids: @escaping @Sendable (any EffectID) -> Bool) -> Effect<Action>
+    public static func cancel(ids: @escaping @Sendable (any EffectID) -> Bool) -> Effect<Action, Emission>
     {
         Effect(kinds: [.cancel(ids)])
     }
 
     /// Cancels running `async`s by specifying `identifier`.
-    public static func cancel<ID>(id: ID) -> Effect<Action>
+    public static func cancel<ID>(id: ID) -> Effect<Action, Emission>
         where ID: EffectID
     {
         Effect(kinds: [.cancel { AnyHashable($0) == AnyHashable(id) }])
@@ -357,10 +379,269 @@ extension Effect
     ///     state.maxConcurrent = n
     ///     return .updateQueue(DynamicQueue(maxCount: n))
     /// ```
-    public static func updateQueue<Queue>(_ queue: Queue) -> Effect<Action>
+    public static func updateQueue<Queue>(_ queue: Queue) -> Effect<Action, Emission>
         where Queue: EffectQueue
     {
         Effect(kinds: [.updateQueue(queue)])
+    }
+}
+
+// MARK: - Convenience for Emission == Never (Action-only API)
+
+extension Effect where Emission == Never
+{
+    /// Single-`async` side-effect returning a feedback action (or `nil`).
+    public init(
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    )
+    {
+        self.init(priority: priority, run: { context -> Outcome? in
+            (try await run(context)).map(Outcome.action)
+        })
+    }
+
+    /// Single-`async` side-effect returning a feedback action (or `nil`).
+    /// - Parameter id: Cancellation identifier.
+    public init<ID>(
+        id: ID? = nil,
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    )
+        where ID: EffectID
+    {
+        self.init(id: id, priority: priority, run: { context -> Outcome? in
+            (try await run(context)).map(Outcome.action)
+        })
+    }
+
+    /// Single-`async` side-effect returning a feedback action (or `nil`).
+    /// - Parameter queue: Effect management queue.
+    public init<Queue>(
+        queue: Queue? = nil,
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    ) where Queue: EffectQueue
+    {
+        self.init(queue: queue, priority: priority, run: { context -> Outcome? in
+            (try await run(context)).map(Outcome.action)
+        })
+    }
+
+    /// Single-`async` side-effect returning a feedback action (or `nil`).
+    public init<ID, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        priority: TaskPriority? = nil,
+        run: @escaping @Sendable (EffectContext) async throws -> Action?
+    ) where ID: EffectID, Queue: EffectQueue
+    {
+        self.init(id: id, queue: queue, priority: priority, run: { context -> Outcome? in
+            (try await run(context)).map(Outcome.action)
+        })
+    }
+
+    /// `AsyncSequence<Action>` side-effect.
+    public static func sequence<S, E: Error>(
+        priority: TaskPriority? = nil,
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action, Never>
+        where S: AsyncSequence<Action, E> & SendableMetatype
+    {
+        Effect<Action, Never>(
+            kinds: [.sequence(
+                Effect<Action, Never>._Sequence(
+                    id: nil,
+                    queue: nil,
+                    priority: priority,
+                    sequence: { context in
+                        guard let seq = try await sequence(context) else { return nil }
+                        return seq.map(Outcome.action).eraseToAnyError()
+                    }
+                )
+            )]
+        )
+    }
+
+    /// `AsyncSequence<Action>` side-effect with cancellation identifier.
+    public static func sequence<ID, S, E: Error>(
+        id: ID? = nil,
+        priority: TaskPriority? = nil,
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action, Never>
+        where ID: EffectID, S: AsyncSequence<Action, E> & SendableMetatype
+    {
+        Effect<Action, Never>(
+            kinds: [.sequence(
+                Effect<Action, Never>._Sequence(
+                    id: id.map(_EffectID.init),
+                    queue: nil,
+                    priority: priority,
+                    sequence: { context in
+                        guard let seq = try await sequence(context) else { return nil }
+                        return seq.map(Outcome.action).eraseToAnyError()
+                    }
+                )
+            )]
+        )
+    }
+
+    /// `AsyncSequence<Action>` side-effect with effect-management queue.
+    public static func sequence<S, E: Error, Queue>(
+        queue: Queue? = nil,
+        priority: TaskPriority? = nil,
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action, Never>
+        where Queue: EffectQueue, S: AsyncSequence<Action, E> & SendableMetatype
+    {
+        Effect<Action, Never>(
+            kinds: [.sequence(
+                Effect<Action, Never>._Sequence(
+                    id: nil,
+                    queue: queue,
+                    priority: priority,
+                    sequence: { context in
+                        guard let seq = try await sequence(context) else { return nil }
+                        return seq.map(Outcome.action).eraseToAnyError()
+                    }
+                )
+            )]
+        )
+    }
+
+    /// `AsyncSequence<Action>` side-effect with cancellation identifier and effect-management queue.
+    public static func sequence<ID, S, E: Error, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        priority: TaskPriority? = nil,
+        _ sequence: @escaping @Sendable (EffectContext) async throws -> S?
+    ) -> Effect<Action, Never>
+        where ID: EffectID, Queue: EffectQueue, S: AsyncSequence<Action, E> & SendableMetatype
+    {
+        Effect<Action, Never>(
+            kinds: [.sequence(
+                Effect<Action, Never>._Sequence(
+                    id: id.map(_EffectID.init),
+                    queue: queue,
+                    priority: priority,
+                    sequence: { context in
+                        guard let seq = try await sequence(context) else { return nil }
+                        return seq.map(Outcome.action).eraseToAnyError()
+                    }
+                )
+            )]
+        )
+    }
+
+    /// Stream-style side-effect that emits `Action`s via `send` (no side-channel).
+    ///
+    /// - Parameter autoFinish: `false` (default) keeps the stream alive after the closure
+    ///   returns; `true` finishes it on return.
+    /// - Parameter priority: Priority of the task that runs this effect.
+    /// - Parameter bufferingPolicy: Buffering policy of the underlying `AsyncThrowingStream`.
+    public static func stream(
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action, Never>
+    {
+        Effect<Action, Never>.stream(
+            priority: priority,
+            bufferingPolicy: _liftBufferingPolicy(bufferingPolicy),
+            autoFinish: autoFinish
+        ) { sendOutcome, context in
+            try await stream({ action in sendOutcome(.action(action)) }, context)
+        }
+    }
+
+    /// Stream-style side-effect with cancellation identifier.
+    public static func stream<ID>(
+        id: ID? = nil,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action, Never>
+        where ID: EffectID
+    {
+        Effect<Action, Never>.stream(
+            id: id,
+            priority: priority,
+            bufferingPolicy: _liftBufferingPolicy(bufferingPolicy),
+            autoFinish: autoFinish
+        ) { sendOutcome, context in
+            try await stream({ action in sendOutcome(.action(action)) }, context)
+        }
+    }
+
+    /// Stream-style side-effect with effect-management queue.
+    public static func stream<Queue>(
+        queue: Queue? = nil,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action, Never>
+        where Queue: EffectQueue
+    {
+        Effect<Action, Never>.stream(
+            queue: queue,
+            priority: priority,
+            bufferingPolicy: _liftBufferingPolicy(bufferingPolicy),
+            autoFinish: autoFinish
+        ) { sendOutcome, context in
+            try await stream({ action in sendOutcome(.action(action)) }, context)
+        }
+    }
+
+    /// Stream-style side-effect with cancellation identifier and effect-management queue.
+    public static func stream<ID, Queue>(
+        id: ID? = nil,
+        queue: Queue? = nil,
+        priority: TaskPriority? = nil,
+        bufferingPolicy: AsyncThrowingStream<Action, any Error>.Continuation.BufferingPolicy = .unbounded,
+        autoFinish: Bool = false,
+        _ stream: @escaping @Sendable (
+            _ send: @escaping @Sendable (sending Action) -> Void,
+            EffectContext
+        ) async throws -> Void
+    ) -> Effect<Action, Never>
+        where ID: EffectID, Queue: EffectQueue
+    {
+        Effect<Action, Never>.stream(
+            id: id, queue: queue, priority: priority,
+            bufferingPolicy: _liftBufferingPolicy(bufferingPolicy),
+            autoFinish: autoFinish
+        ) { sendOutcome, context in
+            try await stream({ action in sendOutcome(.action(action)) }, context)
+        }
+    }
+
+    /// Translates an `T`-typed buffering policy to the equivalent `U`-typed one.
+    private static func _liftBufferingPolicy<T, U>(
+        _ policy: AsyncThrowingStream<T, any Error>.Continuation.BufferingPolicy
+    ) -> AsyncThrowingStream<U, any Error>.Continuation.BufferingPolicy
+    {
+        switch policy {
+        case .unbounded:
+            return .unbounded
+        case let .bufferingNewest(n):
+            return .bufferingNewest(n)
+        case let .bufferingOldest(n):
+            return .bufferingOldest(n)
+        @unknown default:
+            return .unbounded
+        }
     }
 }
 
@@ -368,7 +649,7 @@ extension Effect
 
 extension Effect
 {
-    public static var empty: Effect<Action>
+    public static var empty: Effect<Action, Emission>
     {
         self.init(kinds: [])
     }
@@ -393,8 +674,9 @@ extension Effect
 
 extension Effect
 {
-    /// Changes `Action`.
-    public func map<Action2>(_ f: @escaping @Sendable (Action) -> Action2) -> Effect<Action2>
+    /// Maps `Action` while keeping `Emission`.
+    public func map<Action2>(action f: @escaping @Sendable (Action) -> Action2)
+        -> Effect<Action2, Emission>
     {
         .init(kinds: self.kinds.map { kind in
             switch kind {
@@ -406,6 +688,36 @@ extension Effect
 
             case let .next(action):
                 return .next(f(action))
+
+            case let .emission(value):
+                return .emission(value)
+
+            case let .cancel(predicate):
+                return .cancel(predicate)
+
+            case let .updateQueue(queue):
+                return .updateQueue(queue)
+            }
+        })
+    }
+
+    /// Maps `Emission` while keeping `Action`.
+    public func map<Emission2>(emission f: @escaping @Sendable (Emission) -> Emission2)
+        -> Effect<Action, Emission2>
+    {
+        .init(kinds: self.kinds.map { kind in
+            switch kind {
+            case let .single(single):
+                return .single(single.map(emission: f))
+
+            case let .sequence(sequence):
+                return .sequence(sequence.map(emission: f))
+
+            case let .next(action):
+                return .next(action)
+
+            case let .emission(value):
+                return .emission(f(value))
 
             case let .cancel(predicate):
                 return .cancel(predicate)
@@ -428,7 +740,7 @@ extension Effect
             case let .sequence(sequence):
                 return .sequence(sequence.map(id: f))
 
-            case .next:
+            case .next, .emission:
                 return kind
 
             case let .cancel(predicate):
@@ -452,7 +764,7 @@ extension Effect
             case let .sequence(sequence):
                 return .sequence(sequence.map(queue: { f($0) }))
 
-            case .next:
+            case .next, .emission:
                 return kind
 
             case let .cancel(predicate):
@@ -498,8 +810,11 @@ extension Effect
         /// AsyncSequence effect.
         case sequence(_Sequence)
 
-        /// No async func effect, only returning next action only.
+        /// Synchronous feedback action (re-fed to the reducer by ``MealyMachine/send(_:)``).
         case next(Action)
+
+        /// Synchronous side-channel emission (delivered to caller via the top-level result stream).
+        case emission(Emission)
 
         /// Cancellation effect with filtering effect IDs by a predicate.
         case cancel(@Sendable (any EffectID) -> Bool)
@@ -532,7 +847,7 @@ extension Effect
                 return single.id
             case let .sequence(sequence):
                 return sequence.id
-            case .next:
+            case .next, .emission:
                 return nil
             case .cancel:
                 return nil
@@ -548,12 +863,28 @@ extension Effect
                 return single.queue
             case let .sequence(sequence):
                 return sequence.queue
-            case .next:
+            case .next, .emission:
                 return nil
             case .cancel:
                 return nil
             case let .updateQueue(queue):
                 return queue
+            }
+        }
+
+        internal var priority: TaskPriority?
+        {
+            switch self {
+            case let .single(single):
+                return single.priority
+            case let .sequence(sequence):
+                return sequence.priority
+            case .next, .emission:
+                return nil
+            case .cancel:
+                return nil
+            case .updateQueue:
+                return nil
             }
         }
     }
@@ -563,37 +894,53 @@ extension Effect
     {
         internal let id: _EffectID?
         internal let queue: (any EffectQueue)?
-        internal let run: @Sendable (EffectContext) async throws -> Action?
+        internal let priority: TaskPriority?
+        internal let run: @Sendable (EffectContext) async throws -> Outcome?
 
         internal init(
             id: _EffectID? = nil,
             queue: (any EffectQueue)? = nil,
-            run: @escaping @Sendable (EffectContext) async throws -> Action?
+            priority: TaskPriority? = nil,
+            run: @escaping @Sendable (EffectContext) async throws -> Outcome?
         )
         {
             self.id = id
             self.queue = queue
+            self.priority = priority
             self.run = run
         }
 
-        internal func map<Action2>(action f: @escaping @Sendable (Action) -> Action2) -> Effect<Action2>.Single
+        internal func map<Action2>(
+            action f: @escaping @Sendable (Action) -> Action2
+        ) -> Effect<Action2, Emission>.Single
         {
-            .init(id: id, queue: queue) { context in
-                (try await run(context)).map(f)
+            .init(id: id, queue: queue, priority: priority) { context in
+                guard let outcome = try await run(context) else { return nil }
+                return outcome.map(action: f)
+            }
+        }
+
+        internal func map<Emission2>(
+            emission f: @escaping @Sendable (Emission) -> Emission2
+        ) -> Effect<Action, Emission2>.Single
+        {
+            .init(id: id, queue: queue, priority: priority) { context in
+                guard let outcome = try await run(context) else { return nil }
+                return outcome.map(emission: f)
             }
         }
 
         internal func map<ID>(id f: @escaping ((any EffectID)?) -> ID?) -> Effect.Single
             where ID: EffectID
         {
-            .init(id: f(id?.value).map(_EffectID.init), queue: queue, run: run)
+            .init(id: f(id?.value).map(_EffectID.init), queue: queue, priority: priority, run: run)
         }
 
         internal func map(
             queue f: @escaping ((any EffectQueue)?) -> (any EffectQueue)?
         ) -> Effect.Single
         {
-            .init(id: id, queue: f(queue), run: run)
+            .init(id: id, queue: f(queue), priority: priority, run: run)
         }
     }
 
@@ -602,38 +949,59 @@ extension Effect
     /// The wrapped existential is constrained to `SendableMetatype` (not `Sendable`)
     /// for the same reason as ``MealyMachine``: the produced `AsyncSequence` instance is not
     /// required to be `Sendable`, but its metatype must be so that the existential can appear in
-    /// `@Sendable` closure signatures (here, the `sequence` factory and `Effect.map`'s open-existential
-    /// helper) — it makes no claim about instance sendability.
+    /// `@Sendable` closure signatures.
     internal struct _Sequence
     {
         internal let id: _EffectID?
         internal let queue: (any EffectQueue)?
+        internal let priority: TaskPriority?
         internal let sequence: @Sendable (EffectContext) async throws
-            -> (any AsyncSequence<Action, any Error> & SendableMetatype)?
+            -> (any AsyncSequence<Outcome, any Error> & SendableMetatype)?
 
         internal init(
             id: _EffectID? = nil,
             queue: (any EffectQueue)? = nil,
+            priority: TaskPriority? = nil,
             sequence: @escaping @Sendable (EffectContext) async throws
-                -> (any AsyncSequence<Action, any Error> & SendableMetatype)?
+                -> (any AsyncSequence<Outcome, any Error> & SendableMetatype)?
         )
         {
             self.id = id
             self.queue = queue
+            self.priority = priority
             self.sequence = sequence
         }
 
-        internal func map<Action2>(action f: @escaping @Sendable (Action) -> Action2) -> Effect<Action2>._Sequence
+        internal func map<Action2>(
+            action f: @escaping @Sendable (Action) -> Action2
+        ) -> Effect<Action2, Emission>._Sequence
         {
             // Open Existential
             @Sendable
             func _mapAsyncSequence(
-                _ seq: some AsyncSequence<Action, any Error> & SendableMetatype
-            ) -> any AsyncSequence<Action2, any Error> & SendableMetatype {
-                seq.map(f)
+                _ seq: some AsyncSequence<Outcome, any Error> & SendableMetatype
+            ) -> any AsyncSequence<Effect<Action2, Emission>.Outcome, any Error> & SendableMetatype {
+                seq.map { $0.map(action: f) }
             }
 
-            return .init(id: id, queue: queue, sequence: { context in
+            return .init(id: id, queue: queue, priority: priority, sequence: { context in
+                guard let seq = try await sequence(context) else { return nil }
+                return _mapAsyncSequence(seq)
+            })
+        }
+
+        internal func map<Emission2>(
+            emission f: @escaping @Sendable (Emission) -> Emission2
+        ) -> Effect<Action, Emission2>._Sequence
+        {
+            @Sendable
+            func _mapAsyncSequence(
+                _ seq: some AsyncSequence<Outcome, any Error> & SendableMetatype
+            ) -> any AsyncSequence<Effect<Action, Emission2>.Outcome, any Error> & SendableMetatype {
+                seq.map { $0.map(emission: f) }
+            }
+
+            return .init(id: id, queue: queue, priority: priority, sequence: { context in
                 guard let seq = try await sequence(context) else { return nil }
                 return _mapAsyncSequence(seq)
             })
@@ -642,14 +1010,84 @@ extension Effect
         internal func map<ID>(id f: @escaping ((any EffectID)?) -> ID?) -> Effect._Sequence
             where ID: EffectID
         {
-            .init(id: f(id?.value).map(_EffectID.init), queue: queue, sequence: sequence)
+            .init(id: f(id?.value).map(_EffectID.init), queue: queue, priority: priority, sequence: sequence)
         }
 
         internal func map(
             queue f: @escaping ((any EffectQueue)?) -> (any EffectQueue)?
         ) -> Effect._Sequence
         {
-            .init(id: id, queue: f(queue), sequence: sequence)
+            .init(id: id, queue: f(queue), priority: priority, sequence: sequence)
+        }
+    }
+}
+
+// MARK: - Outcome
+
+extension Effect
+{
+    /// What an async (`.single` / `.sequence` / `.stream`) step produces in a single emission.
+    ///
+    /// - `action`: re-feed `Action` into the reducer; no side-channel emission.
+    /// - `emit`: emit `Emission` to the caller's result stream; no reducer feedback.
+    /// - `both`: do both atomically in the same step.
+    public enum Outcome
+    {
+        case action(Action)
+        case emission(Emission)
+        case both(Action, Emission)
+
+        /// Returns the action half (if any).
+        public var action: Action?
+        {
+            switch self {
+            case let .action(action), let .both(action, _):
+                return action
+            case .emission:
+                return nil
+            }
+        }
+
+        /// Returns the emitted value (if any).
+        public var emission: Emission?
+        {
+            switch self {
+            case let .emission(emission), let .both(_, emission):
+                return emission
+            case .action:
+                return nil
+            }
+        }
+    }
+}
+
+extension Effect.Outcome: Sendable where Action: Sendable, Emission: Sendable {}
+
+// MARK: - Outcome mapping (internal)
+
+extension Effect.Outcome
+{
+    internal func map<Action2>(action f: (Action) -> Action2) -> Effect<Action2, Emission>.Outcome
+    {
+        switch self {
+        case let .action(action):
+            return .action(f(action))
+        case let .emission(value):
+            return .emission(value)
+        case let .both(action, value):
+            return .both(f(action), value)
+        }
+    }
+
+    internal func map<Emission2>(emission f: (Emission) -> Emission2) -> Effect<Action, Emission2>.Outcome
+    {
+        switch self {
+        case let .action(action):
+            return .action(action)
+        case let .emission(value):
+            return .emission(f(value))
+        case let .both(action, value):
+            return .both(action, f(value))
         }
     }
 }

--- a/Sources/ActomatonEffect/EffectManager.swift
+++ b/Sources/ActomatonEffect/EffectManager.swift
@@ -1,16 +1,31 @@
 import Foundation
 
+/// Bare-minimum contract that ``EffectManager``'s `Output` type must satisfy so that the
+/// manager can carry the caller's `Emission` channel without knowing the concrete output
+/// shape (e.g. ``Effect``). Conformers expose the side-channel value type via
+/// ``EffectOutput/Emission`` so a single `EffectManager<Action, State, Output>` constraint
+/// suffices — `Output.Emission` is derived rather than separately bound.
+public protocol EffectOutput
+{
+    associatedtype Emission
+}
+
 /// Protocol for abstracting output processing in ``MealyMachine``.
 ///
-/// Different conformers can handle different reducer output types.
+/// Different conformers can handle different reducer output types — the protocol is generic
+/// over `Output`, and each concrete manager (e.g. ``EffectQueueManager``) refines `Output`
+/// to its specific output shape (`Effect<Action, Emission>` in the queue manager's case).
 ///
 /// The conformer does NOT own the reducer or state — those are managed by ``MealyMachine``.
 /// It only receives the reducer's output and processes it (e.g., creating tasks, managing queues).
+///
+/// `Action` is the feedback channel re-fed into the reducer. `Output.Emission` is the
+/// side-channel value type emitted to the `send` caller via the `emit` callback.
 public protocol EffectManager<Action, State, Output>: SendableMetatype
 {
     associatedtype Action
     associatedtype State
-    associatedtype Output
+    associatedtype Output: EffectOutput
 
     /// Set up communication callbacks bridging the conformer to the parent safe container.
     ///
@@ -25,26 +40,38 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
     ///     marked `@unchecked Sendable`.
     ///     With this sendability, the conformer's private mutable state becomes accessible with
     ///     `@Sendable` protection, which allows robust cross-isolation Swift Concurrency handling
-    ///     such as effect clean-ups via unstructured `Task.detached` — without requiring the
+    ///     such as effect clean-ups via unstructured `Task` — without requiring the
     ///     conformer itself to be `Sendable`. `self` is received as the callback's `Self`
-    ///     parameter rather than captured, so detached cleanup tasks do not need an unsafe `[weak self]`.
+    ///     parameter rather than captured, so unstructured cleanup tasks do not need an unsafe `[weak self]`.
     ///   - sendAction:
     ///     `@Sendable` closure that sends feedback actions back through the reducer pipeline.
-    ///     This closure also derives its sendability from the parent wrapper.
+    ///     The trailing `emit` parameter forwards the original `send`'s emission callback so
+    ///     that any `Output.Emission` values produced by the feedback's downstream effects
+    ///     flow into the same top-level result stream observed by the original caller (only
+    ///     meaningful when `tracksFeedbacks: true`; otherwise the recursive chain is
+    ///     fire-and-forget). This closure also derives its sendability from the parent wrapper.
     func setUp(
         withSendability: @escaping @Sendable (
             _ runEffM: @escaping @Sendable (Self) -> Void
         ) async -> Void,
-        sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
+        sendAction: @escaping @Sendable (
+            _ action: Action,
+            _ priority: TaskPriority?,
+            _ tracksFeedbacks: Bool,
+            _ emit: @escaping @Sendable (Result<Output.Emission, any Error>) -> Void
+        ) async -> Task<(), any Error>?
     )
 
-    /// Process reducer output, creating and managing tasks as needed.
+    /// Process the reducer output, creating and managing tasks as needed.
     ///
     /// Called by the wrapper after ``MealyMachine/send(_:)`` returns its asynchronous-remainder
-    /// output. Synchronous feedback actions have already been resolved by ``MealyMachine``.
+    /// output. Synchronous feedback (e.g. ``Effect/Kind/next``) has already been resolved by
+    /// ``MealyMachine``; this method is responsible for translating the remaining `Output` into
+    /// async tasks while routing synchronous side-channel values via `emit`.
     func processOutput(
         _ output: Output,
         priority: TaskPriority?,
-        tracksFeedbacks: Bool
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Output.Emission, any Error>) -> Void
     ) -> Task<(), any Error>?
 }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -346,6 +346,11 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
     {
         let sendAction = self.sendAction
         let context = self.effectContext
+        let feedbackEmit: @Sendable (Result<Emission, any Error>) -> Void = { result in
+            if tracksFeedbacks {
+                emit(result)
+            }
+        }
 
         switch effectKind {
         case let .single(single):
@@ -361,7 +366,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                         emit(.success(emission))
                     }
                     if let action = outcome.action {
-                        let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, emit)
+                        let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, feedbackEmit)
                         if tracksFeedbacks, let feedbackTask {
                             try await _runTaskForwardingCancellation(feedbackTask)
                         }
@@ -400,7 +405,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                             emit(.success(emission))
                         }
                         if let action = outcome.action {
-                            let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, emit)
+                            let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, feedbackEmit)
                             if tracksFeedbacks, let feedbackTask {
                                 feedbackTasks.append(feedbackTask)
                             }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -125,7 +125,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                 try await withThrowingTaskGroup(of: Void.self) { group in
                     for task in tasks_ {
                         group.addTask(priority: priority) {
-                            try await _awaitTaskForwardingCancellation(task)
+                            try await _runTaskForwardingCancellation(task)
                         }
                     }
                     try await group.waitForAll()
@@ -363,7 +363,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                     if let action = outcome.action {
                         let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, emit)
                         if tracksFeedbacks, let feedbackTask {
-                            try await _awaitTaskForwardingCancellation(feedbackTask)
+                            try await _runTaskForwardingCancellation(feedbackTask)
                         }
                     }
                 }
@@ -388,42 +388,51 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 
         case let .sequence(sequence):
             let task = Task<(), any Error>(priority: priority) { @concurrent in
+                var feedbackTasks: [Task<(), any Error>] = []
+
                 do {
                     if let time {
                         try? await context.clock.sleep(until: time, tolerance: nil)
                     }
                     guard let seq = try await sequence.sequence(context) else { return }
-                    var feedbackTasks: [Task<(), any Error>] = []
                     for try await outcome in seq {
                         if let emission = outcome.emission {
                             emit(.success(emission))
                         }
                         if let action = outcome.action {
                             let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, emit)
-                            if let feedbackTask {
+                            if tracksFeedbacks, let feedbackTask {
                                 feedbackTasks.append(feedbackTask)
                             }
                         }
                     }
                     if tracksFeedbacks {
-                        try await withThrowingTaskGroup(of: Void.self) { group in
-                            for feedbackTask in feedbackTasks {
-                                group.addTask(priority: priority) {
-                                    try await _awaitTaskForwardingCancellation(feedbackTask)
-                                }
-                            }
-                            try await group.waitForAll()
-                        }
+                        try await _runTasksForwardingCancellation(feedbackTasks, priority: priority)
                     }
                 }
                 catch is CancellationError {
                     // Cancellation is not an in-band failure; siblings are torn down by the
                     // supervisor, not by rethrowing here.
+                    if tracksFeedbacks {
+                        await _cancelAndDrainTasks(feedbackTasks)
+                    }
                 }
                 catch {
                     // Surface this sequence effect's error (e.g. an `AsyncSequence` that threw,
                     // or a `.stream` failure) in-band, leaving siblings running.
                     emit(.failure(error))
+
+                    if tracksFeedbacks {
+                        do {
+                            try await _runTasksForwardingCancellation(feedbackTasks, priority: priority)
+                        }
+                        catch is CancellationError {
+                            await _cancelAndDrainTasks(feedbackTasks)
+                        }
+                        catch {
+                            emit(.failure(error))
+                        }
+                    }
                 }
             }
             enqueueTask(
@@ -549,15 +558,6 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         dequeuedTasks.removeValue(forKey: suspendedEffectTask)?.cancel()
     }
 
-    private func completeDequeuedPendingEffect(
-        suspendedEffectTask: Task<(), any Error>,
-        onComplete: AsyncStream<Never>.Continuation
-    )
-    {
-        dequeuedTasks.removeValue(forKey: suspendedEffectTask)
-        onComplete.finish()
-    }
-
     /// Cancels running and pending effects matching the predicate.
     private func cancelEffects(
         predicate: @escaping @Sendable (any EffectID) -> Bool
@@ -669,11 +669,9 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                     _ = await dequeuedTask.result
 
                     await withSendability? { self_ in
-                        self_.completeDequeuedPendingEffect(
-                            suspendedEffectTask: suspendedEffectTask,
-                            onComplete: onComplete
-                        )
+                        self_.dequeuedTasks.removeValue(forKey: suspendedEffectTask)
                     }
+                    onComplete.finish()
                 }
             }
             else {
@@ -747,7 +745,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
     }
 }
 
-/// Awaits `task` while forwarding cancellation from the awaiting task into `task`.
+/// Runs and awaits `task` while forwarding cancellation from the awaiting task into `task`.
 ///
 /// Plain `try await task.value` only waits for the task's result. If the awaiting
 /// task is cancelled, Swift does not automatically call `cancel()` on the task being
@@ -755,7 +753,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 /// than children of the waiter. This helper preserves
 /// `SendResult.cancel()` semantics by turning cancellation of the waiter into
 /// cancellation of the underlying effect task.
-private func _awaitTaskForwardingCancellation(
+private func _runTaskForwardingCancellation(
     _ task: Task<(), any Error>
 ) async throws
 {
@@ -763,5 +761,36 @@ private func _awaitTaskForwardingCancellation(
         try await task.value
     } onCancel: {
         task.cancel()
+    }
+}
+
+private func _runTasksForwardingCancellation(
+    _ tasks: [Task<(), any Error>],
+    priority: TaskPriority?
+) async throws
+{
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        for task in tasks {
+            group.addTask(priority: priority) {
+                try await _runTaskForwardingCancellation(task)
+            }
+        }
+        try await group.waitForAll()
+    }
+}
+
+private func _cancelAndDrainTasks(
+    _ tasks: [Task<(), any Error>]
+) async
+{
+    for task in tasks {
+        task.cancel()
+    }
+
+    // These are already-running unstructured tasks. Sequentially awaiting their results only
+    // drains completion; it does not start them one-by-one, so wall-clock wait is bounded by
+    // the slowest cancellation-aware task rather than the sum of all task durations.
+    for task in tasks {
+        _ = await task.result
     }
 }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -2,18 +2,18 @@ import ActomatonCore
 import Clocks
 import Foundation
 
-/// Default ``EffectManager`` implementation that manages ``Effect<Action>`` with queue-based task lifecycle.
+/// Default ``EffectManager`` implementation that manages ``Effect`` with queue-based task lifecycle.
 ///
 /// Handles task creation, queue policies (newest/oldest), effect delays, and pending effect suspension.
 /// Does NOT own the reducer or state — those are managed by ``MealyMachine``.
 ///
-/// `EffectQueueManager` is a plain non-`Sendable` class. Cleanup work spawned from detached tasks
+/// `EffectQueueManager` is a plain non-`Sendable` class. Cleanup work spawned from unstructured tasks
 /// re-enters the parent safe container that wraps this manager through the `withSendability`
 /// callback supplied at `setUp(...)`-time, which hands `self` back as a parameter — so no
-/// `[weak self]` capture of the (non-Sendable) `self` is needed in the detached task.
-package final class EffectQueueManager<Action, State>: EffectManager
+/// `[weak self]` capture of the (non-Sendable) `self` is needed in those tasks.
+package final class EffectQueueManager<Action, State, Emission>: EffectManager
 {
-    package typealias Output = Effect<Action>
+    package typealias Output = Effect<Action, Emission>
 
     private let effectContext: EffectContext
 
@@ -29,6 +29,15 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// Suspended effects with their original send context.
     private var pendingEffects: [_EffectQueue: [PendingEffect]] = [:]
 
+    /// Dequeued tasks still represented to the original caller by their suspended-effect task.
+    ///
+    /// - Key: the task returned to the public `send` / `SendResult` path while the effect is
+    ///   suspended. It completes only when the pending effect is dropped or the dequeued effect
+    ///   task finishes. This is the task cancelled by `SendResult.cancel()`.
+    /// - Value: the actual running effect task later created by `makeTask(...)` after queue
+    ///   capacity opens and the pending effect is dequeued.
+    private var dequeuedTasks: [Task<(), any Error>: Task<(), any Error>] = [:]
+
     /// Tracked latest effect start time for delayed effects calculation.
     private var latestEffectTime: [_EffectQueue: AnyClock<Duration>.Instant] = [:]
 
@@ -38,15 +47,22 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     // MARK: - Callbacks (set via setUp)
 
-    private var sendAction: (@Sendable (Action, TaskPriority?, Bool) async -> Task<(), any Error>?)?
+    private var sendAction: (
+        @Sendable (
+            Action,
+            TaskPriority?,
+            Bool,
+            _ emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
+        ) async -> Task<(), any Error>?
+    )?
 
     /// `@Sendable` closure with **inherited sendability** from the parent safe container that
     /// wraps this manager. Hands `self` back to the supplied callback under that sendability,
-    /// so the detached cleanup task in ``enqueueTask`` can mutate bookkeeping safely without
+    /// so cleanup tasks in ``enqueueTask`` can mutate bookkeeping safely without
     /// capturing (non-Sendable) `self`.
     private var withSendability: (
         @Sendable (
-            _ runEffM: @escaping @Sendable (EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (EffectQueueManager<Action, State, Emission>) -> Void
         ) async -> Void
     )?
 
@@ -66,9 +82,14 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     package func setUp(
         withSendability: @escaping @Sendable (
-            _ runEffM: @escaping @Sendable (EffectQueueManager<Action, State>) -> Void
+            _ runEffM: @escaping @Sendable (EffectQueueManager<Action, State, Emission>) -> Void
         ) async -> Void,
-        sendAction: @escaping @Sendable (Action, TaskPriority?, _ tracksFeedbacks: Bool) async -> Task<(), any Error>?
+        sendAction: @escaping @Sendable (
+            _ action: Action,
+            _ priority: TaskPriority?,
+            _ tracksFeedbacks: Bool,
+            _ emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
+        ) async -> Task<(), any Error>?
     )
     {
         self.withSendability = withSendability
@@ -76,9 +97,10 @@ package final class EffectQueueManager<Action, State>: EffectManager
     }
 
     package func processOutput(
-        _ output: Effect<Action>,
+        _ output: Effect<Action, Emission>,
         priority: TaskPriority?,
-        tracksFeedbacks: Bool
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> Task<(), any Error>?
     {
         var tasks: [Task<(), any Error>] = []
@@ -87,7 +109,8 @@ package final class EffectQueueManager<Action, State>: EffectManager
                 contentsOf: processEffectKind(
                     kind,
                     priority: priority,
-                    tracksFeedbacks: tracksFeedbacks
+                    tracksFeedbacks: tracksFeedbacks,
+                    emit: emit
                 )
             )
         }
@@ -96,26 +119,21 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
         let tasks_ = tasks
 
-        // Make a detached task that waits for all `tasks`.
-        //
-        // The detached inner tasks are not children of this task group, so
-        // structured-cancellation propagation does NOT reach them automatically.
-        // Each child wraps its `try await task.value` with a per-task
-        // `withTaskCancellationHandler` that forwards an explicit `cancel()` to
-        // the awaited inner task — including the feedback-loop chain when
-        // `tracksFeedbacks` is `true`.
-        return Task.detached {
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                for task in tasks_ {
-                    group.addTask {
-                        try await withTaskCancellationHandler {
-                            try await task.value
-                        } onCancel: {
-                            task.cancel()
+        // Keep the returned task unstructured, but run its supervisor work off any caller actor.
+        return Task(priority: priority) { @concurrent in
+            try await withTaskCancellationHandler {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    for task in tasks_ {
+                        group.addTask(priority: priority) {
+                            try await _awaitTaskForwardingCancellation(task)
                         }
                     }
+                    try await group.waitForAll()
                 }
-                try await group.waitForAll()
+            } onCancel: {
+                for task in tasks_ {
+                    task.cancel()
+                }
             }
         }
     }
@@ -175,33 +193,47 @@ package final class EffectQueueManager<Action, State>: EffectManager
     // MARK: - Private
 
     private func processEffectKind(
-        _ kind: Effect<Action>.Kind,
+        _ kind: Effect<Action, Emission>.Kind,
         priority: TaskPriority?,
-        tracksFeedbacks: Bool
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> [Task<(), any Error>]
     {
         switch kind {
         case .single, .sequence:
-            switch checkQueuePolicy(effectKind: kind, priority: priority, tracksFeedbacks: tracksFeedbacks) {
+            let taskPriority = kind.priority ?? priority
+
+            switch checkQueuePolicy(
+                effectKind: kind,
+                priority: taskPriority,
+                tracksFeedbacks: tracksFeedbacks,
+                emit: emit
+            ) {
             case .execute:
                 let time = calculateEffectTime(queue: kind.queue)
                 if let task = makeTask(
                     effectKind: kind,
                     time: time,
-                    priority: priority,
-                    tracksFeedbacks: tracksFeedbacks
+                    priority: taskPriority,
+                    tracksFeedbacks: tracksFeedbacks,
+                    emit: emit
                 )
                 {
                     return [task]
                 }
                 return []
 
-            case let .suspend(waitTask):
-                return [waitTask]
+            case let .suspend(suspendedEffectTask):
+                return [suspendedEffectTask]
 
             case .discard:
                 return []
             }
+
+        case let .emission(emission):
+            // Synchronous side-channel emission — deliver to the original `send` caller.
+            emit(.success(emission))
+            return []
 
         case .next:
             // Should not appear — MealyMachine.send resolves .next before passing to EffectQueueManager.
@@ -221,9 +253,10 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     /// Checks queue policy and performs any needed task drops/suspensions.
     private func checkQueuePolicy(
-        effectKind: Effect<Action>.Kind,
+        effectKind: Effect<Action, Emission>.Kind,
         priority: TaskPriority?,
-        tracksFeedbacks: Bool
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> QueuePolicyDecision
     {
         guard let queue = effectKind.queue else { return .execute }
@@ -267,19 +300,31 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
                     let (stream, continuation) = AsyncStream<Never>.makeStream()
 
+                    let suspendedEffectTask = Task<(), any Error> {
+                        await withTaskCancellationHandler {
+                            for await _ in stream {}
+                        } onCancel: {
+                            continuation.finish()
+                        }
+                    }
+
                     pendingEffects[effectQueue, default: []].append(
                         PendingEffect(
                             kind: effectKind,
                             priority: priority,
                             tracksFeedbacks: tracksFeedbacks,
+                            suspendedEffectTask: suspendedEffectTask,
+                            emit: emit,
                             onComplete: continuation
                         )
                     )
 
-                    let waitTask = Task<(), any Error> {
-                        for await _ in stream {}
-                    }
-                    return .suspend(waitTask: waitTask)
+                    observeSuspendedEffectTaskCancellation(
+                        suspendedEffectTask,
+                        priority: priority
+                    )
+
+                    return .suspend(suspendedEffectTask: suspendedEffectTask)
 
                 case .discardNew:
                     cancelEffectKind(effectKind)
@@ -290,12 +335,13 @@ package final class EffectQueueManager<Action, State>: EffectManager
         }
     }
 
-    /// Creates a detached task for the given effect kind.
+    /// Creates an unstructured task for the given effect kind.
     private func makeTask(
-        effectKind: Effect<Action>.Kind,
+        effectKind: Effect<Action, Emission>.Kind,
         time: AnyClock<Duration>.Instant?,
         priority: TaskPriority?,
-        tracksFeedbacks: Bool
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> Task<(), any Error>?
     {
         let sendAction = self.sendAction
@@ -303,24 +349,32 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
         switch effectKind {
         case let .single(single):
-            let task = Task.detached(priority: priority) {
-                if let time {
-                    try? await context.clock.sleep(until: time, tolerance: nil)
-                }
-                let nextAction = try await single.run(context)
-                if let nextAction {
-                    let feedbackTask = await sendAction?(nextAction, priority, tracksFeedbacks)
-                    if tracksFeedbacks, let feedbackTask {
-                        // `feedbackTask` is a detached task spawned via `sendAction`,
-                        // so cancellation on this enclosing detached task does not
-                        // reach it through structured concurrency. Forward the
-                        // cancel explicitly so the in-flight feedback chain stops.
-                        try await withTaskCancellationHandler {
-                            try await feedbackTask.value
-                        } onCancel: {
-                            feedbackTask.cancel()
+            let task = Task<(), any Error>(priority: priority) { @concurrent in
+                do {
+                    if let time {
+                        try? await context.clock.sleep(until: time, tolerance: nil)
+                    }
+                    let outcome = try await single.run(context)
+                    guard let outcome else { return }
+
+                    if let emission = outcome.emission {
+                        emit(.success(emission))
+                    }
+                    if let action = outcome.action {
+                        let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, emit)
+                        if tracksFeedbacks, let feedbackTask {
+                            try await _awaitTaskForwardingCancellation(feedbackTask)
                         }
                     }
+                }
+                catch is CancellationError {
+                    // Cancellation is not an in-band failure; teardown is driven by the
+                    // supervisor cancelling all sibling tasks. Swallow so the aggregating
+                    // task group does not rethrow and cancel unrelated siblings.
+                }
+                catch {
+                    // Surface this single effect's error in-band, leaving siblings running.
+                    emit(.failure(error))
                 }
             }
             enqueueTask(
@@ -333,41 +387,43 @@ package final class EffectQueueManager<Action, State>: EffectManager
             return task
 
         case let .sequence(sequence):
-            let task = Task<(), any Error>.detached(priority: priority) {
-                if let time {
-                    try? await context.clock.sleep(until: time, tolerance: nil)
-                }
-                guard let seq = try await sequence.sequence(context) else { return }
-
-                if tracksFeedbacks {
-                    // Each feedback task lives inside its own child task scope
-                    // with its own cancellation handler, so no shared mutable
-                    // collection is needed. Structured cancellation in the
-                    // group propagates the outer task's cancel to every child;
-                    // each child's `onCancel` then cancels its `feedbackTask`.
-                    // `addTask` on an already-cancelled group still produces an
-                    // immediately-cancelled child, so feedback tasks spawned
-                    // during the cancel window are also cancelled.
-                    try await withThrowingTaskGroup(of: Void.self) { group in
-                        for try await nextAction in seq {
-                            let feedbackTask = await sendAction?(nextAction, priority, tracksFeedbacks)
+            let task = Task<(), any Error>(priority: priority) { @concurrent in
+                do {
+                    if let time {
+                        try? await context.clock.sleep(until: time, tolerance: nil)
+                    }
+                    guard let seq = try await sequence.sequence(context) else { return }
+                    var feedbackTasks: [Task<(), any Error>] = []
+                    for try await outcome in seq {
+                        if let emission = outcome.emission {
+                            emit(.success(emission))
+                        }
+                        if let action = outcome.action {
+                            let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, emit)
                             if let feedbackTask {
-                                group.addTask(priority: priority) {
-                                    try await withTaskCancellationHandler {
-                                        try await feedbackTask.value
-                                    } onCancel: {
-                                        feedbackTask.cancel()
-                                    }
-                                }
+                                feedbackTasks.append(feedbackTask)
                             }
                         }
-                        try await group.waitForAll()
+                    }
+                    if tracksFeedbacks {
+                        try await withThrowingTaskGroup(of: Void.self) { group in
+                            for feedbackTask in feedbackTasks {
+                                group.addTask(priority: priority) {
+                                    try await _awaitTaskForwardingCancellation(feedbackTask)
+                                }
+                            }
+                            try await group.waitForAll()
+                        }
                     }
                 }
-                else {
-                    for try await nextAction in seq {
-                        _ = await sendAction?(nextAction, priority, tracksFeedbacks)
-                    }
+                catch is CancellationError {
+                    // Cancellation is not an in-band failure; siblings are torn down by the
+                    // supervisor, not by rethrowing here.
+                }
+                catch {
+                    // Surface this sequence effect's error (e.g. an `AsyncSequence` that threw,
+                    // or a `.stream` failure) in-band, leaving siblings running.
+                    emit(.failure(error))
                 }
             }
             enqueueTask(
@@ -379,16 +435,16 @@ package final class EffectQueueManager<Action, State>: EffectManager
             )
             return task
 
-        case .next, .cancel, .updateQueue:
+        case .next, .emission, .cancel, .updateQueue:
             return nil
         }
     }
 
-    /// Enqueues running `task` and sets up a detached cleanup task.
+    /// Enqueues running `task` and sets up an unstructured cleanup task.
     ///
     /// The cleanup task snapshots `self.withSendability` (a Sendable closure value) and uses
     /// it to re-enter the parent safe container under inherited sendability. `self` is handed
-    /// back as a parameter to the inner callback, so the detached task does NOT need to capture
+    /// back as a parameter to the inner callback, so the cleanup task does NOT need to capture
     /// `self` — letting `EffectQueueManager` remain non-Sendable.
     private func enqueueTask(
         _ task: Task<(), any Error>,
@@ -412,7 +468,7 @@ package final class EffectQueueManager<Action, State>: EffectManager
         let withSendability = self.withSendability
 
         // Clean up after `task` is completed.
-        Task<(), any Error>.detached(priority: priority) {
+        Task<(), any Error>(priority: priority) { @concurrent in
             // Wait for `task` to complete.
             _ = await task.result
 
@@ -431,6 +487,75 @@ package final class EffectQueueManager<Action, State>: EffectManager
                 )
             }
         }
+    }
+
+    /// Observes cancellation of the completion task returned for a suspended pending effect.
+    ///
+    /// `runOldest(..., .suspendNew)` returns this task to the caller before the effect actually
+    /// starts. The task completes only after the pending effect is dropped or the dequeued effect
+    /// task finishes. If `SendResult.cancel()` cancels that task, the cancellation observer re-enters
+    /// the manager and cancels the represented effect: either by removing it from `pendingEffects`,
+    /// or by forwarding cancellation to its dequeued running task.
+    private func observeSuspendedEffectTaskCancellation(
+        _ suspendedEffectTask: Task<(), any Error>,
+        priority: TaskPriority?
+    )
+    {
+        let withSendability = self.withSendability
+
+        // Clean up when the suspended-effect task is cancelled,
+        // whether it is still pending or already dequeued.
+        Task<(), Never>(priority: priority) { @concurrent in
+            _ = await suspendedEffectTask.result
+
+            if suspendedEffectTask.isCancelled {
+                await withSendability? { self_ in
+                    self_.cancelPendingEffect(suspendedEffectTask: suspendedEffectTask)
+                }
+            }
+        }
+    }
+
+    /// Cancels the effect represented by `suspendedEffectTask`.
+    ///
+    /// If the effect is still suspended, it is removed from `pendingEffects` without ever running.
+    /// If it has already been dequeued, the pending entry is gone, so
+    /// `dequeuedTasks` forwards cancellation from the suspended-effect task
+    /// to the running effect task.
+    private func cancelPendingEffect(suspendedEffectTask: Task<(), any Error>)
+    {
+        // Remove pending effect that is associated with `suspendedEffectTask`.
+        for (effectQueue, pendings) in pendingEffects {
+            guard let index = pendings.firstIndex(where: {
+                $0.suspendedEffectTask == suspendedEffectTask
+            })
+            else {
+                continue
+            }
+
+            if let removed = pendingEffects[effectQueue]?.remove(at: index) {
+                cancelEffectKind(removed.kind)
+                removed.onComplete.finish()
+            }
+
+            if pendingEffects[effectQueue]?.isEmpty == true {
+                pendingEffects[effectQueue] = nil
+            }
+
+            return
+        }
+
+        // Or, remove current running dequeued task.
+        dequeuedTasks.removeValue(forKey: suspendedEffectTask)?.cancel()
+    }
+
+    private func completeDequeuedPendingEffect(
+        suspendedEffectTask: Task<(), any Error>,
+        onComplete: AsyncStream<Never>.Continuation
+    )
+    {
+        dequeuedTasks.removeValue(forKey: suspendedEffectTask)
+        onComplete.finish()
     }
 
     /// Cancels running and pending effects matching the predicate.
@@ -510,24 +635,45 @@ package final class EffectQueueManager<Action, State>: EffectManager
             let pending = pendingEffects[effectQueue]!.removeFirst()
             let time = calculateEffectTime(queue: queue)
 
+            if pending.suspendedEffectTask.isCancelled {
+                cancelEffectKind(pending.kind)
+                pending.onComplete.finish()
+                continue
+            }
+
             Debug
                 .print(
                     "[dequeuePendingIfPossible] Dequeued pending effect (running: \(currentCount), maxCount: \(maxCount))"
                 )
 
-            let task = makeTask(
+            let dequeuedTask = makeTask(
                 effectKind: pending.kind,
                 time: time,
                 priority: pending.priority,
-                tracksFeedbacks: pending.tracksFeedbacks
+                tracksFeedbacks: pending.tracksFeedbacks,
+                emit: pending.emit
             )
 
-            // Bridge: signal the original send's waiting task when the dequeued task completes.
+            // Bridge the original suspended-effect task to the newly-created running
+            // task. The bridge is used in both directions: completion of the running task
+            // finishes the suspended-effect task, and cancellation of the
+            // suspended-effect task cancels the running task via `dequeuedTasks`.
             let onComplete = pending.onComplete
-            if let task {
-                Task<Void, Never> {
-                    _ = await task.result
-                    onComplete.finish()
+            let suspendedEffectTask = pending.suspendedEffectTask
+            if let dequeuedTask {
+                dequeuedTasks[suspendedEffectTask] = dequeuedTask
+                let withSendability = self.withSendability
+
+                Task<Void, Never>(priority: pending.priority) {
+                    // Wait for `task` to complete.
+                    _ = await dequeuedTask.result
+
+                    await withSendability? { self_ in
+                        self_.completeDequeuedPendingEffect(
+                            suspendedEffectTask: suspendedEffectTask,
+                            onComplete: onComplete
+                        )
+                    }
                 }
             }
             else {
@@ -538,22 +684,22 @@ package final class EffectQueueManager<Action, State>: EffectManager
 
     /// Cancels `effectKind`'s `single` or `sequence` immediately
     /// so that cancellation can still be delivered to `Effect`'s async scope.
-    private func cancelEffectKind(_ effectKind: Effect<Action>.Kind)
+    private func cancelEffectKind(_ effectKind: Effect<Action, Emission>.Kind)
     {
         let context = self.effectContext
 
         switch effectKind {
         case let .single(single):
-            Task<Void, any Error>.detached {
+            Task<Void, any Error>(priority: single.priority) { @concurrent in
                 _ = try await single.run(context)
             }
             .cancel() // Cancel immediately.
         case let .sequence(sequence):
-            Task<Void, any Error>.detached {
+            Task<Void, any Error>(priority: sequence.priority) { @concurrent in
                 _ = try await sequence.sequence(context)
             }
             .cancel() // Cancel immediately.
-        case .next, .cancel, .updateQueue:
+        case .next, .emission, .cancel, .updateQueue:
             return
         }
     }
@@ -563,9 +709,20 @@ package final class EffectQueueManager<Action, State>: EffectManager
     /// A suspended effect together with its original `send` context.
     private struct PendingEffect
     {
-        let kind: Effect<Action>.Kind
+        let kind: Effect<Action, Emission>.Kind
         let priority: TaskPriority?
         let tracksFeedbacks: Bool
+
+        /// Placeholder task returned to the original `send` while this effect is suspended.
+        ///
+        /// This task does not complete merely when the effect is dequeued. It stays alive until
+        /// the suspended effect is dropped, or until the dequeued effect task finishes, so callers
+        /// can await/cancel the full lifecycle through the original `SendResult`.
+        let suspendedEffectTask: Task<(), any Error>
+
+        /// Original emission callback — preserved so a deferred dequeue still routes
+        /// `Emission` emissions into the top-level result stream that issued the `send`.
+        let emit: @Sendable (Result<Emission, any Error>) -> Void
 
         /// Signalled when the dequeued effect task completes,
         /// allowing the original `send`'s returned Task to finish.
@@ -578,11 +735,33 @@ package final class EffectQueueManager<Action, State>: EffectManager
         /// The effect should be executed immediately.
         case execute
 
-        /// The effect was suspended. The associated task completes when
-        /// the effect is eventually dequeued and finishes.
-        case suspend(waitTask: Task<(), any Error>)
+        /// The effect was suspended.
+        ///
+        /// The associated task represents the suspended effect's full lifecycle: it remains pending
+        /// across dequeue and completes only after the dequeued effect task finishes, or after the
+        /// pending effect is cancelled/dropped.
+        case suspend(suspendedEffectTask: Task<(), any Error>)
 
         /// The effect was discarded (e.g. `discardNew` policy).
         case discard
+    }
+}
+
+/// Awaits `task` while forwarding cancellation from the awaiting task into `task`.
+///
+/// Plain `try await task.value` only waits for the task's result. If the awaiting
+/// task is cancelled, Swift does not automatically call `cancel()` on the task being
+/// awaited, which matters here because effect tasks are unstructured task handles rather
+/// than children of the waiter. This helper preserves
+/// `SendResult.cancel()` semantics by turning cancellation of the waiter into
+/// cancellation of the underlying effect task.
+private func _awaitTaskForwardingCancellation(
+    _ task: Task<(), any Error>
+) async throws
+{
+    try await withTaskCancellationHandler {
+        try await task.value
+    } onCancel: {
+        task.cancel()
     }
 }

--- a/Sources/ActomatonTesting/TestActomaton.swift
+++ b/Sources/ActomatonTesting/TestActomaton.swift
@@ -6,18 +6,22 @@ import XCTest
 /// A testing utility that wraps `MealyMachine` + `EffectQueueManager` to provide
 /// TCA-like `send` / `receive` assertions with readable diff output.
 ///
+/// `Emission` matches the reducer's side-channel output type, so tests can use
+/// the same `Effect<Action, Emission>` reducer shape as production code. `TestActomaton`
+/// does not expose emitted values; it only asserts state changes and feedback actions.
+///
 /// ```swift
-/// let tm = TestActomaton(
+/// let testActomaton = TestActomaton(
 ///     state: MyState(),
 ///     reducer: myReducer,
 ///     environment: ()
 /// )
 ///
-/// await tm.send(.increment) { state in
+/// await testActomaton.send(.increment) { state in
 ///     state.count = 1
 /// }
 ///
-/// await tm.receive(.didLoad) { state in
+/// await testActomaton.receive(.didLoad) { state in
 ///     state.isLoading = false
 /// }
 /// ```
@@ -27,14 +31,14 @@ import XCTest
 ///   `State: Equatable` conformance witness can be sent across isolation when `self` is captured
 ///   in `@Sendable` closures (e.g. `effectManager.setUp` callbacks, `TaskGroup.addTask`).
 ///   `State` values themselves do NOT need to be `Sendable`.
-public actor TestActomaton<Action, State>
-    where Action: Sendable, State: Equatable & SendableMetatype
+public actor TestActomaton<Action, State, Emission>
+    where Action: Sendable, State: Equatable & SendableMetatype, Emission: Sendable
 {
     private typealias InternalAction = TestActomatonAction<Action>
     private typealias RuntimeState = TestActomatonRuntimeState<Action, State>
 
-    private let machine: MealyMachine<InternalAction, RuntimeState, Effect<InternalAction>>
-    private let effectManager: EffectQueueManager<InternalAction, RuntimeState>
+    private let machine: MealyMachine<InternalAction, RuntimeState, Effect<InternalAction, Emission>>
+    private let effectManager: EffectQueueManager<InternalAction, RuntimeState, Emission>
     private let receivedActionSignal: AsyncStream<Void>
     private var consumedReceivedActionCount: Int = 0
 
@@ -44,7 +48,7 @@ public actor TestActomaton<Action, State>
     /// ``receive(_:timeout:assert:fileID:file:line:)``.
     public init<Environment>(
         state: State,
-        reducer: MealyReducer<Action, State, Environment, Effect<Action>>,
+        reducer: MealyReducer<Action, State, Environment, Effect<Action, Emission>>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock())
     ) where Environment: Sendable
@@ -52,10 +56,12 @@ public actor TestActomaton<Action, State>
         let receivedActionSignal = AsyncStream.makeStream(of: Void.self)
         self.receivedActionSignal = receivedActionSignal.stream
 
-        let reducer = MealyReducer<InternalAction, RuntimeState, (), Effect<InternalAction>> { action, state, _ in
+        typealias Reducer = MealyReducer<InternalAction, RuntimeState, (), Effect<InternalAction, Emission>>
+
+        let reducer = Reducer { action, state, _ in
             let stateBeforeAction = state.current
             let effect = reducer.run(action.action, &state.current, environment)
-            let mappedEffect = effect.map(InternalAction.receive)
+            let mappedEffect = effect.map(action: InternalAction.receive)
 
             switch action {
             case .send:
@@ -71,36 +77,43 @@ public actor TestActomaton<Action, State>
                     )
                 )
 
-                return Effect.fireAndForget { _ in
+                return Effect<InternalAction, Emission>.fireAndForget { _ in
                     receivedActionSignal.continuation.yield()
                 } + mappedEffect
             }
         }
 
-        self.machine = MealyMachine<InternalAction, RuntimeState, Effect<InternalAction>>(
+        self.machine = MealyMachine<InternalAction, RuntimeState, Effect<InternalAction, Emission>>(
             state: .init(current: state),
             reducer: reducer
         )
 
-        let effectManager = EffectQueueManager<InternalAction, RuntimeState>(effectContext: effectContext)
+        let effectManager = EffectQueueManager<InternalAction, RuntimeState, Emission>(
+            effectContext: effectContext
+        )
         self.effectManager = effectManager
 
         effectManager.setUp(
             withSendability: { [weak self] runEffM in
                 await self?.runIsolatedEffectManager(runEffM)
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks in
-                await self?.sendFromEffect(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            sendAction: { [weak self] action, priority, tracksFeedbacks, emit in
+                await self?.sendFromEffect(
+                    action,
+                    priority: priority,
+                    tracksFeedbacks: tracksFeedbacks,
+                    emit: emit
+                )
             }
         )
     }
 
     /// Runs `runEffM` within this actor's isolation, supplying the underlying ``EffectManager``
-    /// so that conformers can mutate their own bookkeeping safely from detached tasks without
+    /// so that conformers can mutate their own bookkeeping safely from unstructured tasks without
     /// capturing `self` themselves.
     private func runIsolatedEffectManager<EffM>(
         _ runEffM: (EffM) -> Void
-    ) where EffM: EffectManager<InternalAction, RuntimeState, Effect<InternalAction>>
+    ) where EffM: EffectManager<InternalAction, RuntimeState, Effect<InternalAction, Emission>>
     {
         runEffM(effectManager as! EffM)
     }
@@ -110,11 +123,17 @@ public actor TestActomaton<Action, State>
     private func sendFromEffect(
         _ action: InternalAction,
         priority: TaskPriority?,
-        tracksFeedbacks: Bool
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> Task<(), any Error>?
     {
         let output = machine.send(action)
-        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks,
+            emit: emit
+        )
     }
 
     /// Sends an action and asserts how state changes before any feedback action is received.
@@ -134,7 +153,7 @@ public actor TestActomaton<Action, State>
         fileID: StaticString = #fileID,
         file filePath: StaticString = #filePath,
         line: UInt = #line
-    ) async -> TestActomatonTask
+    ) async -> TestActomatonTask<Emission>
     {
         let runtimeState = self.machine.state
 
@@ -161,13 +180,17 @@ public actor TestActomaton<Action, State>
                 line: line
             )
 
-            return TestActomatonTask(task: nil, timeout: timeout)
+            return TestActomatonTask(sendResult: nil, timeout: timeout)
         }
 
         let expected = runtimeState.current
 
         let output = self.machine.send(.send(action))
-        let task = self.effectManager.processOutput(output, priority: nil, tracksFeedbacks: true)
+        let sendResult = self.effectManager.processOutput(
+            output,
+            priority: nil,
+            tracksFeedbacks: true
+        )
 
         guard let actual = (self.machine.state).latestSentState else {
             XCTFail(
@@ -179,7 +202,7 @@ public actor TestActomaton<Action, State>
                 file: filePath,
                 line: line
             )
-            return .init(task: task, timeout: timeout)
+            return .init(sendResult: sendResult, timeout: timeout)
         }
 
         self.assertStateChange(
@@ -194,7 +217,7 @@ public actor TestActomaton<Action, State>
 
         await Self.drainImmediateFeedbacks()
 
-        return .init(task: task, timeout: timeout)
+        return .init(sendResult: sendResult, timeout: timeout)
     }
 
     /// Asserts an action was received from an effect and verifies the resulting state change.

--- a/Sources/ActomatonTesting/TestActomatonTask.swift
+++ b/Sources/ActomatonTesting/TestActomatonTask.swift
@@ -1,63 +1,59 @@
+import Actomaton
+
 /// A test task returned from ``TestActomaton/send(_:assert:timeout:fileID:file:line:)``.
 ///
 /// Use this value to wait for all effects triggered by the sent action to finish, or to cancel
 /// them explicitly.
-public struct TestActomatonTask: Sendable
+public struct TestActomatonTask<Emission>: Sendable
+    where Emission: Sendable
 {
-    private let task: Task<(), any Error>?
+    /// Result returned by `EffectManager.processOutput`, preserving the same lifecycle semantics
+    /// as production `send` entry points.
+    ///
+    /// `TestActomaton` does not expose emitted values as assertions yet, but owning the
+    /// `SendResult` keeps completion and cancellation behavior aligned with `Actomaton.send`.
+    private let sendResult: SendResult<Emission>?
     private let timeout: Duration
 
     init(
-        task: Task<(), any Error>?,
+        sendResult: SendResult<Emission>?,
         timeout: Duration
     )
     {
-        self.task = task
+        self.sendResult = sendResult
         self.timeout = timeout
     }
 
-    /// Cancels the underlying task and waits for it to settle.
+    /// Cancels the underlying send result and waits for it to settle.
     public func cancel() async
     {
-        self.task?.cancel()
-        _ = await self.task?.result
+        self.sendResult?.cancel()
+        await self.sendResult?.completion()
     }
 
-    /// Waits for the underlying task to finish, throwing ``TimeoutError`` if it does not finish in
-    /// time.
+    /// Waits for the underlying send result to finish, throwing ``TimeoutError`` if it does not
+    /// finish in time.
     ///
     /// - Important:
-    /// This method only waits for task completion and enforces its timeout using wall-clock time.
-    /// It does not advance an injected test clock. If the effect is sleeping on a ``TestClock`` or
-    /// another manually-driven clock, advance that clock separately before awaiting `finish()`.
+    /// This method only waits for send-result completion and enforces its timeout using wall-clock
+    /// time. It does not advance an injected test clock. If the effect is sleeping on a
+    /// ``TestClock`` or another manually-driven clock, advance that clock separately before
+    /// awaiting `finish()`.
     public func finish(timeout: Duration? = nil) async throws
     {
         let duration = timeout ?? self.timeout
 
-        guard let rawValue = self.task else { return }
-
-        let completion = _TaskCompletion()
-
-        Task.detached {
-            let result = await rawValue.result
-
-            switch result {
-            case .success:
-                await completion.succeed()
-            case let .failure(error):
-                await completion.fail(error)
-            }
-        }
+        guard let sendResult = self.sendResult else { return }
 
         try await _withTimeout(duration) {
-            try await completion.wait()
+            await sendResult.completion()
         }
     }
 
-    /// Whether the underlying task has been cancelled.
+    /// Whether the underlying send result has been cancelled.
     public var isCancelled: Bool
     {
-        self.task?.isCancelled ?? true
+        self.sendResult?.isCancelled ?? true
     }
 }
 
@@ -88,69 +84,5 @@ private func _withTimeout<T: Sendable>(
             group.cancelAll()
             throw error
         }
-    }
-}
-
-private actor _TaskCompletion
-{
-    private var result: Result<Void, any Error>?
-    private var continuation: CheckedContinuation<Void, any Error>?
-
-    func wait() async throws
-    {
-        if let result = self.result {
-            return try result.get()
-        }
-
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                if let result = self.result {
-                    continuation.resume(with: result)
-                    return
-                }
-
-                precondition(self.continuation == nil, "Concurrent waits are not supported.")
-                self.continuation = continuation
-            }
-        } onCancel: {
-            Task {
-                await self.cancelWait()
-            }
-        }
-    }
-
-    func succeed()
-    {
-        self.resolve(.success(()))
-    }
-
-    func fail(_ error: any Error)
-    {
-        self.resolve(.failure(error))
-    }
-
-    private func resolve(
-        _ result: Result<Void, any Error>
-    )
-    {
-        guard self.result == nil else { return }
-
-        self.result = result
-
-        switch result {
-        case .success:
-            self.continuation?.resume()
-
-        case let .failure(error):
-            self.continuation?.resume(throwing: error)
-        }
-
-        self.continuation = nil
-    }
-
-    private func cancelWait()
-    {
-        self.continuation?.resume(throwing: CancellationError())
-        self.continuation = nil
     }
 }

--- a/Sources/ActomatonTesting/TestActomatonTask.swift
+++ b/Sources/ActomatonTesting/TestActomatonTask.swift
@@ -45,8 +45,14 @@ public struct TestActomatonTask<Emission>: Sendable
 
         guard let sendResult = self.sendResult else { return }
 
-        try await _withTimeout(duration) {
-            await sendResult.completion()
+        let results = try await _withTimeout(duration) {
+            await sendResult.allResults
+        }
+
+        for result in results {
+            if case let .failure(error) = result {
+                throw error
+            }
         }
     }
 

--- a/Sources/ActomatonUI/Store/Internal/StoreCore.swift
+++ b/Sources/ActomatonUI/Store/Internal/StoreCore.swift
@@ -13,12 +13,12 @@ internal final class StoreCore<Action, State, Environment>
     private typealias Machine = MealyMachine<
         BindableAction<Action, State>,
         State,
-        Effect<BindableAction<Action, State>>
+        Effect<BindableAction<Action, State>, Never>
     >
 
     private let machine: Machine
 
-    private let effectManager: EffectQueueManager<BindableAction<Action, State>, State>
+    private let effectManager: EffectQueueManager<BindableAction<Action, State>, State, Never>
 
     private let _state: CurrentValueSubject<State, Never>
 
@@ -29,7 +29,7 @@ internal final class StoreCore<Action, State, Environment>
     /// Initializer with `environment`.
     internal init(
         state initialState: State,
-        reducer: Reducer<Action, State, Environment>,
+        reducer: Reducer<Action, State, Environment, Never>,
         environment: Environment,
         effectContext: EffectContext,
         configuration: StoreConfiguration
@@ -51,14 +51,16 @@ internal final class StoreCore<Action, State, Environment>
 
         self.machine = machine
 
-        let effectManager = EffectQueueManager<BindableAction<Action, State>, State>(effectContext: effectContext)
+        let effectManager = EffectQueueManager<BindableAction<Action, State>, State, Never>(
+            effectContext: effectContext
+        )
         self.effectManager = effectManager
 
         effectManager.setUp(
             withSendability: { [weak self] runEffM in
                 await self?.runIsolatedEffectManager(runEffM)
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks in
+            sendAction: { [weak self] action, priority, tracksFeedbacks, _ in
                 await self?.send(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
             }
         )
@@ -94,15 +96,20 @@ internal final class StoreCore<Action, State, Environment>
     ) -> Task<(), any Error>?
     {
         let output = machine.send(action)
-        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks,
+            emit: { _ in }
+        )
     }
 
     /// Runs `runEffM` on the MainActor, supplying the underlying ``EffectManager`` so that
-    /// conformers can mutate their own bookkeeping safely from detached tasks without
+    /// conformers can mutate their own bookkeeping safely from unstructured tasks without
     /// capturing `self` itself.
     private func runIsolatedEffectManager<EffM>(
         _ runEffM: (EffM) -> Void
-    ) where EffM: EffectManager<BindableAction<Action, State>, State, Effect<BindableAction<Action, State>>>
+    ) where EffM: EffectManager<BindableAction<Action, State>, State, Effect<BindableAction<Action, State>, Never>>
     {
         runEffM(effectManager as! EffM)
     }
@@ -112,14 +119,14 @@ internal final class StoreCore<Action, State, Environment>
 
 /// Lifts from `Reducer`'s `Action` to `Store.BindableAction`.
 private func lift<Action, State, Environment>(
-    reducer: Reducer<Action, State, Environment>
-) -> Reducer<BindableAction<Action, State>, State, Environment>
+    reducer: Reducer<Action, State, Environment, Never>
+) -> Reducer<BindableAction<Action, State>, State, Environment, Never>
 {
     .init { action, state, environment in
         switch action {
         case let .action(innerAction):
             let effect = reducer.run(innerAction, &state, environment)
-            return effect.map { BindableAction<Action, State>.action($0) }
+            return effect.map(action: { BindableAction<Action, State>.action($0) })
 
         case let .state(newState):
             state = newState

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -65,7 +65,7 @@ public class Store<Action, State, Environment>
     /// Initializer with `environment`.
     public convenience init(
         state initialState: State,
-        reducer: Reducer<Action, State, Environment>,
+        reducer: Reducer<Action, State, Environment, Never>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         configuration: StoreConfiguration = .init()
@@ -89,7 +89,7 @@ public class Store<Action, State, Environment>
     /// Initializer without `environment`.
     public convenience init(
         state initialState: State,
-        reducer: Reducer<Action, State, Void>,
+        reducer: Reducer<Action, State, Void, Never>,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         configuration: StoreConfiguration = .init()
     ) where Environment == Void

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -15,7 +15,7 @@ public final class RouteStore<Action, State, Environment, Route>:
     /// Initializer with `environment`.
     public init(
         state: State,
-        reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>>,
+        reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>, Never>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         configuration: StoreConfiguration = .init(),
@@ -49,7 +49,7 @@ public final class RouteStore<Action, State, Environment, Route>:
     /// Initializer without `environment`.
     public convenience init(
         state: State,
-        reducer: Reducer<Action, State, SendRouteEnvironment<Void, Route>>,
+        reducer: Reducer<Action, State, SendRouteEnvironment<Void, Route>, Never>,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         routeType: Route.Type = Route.self
     ) where Environment == Void

--- a/Sources/DistributedActomaton/DistributedActomaton+Init.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton+Init.swift
@@ -9,7 +9,7 @@ extension DistributedActomaton
     /// Initializer without `environment`.
     public init(
         state: State,
-        reducer: Reducer<Action, State, ()>,
+        reducer: Reducer<Action, State, (), Never>,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         actorSystem: ActorSystem
     )
@@ -17,7 +17,7 @@ extension DistributedActomaton
         self.init(
             state: state,
             reducer: reducer,
-            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext),
+            effectManager: EffectQueueManager<Action, State, Never>(effectContext: effectContext),
             actorSystem: actorSystem
         )
     }
@@ -25,7 +25,7 @@ extension DistributedActomaton
     /// Initializer with `environment`.
     public init<Environment>(
         state: State,
-        reducer: Reducer<Action, State, Environment>,
+        reducer: Reducer<Action, State, Environment, Never>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         actorSystem: ActorSystem
@@ -33,10 +33,10 @@ extension DistributedActomaton
     {
         self.init(
             state: state,
-            reducer: Reducer<Action, State, ()> { action, state, _ in
+            reducer: Reducer<Action, State, (), Never> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectQueueManager<Action, State>(effectContext: effectContext),
+            effectManager: EffectQueueManager<Action, State, Never>(effectContext: effectContext),
             actorSystem: actorSystem
         )
     }

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -2,16 +2,17 @@ import Actomaton
 import ActomatonEffect
 import Distributed
 
-/// `DistributedActomaton` wraps a ``MealyMachine`` specialized with `Output == Effect<Action>` inside a
-/// Swift distributed actor, providing serial isolation for `send(_:)` and `state` access. It owns the
+/// `DistributedActomaton` wraps a ``MealyMachine`` specialized with
+/// `Output == Effect<Action, Never>` inside a Swift distributed actor, providing serial isolation
+/// for `send(_:)` and `state` access. It owns the
 /// ``EffectManager`` and turns the asynchronous-remainder output from ``MealyMachine`` into
 /// running Swift Concurrency tasks.
 public distributed actor DistributedActomaton<Action, State, ActorSystem>
     where Action: Sendable, State: Sendable, ActorSystem: DistributedActorSystem
 {
-    private let machine: MealyMachine<Action, State, Effect<Action>>
+    private let machine: MealyMachine<Action, State, Effect<Action, Never>>
 
-    private let effectManager: any EffectManager<Action, State, Effect<Action>>
+    private let effectManager: any EffectManager<Action, State, Effect<Action, Never>>
 
     public distributed var state: State
     {
@@ -21,8 +22,8 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
     /// Designated initializer that takes an explicit ``EffectManager``.
     public init(
         state: State,
-        reducer: MealyReducer<Action, State, (), Effect<Action>>,
-        effectManager: some EffectManager<Action, State, Effect<Action>>,
+        reducer: MealyReducer<Action, State, (), Effect<Action, Never>>,
+        effectManager: some EffectManager<Action, State, Effect<Action, Never>>,
         actorSystem: ActorSystem
     )
     {
@@ -39,7 +40,7 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
                     self_.runIsolatedEffectManager(runEffM)
                 }
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks in
+            sendAction: { [weak self] action, priority, tracksFeedbacks, _ in
                 return await self?.whenLocal { self_ in
                     self_.sendLocal(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
                 } ?? nil
@@ -50,10 +51,8 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
     /// Sends `action` to the underlying ``MealyMachine`` and forwards the resulting output
     /// to ``EffectManager/processOutput(_:priority:tracksFeedbacks:)``.
     ///
-    /// The return type is `Void` (rather than `Task<(), any Error>?` like
-    /// ``Actomaton/send(_:priority:tracksFeedbacks:)``)
-    /// because a `distributed func`'s return type must satisfy the actor system's
-    /// `SerializationRequirement` (typically `Codable`), and `Task` is not `Codable`.
+    /// The return type is `Void` because a `distributed func`'s return type must satisfy the
+    /// actor system's `SerializationRequirement` (typically `Codable`), and `Task` is not `Codable`.
     /// For local-only access to the launched effect task, use ``sendLocal(_:priority:tracksFeedbacks:)``
     /// via `whenLocal { ... }`.
     ///
@@ -85,15 +84,20 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
     ) -> Task<(), any Error>?
     {
         let output = machine.send(action)
-        return effectManager.processOutput(output, priority: priority, tracksFeedbacks: tracksFeedbacks)
+        return effectManager.processOutput(
+            output,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks,
+            emit: { _ in }
+        )
     }
 
     /// Runs `runEffM` within this actor's isolation, supplying the underlying ``EffectManager``
-    /// so that conformers can mutate their own bookkeeping safely from detached tasks without
+    /// so that conformers can mutate their own bookkeeping safely from unstructured tasks without
     /// capturing `self` themselves.
     fileprivate func runIsolatedEffectManager<EffM>(
         _ runEffM: (EffM) -> Void
-    ) where EffM: EffectManager<Action, State, Effect<Action>>
+    ) where EffM: EffectManager<Action, State, Effect<Action, Never>>
     {
         // Safe downcast from the existential storage to the conformer's concrete `Self`.
         runEffM(effectManager as! EffM)

--- a/Tests/ActomatonTestingTests/TestActomatonTests.swift
+++ b/Tests/ActomatonTestingTests/TestActomatonTests.swift
@@ -8,9 +8,9 @@ final class TestActomatonTests: MainTestCase
 {
     func test_sendTask_finish_success() async throws
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
-            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction, Never>> { action, state, _ in
                 switch action {
                 case .increment:
                     state.count = 1
@@ -29,7 +29,7 @@ final class TestActomatonTests: MainTestCase
             effectContext: effectContext
         )
 
-        let task = await tm.send(.increment) { state in
+        let task = await testActomaton.send(.increment) { state in
             state.count = 1
         }
 
@@ -42,9 +42,9 @@ final class TestActomatonTests: MainTestCase
 
     func test_sendTask_finish_timeout() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
-            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction, Never>> { action, state, _ in
                 switch action {
                 case .increment:
                     state.count = 1
@@ -63,7 +63,7 @@ final class TestActomatonTests: MainTestCase
             effectContext: effectContext
         )
 
-        let task = await tm.send(.increment) { state in
+        let task = await testActomaton.send(.increment) { state in
             state.count = 1
         }
 
@@ -87,13 +87,13 @@ final class TestActomatonTests: MainTestCase
 
     func test_singleSend() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
             reducer: counterReducer,
             environment: ()
         )
 
-        await tm.send(.increment) { state in
+        await testActomaton.send(.increment) { state in
             state.count = 1
         }
     }
@@ -102,21 +102,21 @@ final class TestActomatonTests: MainTestCase
 
     func test_chainedSends() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
             reducer: counterReducer,
             environment: ()
         )
 
-        await tm.send(.increment) { state in
+        await testActomaton.send(.increment) { state in
             state.count = 1
         }
 
-        await tm.send(.increment) { state in
+        await testActomaton.send(.increment) { state in
             state.count = 2
         }
 
-        await tm.send(.decrement) { state in
+        await testActomaton.send(.decrement) { state in
             state.count = 1
         }
     }
@@ -128,11 +128,18 @@ final class TestActomatonTests: MainTestCase
 #else
         let recorder = ResultsCollector<CounterAction>()
 
-        let tm = TestActomaton(
+        typealias Reducer = MealyReducer<
+            CounterAction,
+            CounterState,
+            ResultsCollector<CounterAction>,
+            Effect<CounterAction, Never>
+        >
+
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
-            reducer: MealyReducer<CounterAction, CounterState, ResultsCollector<CounterAction>, Effect<CounterAction>> {
+            reducer: Reducer {
                 action, state, recorder in
-                let recordEffect = Effect<CounterAction>.fireAndForget { _ in
+                let recordEffect = Effect<CounterAction, Never>.fireAndForget { _ in
                     await recorder.append(action)
                 }
 
@@ -151,13 +158,13 @@ final class TestActomatonTests: MainTestCase
             environment: recorder
         )
 
-        let task = await tm.send(.increment) { state in
+        let task = await testActomaton.send(.increment) { state in
             state.count = 1
         }
         try await task.finish()
 
         XCTExpectFailure("`send` should fail before dispatching a new action when feedback remains unhandled.")
-        _ = await tm.send(.decrement)
+        _ = await testActomaton.send(.decrement)
 
         let recordedActions = await recorder.results
         XCTAssertEqual(recordedActions, [.increment, .reset])
@@ -168,35 +175,35 @@ final class TestActomatonTests: MainTestCase
 
     func test_noAssertionSend_stateUnchanged() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
             reducer: counterReducer,
             environment: ()
         )
 
         // Reset when count is already 0 — state doesn't change, so no assertion needed.
-        await tm.send(.reset)
+        await testActomaton.send(.reset)
     }
 
     // MARK: - Action feedback chain
 
     func test_actionFeedbackChain() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: ChainState(steps: []),
             reducer: chainReducer,
             environment: ()
         )
 
-        await tm.send(.step1) { state in
+        await testActomaton.send(.step1) { state in
             state.steps = ["step1"]
         }
 
-        await tm.receive(.step2) { state in
+        await testActomaton.receive(.step2) { state in
             state.steps = ["step1", "step2"]
         }
 
-        await tm.receive(.step3) { state in
+        await testActomaton.receive(.step3) { state in
             state.steps = ["step1", "step2", "step3"]
         }
     }
@@ -205,9 +212,9 @@ final class TestActomatonTests: MainTestCase
 
     func test_effectBasedReducer_asyncNextAction() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
-            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction, Never>> { action, state, _ in
                 switch action {
                 case .increment:
                     state.count += 1
@@ -225,20 +232,20 @@ final class TestActomatonTests: MainTestCase
             environment: ()
         )
 
-        await tm.send(.increment) { state in
+        await testActomaton.send(.increment) { state in
             state.count = 1
         }
 
-        await tm.receive(.reset) { state in
+        await testActomaton.receive(.reset) { state in
             state.count = 0
         }
     }
 
     func test_effectBasedReducer_syncNextAction() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
-            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction, Never>> { action, state, _ in
                 switch action {
                 case .increment:
                     state.count += 1
@@ -254,20 +261,51 @@ final class TestActomatonTests: MainTestCase
             environment: ()
         )
 
-        await tm.send(.increment) { state in
+        await testActomaton.send(.increment) { state in
             state.count = 1
         }
 
-        await tm.receive(.reset) { state in
+        await testActomaton.receive(.reset) { state in
+            state.count = 0
+        }
+    }
+
+    func test_acceptsNonNeverEmissionReducer() async
+    {
+        let testActomaton = TestActomaton(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<
+                CounterAction, CounterState, Void, Effect<CounterAction, String>
+            > { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count += 1
+                    return .emit("incremented") + .next(action: .reset)
+                case .decrement:
+                    state.count -= 1
+                    return .emit("decremented")
+                case .reset:
+                    state.count = 0
+                    return .emit("reset")
+                }
+            },
+            environment: ()
+        )
+
+        await testActomaton.send(.increment) { state in
+            state.count = 1
+        }
+
+        await testActomaton.receive(.reset) { state in
             state.count = 0
         }
     }
 
     func test_asyncEffectReceive() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: CounterState(count: 0),
-            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction>> { action, state, _ in
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction, Never>> { action, state, _ in
                 switch action {
                 case .increment:
                     state.count = 1
@@ -286,11 +324,11 @@ final class TestActomatonTests: MainTestCase
             environment: ()
         )
 
-        await tm.send(.increment) { state in
+        await testActomaton.send(.increment) { state in
             state.count = 1
         }
 
-        await tm.receive(.reset) { state in
+        await testActomaton.receive(.reset) { state in
             state.count = 0
         }
     }
@@ -299,18 +337,18 @@ final class TestActomatonTests: MainTestCase
 
     func test_multipleFieldChanges() async
     {
-        let tm = TestActomaton(
+        let testActomaton = TestActomaton(
             state: UserState(name: "", loggedIn: false),
             reducer: userReducer,
             environment: ()
         )
 
-        await tm.send(.login(name: "alice")) { state in
+        await testActomaton.send(.login(name: "alice")) { state in
             state.name = "alice"
             state.loggedIn = true
         }
 
-        await tm.send(.logout) { state in
+        await testActomaton.send(.logout) { state in
             state.name = ""
             state.loggedIn = false
         }
@@ -332,7 +370,7 @@ private enum CounterAction: Equatable, Sendable
 }
 
 private let counterReducer = MealyReducer<
-    CounterAction, CounterState, Void, Effect<CounterAction>
+    CounterAction, CounterState, Void, Effect<CounterAction, Never>
 > { action, state, _ in
     switch action {
     case .increment:
@@ -359,7 +397,7 @@ private enum ChainAction: Sendable
     case step3
 }
 
-private let chainReducer = MealyReducer<ChainAction, ChainState, Void, Effect<ChainAction>> { action, state, _ in
+private let chainReducer = MealyReducer<ChainAction, ChainState, Void, Effect<ChainAction, Never>> { action, state, _ in
     switch action {
     case .step1:
         state.steps.append("step1")
@@ -385,7 +423,7 @@ private enum UserAction: Sendable
     case logout
 }
 
-private let userReducer = MealyReducer<UserAction, UserState, Void, Effect<UserAction>> { action, state, _ in
+private let userReducer = MealyReducer<UserAction, UserState, Void, Effect<UserAction, Never>> { action, state, _ in
     switch action {
     case let .login(name):
         state.name = name

--- a/Tests/ActomatonTestingTests/TestActomatonTests.swift
+++ b/Tests/ActomatonTestingTests/TestActomatonTests.swift
@@ -83,6 +83,45 @@ final class TestActomatonTests: MainTestCase
         XCTAssertLessThan(elapsed, .seconds(0.5))
     }
 
+    func test_sendTask_finish_throwsEffectFailure() async
+    {
+        let testActomaton = TestActomaton(
+            state: CounterState(count: 0),
+            reducer: MealyReducer<CounterAction, CounterState, Void, Effect<CounterAction, Never>> { action, state, _ in
+                switch action {
+                case .increment:
+                    state.count = 1
+                    return Effect.fireAndForget { _ in
+                        throw TestError()
+                    }
+                case .decrement:
+                    state.count -= 1
+                    return .empty
+                case .reset:
+                    state.count = 0
+                    return .empty
+                }
+            },
+            environment: (),
+            effectContext: effectContext
+        )
+
+        let task = await testActomaton.send(.increment) { state in
+            state.count = 1
+        }
+
+        do {
+            try await task.finish()
+            XCTFail("Expected effect failure.")
+        }
+        catch let error as TestError {
+            XCTAssertEqual(error, TestError())
+        }
+        catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - Basic send + assertion
 
     func test_singleSend() async
@@ -368,6 +407,8 @@ private enum CounterAction: Equatable, Sendable
     case decrement
     case reset
 }
+
+private struct TestError: Error, Equatable {}
 
 private let counterReducer = MealyReducer<
     CounterAction, CounterState, Void, Effect<CounterAction, Never>

--- a/Tests/ActomatonTests/CounterTests.swift
+++ b/Tests/ActomatonTests/CounterTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 final class CounterTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     override func setUp() async throws
     {
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -9,7 +9,7 @@ final class DeinitTests: MainTestCase
         let resultsCollector = ResultsCollector<String>()
         let clock = self.clock
 
-        var actomaton: Actomaton? = Actomaton<Action, State>(
+        var actomaton: Actomaton? = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, _, _ in
                 switch action {
@@ -32,7 +32,7 @@ final class DeinitTests: MainTestCase
 
         weak var weakActomaton = actomaton
 
-        let task = await actomaton?.send(.run)
+        let result = await actomaton?.send(.run)
         await clock.advance(by: .ticks(1))
 
         // Deinit `actomaton`.
@@ -40,7 +40,7 @@ final class DeinitTests: MainTestCase
         XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
 
         // Wait until deinit fully completes.
-        try? await task?.value
+        await result?.completion()
 
         await settle()
 

--- a/Tests/ActomatonTests/DynamicQueueTests.swift
+++ b/Tests/ActomatonTests/DynamicQueueTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for dynamic `EffectQueue` where `maxCount` changes at runtime.
 final class DynamicQueueTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     fileprivate var resultsCollector: ResultsCollector<String> = .init()
 
@@ -12,7 +12,7 @@ final class DynamicQueueTests: MainTestCase
     {
         self.resultsCollector = ResultsCollector<String>()
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/EffectCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectCancellationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for `Effect.cancel`.
 final class EffectCancellationTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     private var flags = Flags()
 
@@ -34,7 +34,7 @@ final class EffectCancellationTests: MainTestCase
         struct EffectID1To2: EffectID {}
         struct EffectID2To3: EffectID {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: ._1,
             reducer: Reducer { [flags] action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/EffectContextClockTests.swift
+++ b/Tests/ActomatonTests/EffectContextClockTests.swift
@@ -8,7 +8,7 @@ final class EffectContextClockTests: XCTestCase
     {
         let clock = TestClock<Duration>()
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: .idle,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -27,11 +27,11 @@ final class EffectContextClockTests: XCTestCase
             effectContext: EffectContext(clock: clock)
         )
 
-        let task = await actomaton.send(.start)
+        let result = await actomaton.send(.start)
         assertEqual(await actomaton.state, .running)
 
         await clock.advance(by: .ticks(1))
-        try await task?.value
+        await result.completion()
 
         assertEqual(await actomaton.state, .finished)
     }
@@ -40,7 +40,7 @@ final class EffectContextClockTests: XCTestCase
     {
         let clock = TestClock<Duration>()
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: .idle,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -59,11 +59,11 @@ final class EffectContextClockTests: XCTestCase
             effectContext: EffectContext(clock: clock)
         )
 
-        let task = await actomaton.send(.start)
+        let result = await actomaton.send(.start)
         assertEqual(await actomaton.state, .running)
 
         await clock.advance(by: .ticks(2))
-        try await task?.value
+        await result.completion()
 
         assertEqual(await actomaton.state, .finished)
     }

--- a/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
+++ b/Tests/ActomatonTests/EffectIDAutoCancellationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for `Newest1EffectQueue` where previous effect will be automatically cancelled by the next effect.
 final class EffectIDAutoCancellationTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     private var flags = Flags()
 
@@ -33,7 +33,7 @@ final class EffectIDAutoCancellationTests: MainTestCase
 
         struct TestNewest1EffectQueue: Newest1EffectQueue {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: ._1,
             reducer: Reducer { [flags] action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/EffectPriorityTests.swift
+++ b/Tests/ActomatonTests/EffectPriorityTests.swift
@@ -1,0 +1,116 @@
+import Actomaton
+import XCTest
+
+final class EffectPriorityTests: MainTestCase
+{
+    private var priorities = ResultsCollector<RecordedPriority>()
+
+    override func setUp() async throws
+    {
+        priorities = ResultsCollector<RecordedPriority>()
+    }
+
+    func test_singleEffectPriorityOverridesSendPriority() async throws
+    {
+        let actomaton = makeActomaton()
+
+        let result = await actomaton.send(.single, priority: .background)
+        await result.completion()
+
+        assertEqual(
+            await priorities.results,
+            [.init(name: "single", priority: .high)]
+        )
+    }
+
+    func test_sequenceEffectPriorityOverridesSendPriority() async throws
+    {
+        let actomaton = makeActomaton()
+
+        let result = await actomaton.send(.sequence, priority: .background)
+        await result.completion()
+
+        assertEqual(
+            await priorities.results,
+            [.init(name: "sequence", priority: .high)]
+        )
+    }
+
+    func test_suspendedEffectUsesEffectPriorityWhenDequeued() async throws
+    {
+        let actomaton = makeActomaton()
+
+        let firstResult = await actomaton.send(
+            .queued(name: "first", priority: nil),
+            priority: .background
+        )
+        let secondResult = await actomaton.send(
+            .queued(name: "second", priority: .high),
+            priority: .background
+        )
+
+        await settle()
+        assertEqual(await priorities.results.map(\.name), ["first"])
+
+        await clock.advance(by: .ticks(1.5))
+        await settle()
+        assertEqual(await priorities.results.map(\.name), ["first", "second"])
+
+        await clock.advance(by: .ticks(1.5))
+        await firstResult.completion()
+        await secondResult.completion()
+
+        assertEqual(
+            await priorities.results.last,
+            .init(name: "second", priority: .high)
+        )
+    }
+
+    private func makeActomaton() -> Actomaton<PriorityAction, Int, Never>
+    {
+        Actomaton<PriorityAction, Int, Never>(
+            state: 0,
+            reducer: Reducer { [priorities] action, state, _ in
+                switch action {
+                case .single:
+                    return Effect(priority: .high) { _ -> PriorityAction? in
+                        await priorities.append(.init(name: "single", priority: Task.currentPriority))
+                        return nil
+                    }
+
+                case .sequence:
+                    return Effect.sequence(priority: .high) { _ -> AsyncStream<PriorityAction>? in
+                        await priorities.append(.init(name: "sequence", priority: Task.currentPriority))
+                        return AsyncStream { continuation in
+                            continuation.finish()
+                        }
+                    }
+
+                case let .queued(name, priority):
+                    state += 1
+                    return Effect(queue: PrioritySuspendQueue(), priority: priority) { context -> PriorityAction? in
+                        await priorities.append(.init(name: name, priority: Task.currentPriority))
+                        try await context.clock.sleep(for: .ticks(1))
+                        return nil
+                    }
+                }
+            },
+            effectContext: effectContext
+        )
+    }
+}
+
+private enum PriorityAction: Sendable
+{
+    case single
+    case sequence
+    case queued(name: String, priority: TaskPriority?)
+}
+
+private struct RecordedPriority: Equatable, Sendable
+{
+    var name: String
+    var priority: TaskPriority
+}
+
+private struct PrioritySuspendQueue: Oldest1SuspendNewEffectQueue {}

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -7,12 +7,12 @@ final class EffectQueueDelayTests: MainTestCase
     private func makeActomaton<Queue: EffectQueue>(
         queue: Queue,
         effectTime: TestDuration
-    ) -> (Actomaton<Action, State>, startedIDs: ResultsCollector<String>, cancelledIDs: ResultsCollector<String>)
+    ) -> (Actomaton<Action, State, Never>, startedIDs: ResultsCollector<String>, cancelledIDs: ResultsCollector<String>)
     {
         let startedIDs: ResultsCollector<String> = .init()
         let cancelledIDs: ResultsCollector<String> = .init()
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: .init(),
             reducer: Reducer { action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/EffectStreamTests.swift
+++ b/Tests/ActomatonTests/EffectStreamTests.swift
@@ -29,7 +29,7 @@ final class EffectStreamTests: MainTestCase
 
     func test_stream_emitsMultipleActions() async throws
     {
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -81,7 +81,7 @@ final class EffectStreamTests: MainTestCase
     {
         struct TimerID: EffectID {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { [flags] action, state, _ in
                 switch action {
@@ -138,7 +138,7 @@ final class EffectStreamTests: MainTestCase
     {
         struct TestNewest1Queue: Newest1EffectQueue {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { [flags] action, state, _ in
                 switch action {
@@ -197,7 +197,7 @@ final class EffectStreamTests: MainTestCase
         struct TimerID: EffectID {}
         struct TestNewest1Queue: Newest1EffectQueue {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { [flags] action, state, _ in
                 switch action {
@@ -248,7 +248,7 @@ final class EffectStreamTests: MainTestCase
     /// task completes without explicit cancellation.
     func test_stream_autoFinishTrue_unifiedTaskCompletesWhenClosureReturns() async throws
     {
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -269,32 +269,31 @@ final class EffectStreamTests: MainTestCase
             effectContext: effectContext
         )
 
-        let task = await actomaton.send(.start)
-        XCTAssertNotNil(task)
+        let result = await actomaton.send(.start)
 
         await clock.advance(by: .ticks(2.6))
 
         // Should NOT hang — `autoFinish: true` calls `continuation.finish()` on closure return.
-        try await task?.value
+        await result.completion()
 
         assertEqual(await actomaton.state, 2)
     }
 
-    /// `autoFinish: false` — `send` captured into an outer reference (here a detached
+    /// `autoFinish: false` — `send` captured into an outer reference (here an unstructured
     /// `Task`) can still emit `Action`s after the producer closure has returned.
     /// This is the long-lived-observer bridging pattern the docstring promises.
     func test_stream_autoFinishFalse_canEmitAfterClosureReturns() async throws
     {
         struct TimerID: EffectID {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { [clock] action, state, _ in
                 switch action {
                 case .start:
                     return .stream(id: TimerID()) { send, _ in
-                        // Hand `send` off to a detached task, then return immediately.
-                        // The continuation must stay open so the detached task can emit.
+                        // Hand `send` off to an unstructured task, then return immediately.
+                        // The continuation must stay open so that task can emit.
                         Task { @Sendable in
                             for _ in 0 ..< 3 {
                                 try await clock.sleep(for: .ticks(1))
@@ -324,7 +323,7 @@ final class EffectStreamTests: MainTestCase
         assertEqual(
             await actomaton.state,
             3,
-            "Detached task should keep emitting via `send` even after the producer closure returned."
+            "Unstructured task should keep emitting via `send` even after the producer closure returned."
         )
 
         await actomaton.send(.stop)
@@ -336,7 +335,7 @@ final class EffectStreamTests: MainTestCase
     {
         struct TimerID: EffectID {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -358,36 +357,30 @@ final class EffectStreamTests: MainTestCase
             effectContext: effectContext
         )
 
-        let task = await actomaton.send(.start)
-        XCTAssertNotNil(task)
+        let result = await actomaton.send(.start)
 
         await clock.advance(by: .ticks(2.6))
         assertEqual(await actomaton.state, 2)
 
-        // Stream did not finish on its own — `task.value` would hang here.
-        XCTAssertFalse(task?.isCancelled ?? true)
+        // Stream did not finish on its own — `result.completion()` would hang here.
+        XCTAssertFalse(result.isCancelled)
 
         // Explicit cancellation is required to complete the effect.
         await actomaton.send(.stop)
 
-        do {
-            try await task?.value
-        }
-        catch is CancellationError {
-            // Cancellation is one acceptable outcome.
-        }
+        await result.completion()
 
         assertEqual(await actomaton.state, 2)
     }
 
     /// Verifies that the underlying `AsyncThrowingStream` continuation finishes
-    /// with the thrown error, so the unified `send` task rethrows that error
-    /// (rather than hanging on the inner `for try await` loop).
-    func test_stream_unifiedTaskRethrowsClosureError() async throws
+    /// with the thrown error, so the unified `send` result receives that error
+    /// in-band rather than hanging on the inner `for try await` loop.
+    func test_stream_unifiedResultReceivesClosureError() async throws
     {
         struct StreamError: Error, Equatable {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -407,18 +400,15 @@ final class EffectStreamTests: MainTestCase
             effectContext: effectContext
         )
 
-        let task = await actomaton.send(.start)
-        XCTAssertNotNil(task)
+        let result = await actomaton.send(.start)
 
         await clock.advance(by: .ticks(1.3))
 
-        do {
-            try await task?.value
-            XCTFail("Should rethrow StreamError from the closure.")
+        let errors = await result.errors
+        guard let error = errors.first as? StreamError else {
+            return XCTFail("Should receive StreamError from the closure.")
         }
-        catch is StreamError {
-            // Expected — `continuation.finish(throwing:)` propagated the error.
-        }
+        XCTAssertEqual(error, StreamError())
 
         assertEqual(await actomaton.state, 1)
     }

--- a/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
+++ b/Tests/ActomatonTests/FeedbackTrackingTaskTests.swift
@@ -4,11 +4,11 @@ import XCTest
 /// Tests for `actomaton.send`'s returned `Task`.
 final class FeedbackTrackingTaskTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     private func setupActomaton(initalState: State) async
     {
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: initalState,
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -107,11 +107,11 @@ final class FeedbackTrackingTaskTests: MainTestCase
 
         assertEqual(await actomaton.state, ._1)
 
-        let task = await actomaton.send(._1To2, tracksFeedbacks: false)
+        let result = await actomaton.send(._1To2, tracksFeedbacks: false)
 
         // Wait for `._1To2`'s effect only (upto `_2To3`'s next state-transition without its effect)
         await clock.advance(by: .ticks(1))
-        try await task?.value
+        await result.completion()
 
         assertEqual(
             await actomaton.state,
@@ -147,11 +147,11 @@ final class FeedbackTrackingTaskTests: MainTestCase
         assertEqual(await actomaton.state, ._1)
 
         // Single effect, tracking feedbacks.
-        let task = await actomaton.send(._1To2, tracksFeedbacks: true)
+        let result = await actomaton.send(._1To2, tracksFeedbacks: true)
 
         // Wait for all: `._1To2`, `._2To3`, `._3To4`, `._increment`, `._4To5`, `._5To6`.
         await clock.advance(by: .ticks(6))
-        try await task?.value
+        await result.completion()
 
         assertEqual(
             await actomaton.state,
@@ -168,11 +168,11 @@ final class FeedbackTrackingTaskTests: MainTestCase
         assertEqual(await actomaton.state, ._3)
 
         // Sequence effect, tracking feedbacks.
-        let task = await actomaton.send(._3To4, tracksFeedbacks: true)
+        let result = await actomaton.send(._3To4, tracksFeedbacks: true)
 
         // Wait for all: `._3To4`, `._increment`, `._4To5`, `._5To6`.
         await clock.advance(by: .ticks(4))
-        try await task?.value
+        await result.completion()
 
         assertEqual(
             await actomaton.state,

--- a/Tests/ActomatonTests/LoginLogoutTests.swift
+++ b/Tests/ActomatonTests/LoginLogoutTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class LoginLogoutTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     private var flags = Flags()
 
@@ -27,7 +27,7 @@ final class LoginLogoutTests: MainTestCase
 
         struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: .loggedOut,
             reducer: Reducer { [flags] action, state, _ in
                 switch (action, state) {
@@ -87,22 +87,22 @@ final class LoginLogoutTests: MainTestCase
     // `loggedOut => loggingIn => loggedIn => loggingOut => loggedOut` succeeds.
     func test_login_logout() async throws
     {
-        var t: Task<(), any Error>?
+        var result: SendResult<Never>?
 
         assertEqual(await actomaton.state, .loggedOut)
 
-        t = await actomaton.send(.login)
+        result = await actomaton.send(.login)
         assertEqual(await actomaton.state, .loggingIn)
 
         await clock.advance(by: .ticks(1))
-        try await t?.value // wait for previous effect
+        await result?.completion() // wait for previous effect
         assertEqual(await actomaton.state, .loggedIn)
 
-        t = await actomaton.send(.logout)
+        result = await actomaton.send(.logout)
         assertEqual(await actomaton.state, .loggingOut)
 
         await clock.advance(by: .ticks(1))
-        try await t?.value // wait for previous effect
+        await result?.completion() // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
 
         let isLoginCancelled = await flags.isLoginCancelled
@@ -112,7 +112,7 @@ final class LoginLogoutTests: MainTestCase
     // `loggedOut => loggingIn ==(ForceLogout)==> loggingOut => loggedOut` succeeds.
     func test_login_forceLogout() async throws
     {
-        var t: Task<(), any Error>?
+        var result: SendResult<Never>?
 
         assertEqual(await actomaton.state, .loggedOut)
 
@@ -121,12 +121,12 @@ final class LoginLogoutTests: MainTestCase
 
         // Wait for a while and interrupt by `forceLogout`.
         await clock.advance(by: .ticks(0.1))
-        t = await actomaton.send(.forceLogout)
+        result = await actomaton.send(.forceLogout)
 
         assertEqual(await actomaton.state, .loggingOut)
 
         await clock.advance(by: .ticks(1))
-        try await t?.value // wait for previous effect
+        await result?.completion() // wait for previous effect
         assertEqual(await actomaton.state, .loggedOut)
 
         let isLoginCancelled = await flags.isLoginCancelled

--- a/Tests/ActomatonTests/MealyDriverTests.swift
+++ b/Tests/ActomatonTests/MealyDriverTests.swift
@@ -4,11 +4,11 @@ import XCTest
 /// Smoke test for ``MealyDriver`` — the non-actor counterpart of ``Actomaton``.
 final class MealyDriverTests: MainTestCase
 {
-    fileprivate var driver: MealyDriver<Action, State>!
+    fileprivate var driver: MealyDriver<Action, State, Never>!
 
     override func setUp() async throws
     {
-        let driver = MealyDriver<Action, State>(
+        let driver = MealyDriver<Action, State, Never>(
             state: State(),
             reducer: Reducer { action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for `Effect.cancel` to cancel pending effects by `Oldest1SuspendNewEffectQueue`.
 final class PendingEffectCancellationTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     private var flags = Flags()
 
@@ -45,7 +45,7 @@ final class PendingEffectCancellationTests: MainTestCase
 
         struct TestOldest1SuspendNewEffectQueue: Oldest1SuspendNewEffectQueue {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: .init(),
             reducer: Reducer { [flags] action, _, _ in
                 switch action {

--- a/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
+++ b/Tests/ActomatonTests/RunNewestDiscardOldTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for `EffectQueue` with `EffectQueuePolicy.runNewest(maxCount: n)`.
 final class RunNewestDiscardOldTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     fileprivate var resultsCollector: ResultsCollector<Int> = .init()
 
@@ -22,7 +22,7 @@ final class RunNewestDiscardOldTests: MainTestCase
             }
         }
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for `EffectQueue` with `EffectQueuePolicy.runOldest(maxCount: n, .discardNew)`.
 final class RunOldestDiscardNewTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     fileprivate var resultsCollector: ResultsCollector<Int> = .init()
 
@@ -22,7 +22,7 @@ final class RunOldestDiscardNewTests: MainTestCase
             }
         }
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestSuspendNewTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for `EffectQueue` with `EffectQueuePolicy.runOldest(maxCount: n, .suspendNew)`.
 final class RunOldestSuspendNewTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     fileprivate var resultsCollector: ResultsCollector<Int> = .init()
 
@@ -22,7 +22,7 @@ final class RunOldestSuspendNewTests: MainTestCase
             }
         }
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {

--- a/Tests/ActomatonTests/SendResultCancellationTests.swift
+++ b/Tests/ActomatonTests/SendResultCancellationTests.swift
@@ -1,0 +1,220 @@
+import Actomaton
+import XCTest
+
+/// Tests for `SendResult.cancel()` cascading into the actual effect tasks.
+final class SendResultCancellationTests: MainTestCase
+{
+    private var flags = Flags()
+
+    private actor Flags
+    {
+        var isTopLevelCancelled = false
+        var isFeedbackRootCancelled = false
+        var isFeedbackChildCancelled = false
+        var isQueuedFirstCancelled = false
+        var isQueuedSecondCancelled = false
+
+        func mark(
+            isTopLevelCancelled: Bool? = nil,
+            isFeedbackRootCancelled: Bool? = nil,
+            isFeedbackChildCancelled: Bool? = nil,
+            isQueuedFirstCancelled: Bool? = nil,
+            isQueuedSecondCancelled: Bool? = nil
+        )
+        {
+            if let isTopLevelCancelled {
+                self.isTopLevelCancelled = isTopLevelCancelled
+            }
+            if let isFeedbackRootCancelled {
+                self.isFeedbackRootCancelled = isFeedbackRootCancelled
+            }
+            if let isFeedbackChildCancelled {
+                self.isFeedbackChildCancelled = isFeedbackChildCancelled
+            }
+            if let isQueuedFirstCancelled {
+                self.isQueuedFirstCancelled = isQueuedFirstCancelled
+            }
+            if let isQueuedSecondCancelled {
+                self.isQueuedSecondCancelled = isQueuedSecondCancelled
+            }
+        }
+    }
+
+    override func setUp() async throws
+    {
+        flags = Flags()
+    }
+
+    func test_cancelStopsTopLevelEffect() async throws
+    {
+        let actomaton = makeActomaton()
+
+        let result = await actomaton.send(.topLevel)
+
+        await clock.advance(by: .ticks(0.1))
+        result.cancel()
+        await result.completion()
+
+        await clock.advance(by: .ticks(2))
+
+        let isTopLevelCancelled = await flags.isTopLevelCancelled
+        XCTAssertTrue(isTopLevelCancelled)
+        assertEqual(await actomaton.state.isTopLevelFinished, false)
+    }
+
+    func test_cancelStopsTrackedFeedbackEffect() async throws
+    {
+        let actomaton = makeActomaton()
+
+        let result = await actomaton.send(.feedbackRoot, tracksFeedbacks: true)
+
+        await clock.advance(by: .ticks(1.5))
+        assertEqual(await actomaton.state.isFeedbackChildStarted, true)
+
+        result.cancel()
+        await result.completion()
+
+        await clock.advance(by: .ticks(2))
+
+        let isFeedbackRootCancelled = await flags.isFeedbackRootCancelled
+        let isFeedbackChildCancelled = await flags.isFeedbackChildCancelled
+        XCTAssertFalse(isFeedbackRootCancelled)
+        XCTAssertTrue(isFeedbackChildCancelled)
+        assertEqual(await actomaton.state.isFeedbackFinished, false)
+    }
+
+    func test_cancelDropsPendingEffect() async throws
+    {
+        let actomaton = makeActomaton()
+
+        let firstResult = await actomaton.send(.queuedFirst)
+        let secondResult = await actomaton.send(.queuedSecond)
+
+        secondResult.cancel()
+        await secondResult.completion()
+        await settle()
+
+        let isQueuedSecondCancelled = await flags.isQueuedSecondCancelled
+        XCTAssertTrue(isQueuedSecondCancelled)
+
+        await clock.advance(by: .ticks(2.5))
+        await firstResult.completion()
+
+        await clock.advance(by: .ticks(2))
+
+        let isQueuedFirstCancelled = await flags.isQueuedFirstCancelled
+        XCTAssertFalse(isQueuedFirstCancelled)
+        assertEqual(await actomaton.state.isQueuedFirstFinished, true)
+        assertEqual(await actomaton.state.isQueuedSecondFinished, false)
+    }
+
+    private func makeActomaton() -> Actomaton<Action, State, Never>
+    {
+        Actomaton<Action, State, Never>(
+            state: State(),
+            reducer: Reducer { [flags] action, state, _ in
+                switch action {
+                case .topLevel:
+                    return Effect { context in
+                        try await context.clock.sleep(for: .ticks(1)) {
+                            .topLevelFinished
+                        } ifCancelled: {
+                            await flags.mark(isTopLevelCancelled: true)
+                            return nil
+                        }
+                    }
+
+                case .topLevelFinished:
+                    state.isTopLevelFinished = true
+                    return .empty
+
+                case .feedbackRoot:
+                    return Effect { context in
+                        try await context.clock.sleep(for: .ticks(1)) {
+                            .feedbackChild
+                        } ifCancelled: {
+                            await flags.mark(isFeedbackRootCancelled: true)
+                            return nil
+                        }
+                    }
+
+                case .feedbackChild:
+                    state.isFeedbackChildStarted = true
+                    return Effect { context in
+                        try await context.clock.sleep(for: .ticks(1)) {
+                            .feedbackFinished
+                        } ifCancelled: {
+                            await flags.mark(isFeedbackChildCancelled: true)
+                            return nil
+                        }
+                    }
+
+                case .feedbackFinished:
+                    state.isFeedbackFinished = true
+                    return .empty
+
+                case .queuedFirst:
+                    return Effect(queue: SuspendQueue()) { context in
+                        try await context.clock.sleep(for: .ticks(2)) {
+                            .queuedFirstFinished
+                        } ifCancelled: {
+                            await flags.mark(isQueuedFirstCancelled: true)
+                            return nil
+                        }
+                    }
+
+                case .queuedSecond:
+                    return Effect(queue: SuspendQueue()) { context in
+                        try await context.clock.sleep(for: .ticks(1)) {
+                            .queuedSecondFinished
+                        } ifCancelled: {
+                            await flags.mark(isQueuedSecondCancelled: true)
+                            return nil
+                        }
+                    }
+
+                case .queuedFirstFinished:
+                    state.isQueuedFirstFinished = true
+                    return .empty
+
+                case .queuedSecondFinished:
+                    state.isQueuedSecondFinished = true
+                    return .empty
+                }
+            },
+            effectContext: effectContext
+        )
+    }
+}
+
+// MARK: - Private
+
+private enum Action: Sendable
+{
+    case topLevel
+    case topLevelFinished
+    case feedbackRoot
+    case feedbackChild
+    case feedbackFinished
+    case queuedFirst
+    case queuedSecond
+    case queuedFirstFinished
+    case queuedSecondFinished
+}
+
+private struct State: Equatable, Sendable
+{
+    var isTopLevelFinished = false
+    var isFeedbackChildStarted = false
+    var isFeedbackFinished = false
+    var isQueuedFirstFinished = false
+    var isQueuedSecondFinished = false
+}
+
+private struct SuspendQueue: EffectQueue, Hashable
+{
+    var effectQueuePolicy: EffectQueuePolicy
+    {
+        .runOldest(maxCount: 1, .suspendNew)
+    }
+}

--- a/Tests/ActomatonTests/SendResultTests.swift
+++ b/Tests/ActomatonTests/SendResultTests.swift
@@ -170,6 +170,29 @@ final class SendResultTests: MainTestCase
         XCTAssertEqual(errors.first as? TestError, TestError())
     }
 
+    func test_untrackedFeedbackDoesNotEmitIntoOriginalResult() async throws
+    {
+        let actomaton = Actomaton<UntrackedFeedbackAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: untrackedFeedbackReducer,
+            effectContext: effectContext
+        )
+
+        let singleResult = await actomaton.send(.singleRoot)
+        let singleResults = await singleResult.allResults
+        XCTAssertTrue(
+            singleResults.isEmpty,
+            "Untracked single-effect feedback emissions must not leak into the original SendResult."
+        )
+
+        let sequenceResult = await actomaton.send(.sequenceRoot)
+        let sequenceResults = await sequenceResult.allResults
+        XCTAssertTrue(
+            sequenceResults.isEmpty,
+            "Untracked sequence feedback emissions must not leak into the original SendResult."
+        )
+    }
+
     func test_tracksFeedbacks_sequenceFailureWaitsForSpawnedFeedback() async throws
     {
         let actomaton = Actomaton<SequenceFailureAction, SequenceFailureState, Never>(
@@ -280,6 +303,32 @@ private let neverEmissionReducer = Reducer<NeverEmissionAction, ErrorState, Void
         return Effect.fireAndForget { _ in
             throw TestError()
         }
+    }
+}
+
+// MARK: - Untracked feedback emission helpers
+
+private enum UntrackedFeedbackAction: Equatable, Sendable
+{
+    case singleRoot
+    case sequenceRoot
+    case feedback
+}
+
+private let untrackedFeedbackReducer = Reducer<UntrackedFeedbackAction, ErrorState, Void, String> { action, _, _ in
+    switch action {
+    case .singleRoot:
+        return Effect { _ in
+            .action(.feedback)
+        }
+
+    case .sequenceRoot:
+        return Effect.stream(autoFinish: true) { send, _ in
+            send(.action(.feedback))
+        }
+
+    case .feedback:
+        return .emit("feedback")
     }
 }
 

--- a/Tests/ActomatonTests/SendResultTests.swift
+++ b/Tests/ActomatonTests/SendResultTests.swift
@@ -1,0 +1,252 @@
+import Actomaton
+import XCTest
+
+final class SendResultTests: MainTestCase
+{
+    func test_actomatonSend_returnsEmissions() async throws
+    {
+        let actomaton = Actomaton<EmissionAction, EmissionState, String>(
+            state: EmissionState(),
+            reducer: emissionReducer,
+            effectContext: effectContext
+        )
+
+        let result = await actomaton.send(.start, tracksFeedbacks: true)
+        let values = await result.emissions
+        let visitedActions = await actomaton.state.visitedActions
+
+        XCTAssertEqual(values, ["start", "finish"])
+        XCTAssertEqual(visitedActions, [.start, .finish])
+    }
+
+    func test_mealyDriverSend_returnsEmissions() async throws
+    {
+        let driver = MealyDriver<EmissionAction, EmissionState, String>(
+            state: EmissionState(),
+            reducer: emissionReducer,
+            effectContext: effectContext
+        )
+
+        let result = driver.send(.start, tracksFeedbacks: true)
+        let values = await result.emissions
+
+        XCTAssertEqual(values, ["start", "finish"])
+        XCTAssertEqual(driver.state.visitedActions, [.start, .finish])
+    }
+
+    // MARK: - In-band errors
+
+    /// A `.single` effect that throws a non-cancellation error surfaces the error in-band as a
+    /// `.failure` element, NOT by throwing from iteration.
+    func test_actomatonSend_singleEffectThrows_deliversInBandFailure() async throws
+    {
+        let actomaton = Actomaton<ErrorAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: errorReducer,
+            effectContext: effectContext
+        )
+
+        let result = await actomaton.send(.throwImmediately)
+        let results = await result.allResults
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(result.isCancelled, false, "Finished by an in-band failure, not cancellation.")
+        guard case let .failure(error)? = results.first else {
+            return XCTFail("Expected a single `.failure` element, got \(results).")
+        }
+        XCTAssertEqual(error as? TestError, TestError())
+    }
+
+    /// An effect that emits a value and then throws delivers the value as `.success` followed by
+    /// the error as `.failure` — both in-band, iteration never throws.
+    func test_actomatonSend_emitsValueThenThrows() async throws
+    {
+        let actomaton = Actomaton<ErrorAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: errorReducer,
+            effectContext: effectContext
+        )
+
+        let result = await actomaton.send(.emitThenThrow)
+
+        var collected: [Result<String, any Error>] = []
+        for await element in result {
+            collected.append(element)
+        }
+
+        XCTAssertEqual(collected.count, 2)
+        XCTAssertEqual(collected.first.flatMap { try? $0.get() }, "first")
+        guard case let .failure(error)? = collected.last else {
+            return XCTFail("Expected trailing `.failure`, got \(collected).")
+        }
+        XCTAssertEqual(error as? TestError, TestError())
+    }
+
+    /// **The core guarantee:** one effect throwing must NOT cancel its concurrent siblings.
+    /// The sibling keeps running (across an `await`) and still emits its value.
+    func test_actomatonSend_oneEffectThrows_doesNotCancelSiblings() async throws
+    {
+        let actomaton = Actomaton<ErrorAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: errorReducer,
+            effectContext: effectContext
+        )
+
+        // `.concurrent` fires two independent single effects:
+        //   - one throws immediately
+        //   - one sleeps briefly then emits "delayed"
+        // Under fail-fast aggregation the throw would cancel the sleeping sibling and "delayed"
+        // would never arrive (or arrive as a CancellationError failure).
+        let result = await actomaton.send(.concurrent)
+        let results = await result.allResults
+
+        let successes = results.compactMap { try? $0.get() }
+        let failures = results.filter { if case .failure = $0 { return true } else { return false } }
+
+        XCTAssertEqual(successes, ["delayed"], "Sibling effect must survive and emit its value.")
+        XCTAssertEqual(failures.count, 1, "Exactly one effect failed in-band.")
+    }
+
+    /// A `CancellationError` thrown from inside an effect is swallowed (not reported as a
+    /// `.failure`); the chain finishes cleanly.
+    func test_actomatonSend_effectThrowsCancellationError_finishesCleanlyNoFailure() async throws
+    {
+        let actomaton = Actomaton<ErrorAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: errorReducer,
+            effectContext: effectContext
+        )
+
+        let result = await actomaton.send(.throwCancellation)
+        let results = await result.allResults
+
+        XCTAssertTrue(results.isEmpty, "CancellationError must not surface as an in-band element.")
+        XCTAssertFalse(result.isCancelled, "The effect threw cancellation; the chain itself wasn't cancelled.")
+    }
+
+    func test_firstResult_returnsInBandFailure() async throws
+    {
+        let actomaton = Actomaton<ErrorAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: errorReducer,
+            effectContext: effectContext
+        )
+
+        let result = await actomaton.send(.throwImmediately)
+
+        guard case let .failure(error)? = await result.firstResult else {
+            return XCTFail("Expected first result to be an in-band failure.")
+        }
+
+        XCTAssertEqual(error as? TestError, TestError())
+    }
+
+    func test_neverEmission_completion_finishes() async throws
+    {
+        let actomaton = Actomaton<NeverEmissionAction, ErrorState, Never>(
+            state: ErrorState(),
+            reducer: neverEmissionReducer,
+            effectContext: effectContext
+        )
+
+        let result = await actomaton.send(.throwImmediately)
+
+        await result.completion()
+        XCTAssertFalse(result.isCancelled)
+    }
+
+    func test_mealyDriverSend_singleEffectThrows_deliversInBandFailure() async throws
+    {
+        let driver = MealyDriver<ErrorAction, ErrorState, String>(
+            state: ErrorState(),
+            reducer: errorReducer,
+            effectContext: effectContext
+        )
+
+        let result = driver.send(.throwImmediately)
+        let errors = await result.errors
+
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors.first as? TestError, TestError())
+    }
+}
+
+// MARK: - Private
+
+private enum EmissionAction: Equatable, Sendable
+{
+    case start
+    case finish
+}
+
+private struct EmissionState: Equatable, Sendable
+{
+    var visitedActions: [EmissionAction] = []
+}
+
+private let emissionReducer = Reducer<EmissionAction, EmissionState, Void, String> { action, state, _ in
+    state.visitedActions.append(action)
+
+    switch action {
+    case .start:
+        return .emit("start") + .next(action: .finish)
+    case .finish:
+        return .emit("finish")
+    }
+}
+
+// MARK: - Error helpers
+
+private struct TestError: Error, Equatable {}
+
+private enum ErrorAction: Equatable, Sendable
+{
+    case throwImmediately
+    case emitThenThrow
+    case throwCancellation
+    case concurrent
+}
+
+private struct ErrorState: Equatable, Sendable {}
+
+private let errorReducer = Reducer<ErrorAction, ErrorState, Void, String> { action, _, _ in
+    switch action {
+    case .throwImmediately:
+        return Effect { _ in throw TestError() }
+
+    case .emitThenThrow:
+        return Effect.stream { send, _ in
+            send(.emission("first"))
+            throw TestError()
+        }
+
+    case .throwCancellation:
+        return Effect { _ in throw CancellationError() }
+
+    case .concurrent:
+        // One effect throws immediately; the sibling sleeps then emits. If the throw were to
+        // cancel siblings, "delayed" would never be emitted.
+        let throwing = Effect<ErrorAction, String> { _ in throw TestError() }
+        let delayed = Effect<ErrorAction, String> { _ in
+            try await Task.sleep(for: .milliseconds(50))
+            return .emission("delayed")
+        }
+        return throwing + delayed
+    }
+}
+
+// MARK: - Never-emission helpers
+
+private enum NeverEmissionAction: Equatable, Sendable
+{
+    case throwImmediately
+}
+
+private let neverEmissionReducer = Reducer<NeverEmissionAction, ErrorState, Void, Never> { action, _, _ in
+    switch action {
+    case .throwImmediately:
+        return Effect.fireAndForget { _ in
+            throw TestError()
+        }
+    }
+}

--- a/Tests/ActomatonTests/SendResultTests.swift
+++ b/Tests/ActomatonTests/SendResultTests.swift
@@ -169,6 +169,38 @@ final class SendResultTests: MainTestCase
         XCTAssertEqual(errors.count, 1)
         XCTAssertEqual(errors.first as? TestError, TestError())
     }
+
+    func test_tracksFeedbacks_sequenceFailureWaitsForSpawnedFeedback() async throws
+    {
+        let actomaton = Actomaton<SequenceFailureAction, SequenceFailureState, Never>(
+            state: SequenceFailureState(),
+            reducer: sequenceFailureReducer,
+            effectContext: effectContext
+        )
+        let completionFlag = CompletionFlag()
+
+        let result = await actomaton.send(.start, tracksFeedbacks: true)
+        let completionTask = Task {
+            await result.completion()
+            await completionFlag.markCompleted()
+        }
+
+        await settle()
+
+        assertEqual(await actomaton.state.isFollowUpStarted, true)
+        let isCompletedBeforeFollowUpFinishes = await completionFlag.isCompleted
+        XCTAssertFalse(
+            isCompletedBeforeFollowUpFinishes,
+            "Tracked sequence result must stay open for feedback effects emitted before the sequence failure."
+        )
+
+        await clock.advance(by: .ticks(1.5))
+        await completionTask.value
+
+        assertEqual(await actomaton.state.isFollowUpFinished, true)
+        let isCompletedAfterFollowUpFinishes = await completionFlag.isCompleted
+        XCTAssertTrue(isCompletedAfterFollowUpFinishes)
+    }
 }
 
 // MARK: - Private
@@ -248,5 +280,56 @@ private let neverEmissionReducer = Reducer<NeverEmissionAction, ErrorState, Void
         return Effect.fireAndForget { _ in
             throw TestError()
         }
+    }
+}
+
+// MARK: - Sequence failure feedback helpers
+
+private enum SequenceFailureAction: Equatable, Sendable
+{
+    case start
+    case followUp
+    case finishFollowUp
+}
+
+private struct SequenceFailureState: Equatable, Sendable
+{
+    var isFollowUpStarted = false
+    var isFollowUpFinished = false
+}
+
+private let sequenceFailureReducer = Reducer<SequenceFailureAction, SequenceFailureState, Void, Never> {
+    action,
+    state,
+    _ in
+    switch action {
+    case .start:
+        return Effect.sequence { _ in
+            AsyncThrowingStream<SequenceFailureAction, any Error> { continuation in
+                continuation.yield(.followUp)
+                continuation.finish(throwing: TestError())
+            }
+        }
+
+    case .followUp:
+        state.isFollowUpStarted = true
+        return Effect { context in
+            try await context.clock.sleep(for: .ticks(1))
+            return .finishFollowUp
+        }
+
+    case .finishFollowUp:
+        state.isFollowUpFinished = true
+        return .empty
+    }
+}
+
+private actor CompletionFlag
+{
+    private(set) var isCompleted = false
+
+    func markCompleted()
+    {
+        isCompleted = true
     }
 }

--- a/Tests/ActomatonTests/SendTaskAwaitPendingEffectTests.swift
+++ b/Tests/ActomatonTests/SendTaskAwaitPendingEffectTests.swift
@@ -1,15 +1,15 @@
 import Actomaton
 import XCTest
 
-/// Tests that `send`'s returned Task tracks effects that were initially suspended
+/// Tests that `send`'s returned result tracks effects that were initially suspended
 /// by a queue's `suspendNew` policy and later dequeued.
 final class SendTaskAwaitPendingEffectTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     override func setUp() async throws
     {
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: State(),
             reducer: Reducer { action, state, _ in
                 switch action {
@@ -31,17 +31,17 @@ final class SendTaskAwaitPendingEffectTests: MainTestCase
         self.actomaton = actomaton
     }
 
-    /// `send`'s returned Task should be non-nil for a suspended effect and should
+    /// `send`'s returned result should be non-nil for a suspended effect and should
     /// complete only after the effect is eventually dequeued and finishes.
     func test_sendTask_tracksPendingEffectCompletion() async throws
     {
         // maxConcurrent = 1.
         // A runs immediately, B gets suspended.
-        let taskA = await actomaton.send(.fetch(id: "A"))
-        let taskB = await actomaton.send(.fetch(id: "B"))
+        let resultA = await actomaton.send(.fetch(id: "A"))
+        let resultB = await actomaton.send(.fetch(id: "B"))
 
-        XCTAssertNotNil(taskA, "Task for an immediately-running effect should be non-nil.")
-        XCTAssertNotNil(taskB, "Task for a suspended effect should be non-nil (waitTask).")
+        XCTAssertNotNil(resultA, "Result for an immediately-running effect should be non-nil.")
+        XCTAssertNotNil(resultB, "Result for a suspended effect should be non-nil.")
 
         assertEqual(
             await actomaton.state.completedCount, 0,
@@ -56,12 +56,12 @@ final class SendTaskAwaitPendingEffectTests: MainTestCase
             "Only A should have completed. B just started."
         )
 
-        // Run clock advance and taskB await in parallel.
-        // taskB is still waiting (B is running), and clock.advance triggers B's completion.
-        // If the AsyncStream bridge is broken, taskB would never complete and this would hang.
+        // Run clock advance and resultB await in parallel.
+        // resultB is still waiting (B is running), and clock.advance triggers B's completion.
+        // If the AsyncStream bridge is broken, resultB would never complete and this would hang.
         try await withThrowingTaskGroup(of: Void.self) { [clock] group in
             group.addTask {
-                try await taskB?.value
+                await resultB.completion()
             }
             group.addTask {
                 // B completes at tick 6.

--- a/Tests/ActomatonTests/SendTaskAwaitPendingEffectTests.swift
+++ b/Tests/ActomatonTests/SendTaskAwaitPendingEffectTests.swift
@@ -75,6 +75,35 @@ final class SendTaskAwaitPendingEffectTests: MainTestCase
             "Both A and B should have completed."
         )
     }
+
+    func test_deinitFinishesDequeuedPendingEffectCompletion() async throws
+    {
+        var actomaton: Actomaton<Action, State, Never>? = self.actomaton
+        self.actomaton = nil
+        weak var weakActomaton = actomaton
+
+        guard let resultA = await actomaton?.send(.fetch(id: "A")) else {
+            return XCTFail("Result for an immediately-running effect should be non-nil.")
+        }
+        guard let resultB = await actomaton?.send(.fetch(id: "B")) else {
+            return XCTFail("Result for a suspended effect should be non-nil.")
+        }
+
+        // A completes at tick 3, then B is dequeued and starts running.
+        await clock.advance(by: .ticks(3.5))
+        await resultA.completion()
+
+        guard let completedCount = await actomaton?.state.completedCount else {
+            return XCTFail("Actomaton should still be alive before explicit release.")
+        }
+        assertEqual(completedCount, 1)
+
+        actomaton = nil
+        XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
+        weakActomaton = nil // For suppressing `WeakMutability` warning.
+
+        try await awaitCompletionWithTimeout(resultB)
+    }
 }
 
 // MARK: - Private
@@ -97,5 +126,26 @@ private struct SuspendQueue: EffectQueue, Hashable
     var effectQueuePolicy: EffectQueuePolicy
     {
         .runOldest(maxCount: 1, .suspendNew)
+    }
+}
+
+private struct CompletionTimeoutError: Error {}
+
+private func awaitCompletionWithTimeout(
+    _ result: SendResult<Never>,
+    timeout: Duration = .milliseconds(500)
+) async throws
+{
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+            await result.completion()
+        }
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw CompletionTimeoutError()
+        }
+
+        defer { group.cancelAll() }
+        _ = try await group.next()
     }
 }

--- a/Tests/ActomatonTests/SendTaskCancellationTests.swift
+++ b/Tests/ActomatonTests/SendTaskCancellationTests.swift
@@ -6,13 +6,13 @@ import XCTest
 /// in-flight feedback-loop effects.
 final class SendTaskCancellationTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     private var flags = Flags()
 
     private func setupActomaton(initialState: State) async
     {
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: initialState,
             reducer: Reducer { [flags] action, state, _ in
                 switch action {
@@ -103,7 +103,7 @@ final class SendTaskCancellationTests: MainTestCase
 
         assertEqual(await actomaton.state, ._1)
 
-        let task = await actomaton.send(._1To2, tracksFeedbacks: true)
+        let result = await actomaton.send(._1To2, tracksFeedbacks: true)
 
         // Advance to mid-flight of `._2To3`'s effect:
         // - `._1To2`'s effect sleeps 1 tick, fires `._2To3`, state -> _3
@@ -112,8 +112,8 @@ final class SendTaskCancellationTests: MainTestCase
         assertEqual(await actomaton.state, ._3)
 
         // Cancel while `._2To3` is still in-flight.
-        task?.cancel()
-        _ = try? await task?.value
+        result.cancel()
+        await result.completion()
 
         // Advance well past every remaining sleep so the in-flight effect would
         // have completed had cancellation not propagated.
@@ -152,14 +152,14 @@ final class SendTaskCancellationTests: MainTestCase
 
         assertEqual(await actomaton.state, ._1)
 
-        let task = await actomaton.send(._1To2, tracksFeedbacks: true)
+        let result = await actomaton.send(._1To2, tracksFeedbacks: true)
 
         // `._1To2`'s effect is mid-flight (0.5 of 1 tick).
         await clock.advance(by: .ticks(0.5))
         assertEqual(await actomaton.state, ._2)
 
-        task?.cancel()
-        _ = try? await task?.value
+        result.cancel()
+        await result.completion()
 
         await clock.advance(by: .ticks(10))
 
@@ -188,15 +188,15 @@ final class SendTaskCancellationTests: MainTestCase
 
         assertEqual(await actomaton.state, ._1)
 
-        let task = await actomaton.send(._startSeq, tracksFeedbacks: true)
+        let result = await actomaton.send(._startSeq, tracksFeedbacks: true)
 
         // Advance until the sequence has emitted `._seqInnerStep` and the
         // follow-up single effect is mid-flight.
         await clock.advance(by: .ticks(1.5))
         assertEqual(await actomaton.state, ._3)
 
-        task?.cancel()
-        _ = try? await task?.value
+        result.cancel()
+        await result.completion()
 
         await clock.advance(by: .ticks(10))
 

--- a/Tests/ActomatonTests/TimerTests.swift
+++ b/Tests/ActomatonTests/TimerTests.swift
@@ -4,13 +4,13 @@ import XCTest
 /// Tests for `Effect.cancel`.
 final class TimerTests: MainTestCase
 {
-    fileprivate var actomaton: Actomaton<Action, State>!
+    fileprivate var actomaton: Actomaton<Action, State, Never>!
 
     override func setUp() async throws
     {
         struct TimerID: EffectID {}
 
-        let actomaton = Actomaton<Action, State>(
+        let actomaton = Actomaton<Action, State, Never>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 switch action {

--- a/Tests/ReadMeTests/ReadMeTests.swift
+++ b/Tests/ReadMeTests/ReadMeTests.swift
@@ -14,7 +14,7 @@ private func readMe1_1_effectContext() async throws
         var isRunning = false
     }
 
-    let reducer = Reducer<Action, State, Void> { action, state, _ in
+    let reducer = Reducer<Action, State, Void, Never> { action, state, _ in
         switch action {
         case .start:
             state.isRunning = true
@@ -29,7 +29,7 @@ private func readMe1_1_effectContext() async throws
         }
     }
 
-    let actomaton = Actomaton<Action, State>(
+    let actomaton = Actomaton<Action, State, Never>(
         state: State(),
         reducer: reducer
     )
@@ -63,7 +63,7 @@ private func readMe1_4() async throws
         }
     }
 
-    let reducer = Reducer<Action, State, Environment> { action, _, environment in
+    let reducer = Reducer<Action, State, Environment, Never> { action, _, environment in
         switch action {
         case let .fetch(id):
             return Effect(queue: DelayedEffectQueue()) { _ in
@@ -77,7 +77,7 @@ private func readMe1_4() async throws
         }
     }
 
-    let actomaton = Actomaton<Action, State>(
+    let actomaton = Actomaton<Action, State, Never>(
         state: State(),
         reducer: reducer,
         environment: Environment(fetch: { _ in Data() /* ... */ })

--- a/Tests/WasmSmokeTests/WasmSmokeTests.swift
+++ b/Tests/WasmSmokeTests/WasmSmokeTests.swift
@@ -31,7 +31,7 @@ func `mealy machine transitions on wasm`() async
 @Test
 func `actomaton runs synchronous effects on wasm`() async
 {
-    let reducer = Reducer<CounterAction, CounterState, Void> { action, state, _ in
+    let reducer = Reducer<CounterAction, CounterState, Void, Never> { action, state, _ in
         switch action {
         case .increment:
             state.count += 1


### PR DESCRIPTION
## Summary

**Breaking change.** Adds a typed `Emission` side-channel across the stack and changes what `send(_:)` returns.

`Effect<Action>` becomes `Effect<Action, Emission>`, and `Actomaton`, `MealyMachine`, `MealyDriver`, `Reducer`, `EffectManager`, `TestActomaton`, and `DistributedActomaton` all gain the matching `Emission` generic parameter (`Store` / `RouteStore` pin theirs to `Never`). `send(_:)` now returns a `SendResult<Emission>` instead of `Task<(), any Error>?`.

`Emission` is the typed value an effect can yield **back to the `send` caller** — as opposed to `Action`, which is re-fed into the reducer. Use `Never` when no side-channel is needed; existing action-only call sites keep compiling.

### `SendResult` — what `send` returns now

`SendResult<Emission>` is an `AsyncSequence` of `Result<Emission, any Error>` with `Failure == Never`, so iteration never throws:

- **In-band errors.** Multiple effects from one `send` run concurrently; a throwing sequence would tear the whole chain down on the first error and drop sibling emissions. Instead each effect's failure surfaces as a `.failure` element and only that effect ends — siblings keep emitting.
- **Cancellation is clean.** Iteration ends without a `.failure` on cancellation; use `isCancelled` to distinguish normal completion from cancellation. `cancel()` aborts the whole chain.
- **Convenience accessors:** `allResults`, `firstResult`, `emissions`, `errors`, `completion()`.

### `Effect.Outcome` and `.emit`

Async effect closures (`init`, `sequence`, `stream`) now return an `Outcome?`:

```swift
public enum Outcome {
    case action(Action)         // re-feed Action into the reducer
    case emission(Emission)     // emit Emission to the SendResult stream
    case both(Action, Emission) // both, atomically
}
```

A synchronous `Effect.emit(_:)` factory is also added (emission-only, no async). When `Emission == Never`, `@_disfavoredOverload` on the canonical `Outcome`-returning inits keeps the existing `Action?`-returning closures (`Effect { _ in .someAction }`) unambiguous, so action-only reducers are unchanged.

### Per-effect `priority:`

Every effect constructor (`init`, `sequence`, `stream`, `fireAndForget`) gains a `priority: TaskPriority?` that overrides the `send`-level priority for that effect — including queue-suspended effects, which apply their own priority when dequeued.

### Migration

```swift
// Type parameters — add the Emission arg (Never when unused)
Actomaton<Action, State>          ->  Actomaton<Action, State, Never>
Effect<Action>                    ->  Effect<Action, Never>
Reducer<Action, State, Env>       ->  Reducer<Action, State, Env, Never>

// send() return value
let task = actomaton.send(.foo)   ->  let result = actomaton.send(.foo)
await task?.value                 ->  await result.completion()
task?.cancel()                    ->  result.cancel()
```

## Test plan

- [x] Local `swift build` — passes
- [x] Local `TEST_CLOCK=1 swift test` — 94 tests; new `SendResultTests` (9), `SendResultCancellationTests` (3), and `EffectPriorityTests` (3) all pass
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
