### PR TITLE
Narrow effect chain-task failure type to `Never`

### DIFF
--- a/Sources/Actomaton/Actomaton.swift
+++ b/Sources/Actomaton/Actomaton.swift
@@ -91,7 +91,7 @@ public actor Actomaton<Action, State, Emission>
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         // `MealyMachine.send` recursively resolves synchronous `.next(Action)` feedbacks
         // because `Effect<Action, Emission>: MealyOutput` exposes `MealyOutput.Action == Action`.

--- a/Sources/Actomaton/EffectManager+SendResult.swift
+++ b/Sources/Actomaton/EffectManager+SendResult.swift
@@ -29,25 +29,17 @@ extension EffectManager
         // Stream-finishing supervisor.
         //
         // Effect errors are surfaced in-band as `.failure` elements by each effect task itself
-        // (see `EffectQueueManager.makeTask`), so `task` only ever throws `CancellationError`
-        // (on explicit `SendResult.cancel()`). The supervisor therefore just awaits the chain
-        // and finishes the stream:
+        // (see `EffectQueueManager.makeTask`), and the chain task swallows cancellation too, so
+        // its `Failure` type is `Never`: it never throws, and `task?.value` always returns once
+        // the whole chain settles. The supervisor therefore just awaits the chain and finishes
+        // the stream:
         //
         // - `task` completes (success or in-band failures already delivered) -> finish cleanly.
         // - `task` is cancelled via `SendResult.cancel()` -> propagate cancellation to `task`
         //   so the effect chain unwinds, then finish cleanly.
-        // - Any unexpected non-cancellation error (defensive) -> deliver as a final `.failure`.
         let supervisor = Task<Void, Never>(priority: priority) { @concurrent in
             await withTaskCancellationHandler {
-                do {
-                    try await task?.value
-                }
-                catch is CancellationError {
-                    // Cancellation finishes cleanly; it is not an in-band failure.
-                }
-                catch {
-                    continuation.yield(.failure(error))
-                }
+                await task?.value
 
                 // Call `finish` regardless of successful / failure completions.
                 continuation.finish()

--- a/Sources/Actomaton/MealyDriver.swift
+++ b/Sources/Actomaton/MealyDriver.swift
@@ -108,7 +108,7 @@ public final class MealyDriver<Action, State, Emission>: @unchecked Sendable
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         let output = mutex.withLock { _ in machine.send(action) }
         return effectManager.processOutput(

--- a/Sources/ActomatonEffect/EffectManager.swift
+++ b/Sources/ActomatonEffect/EffectManager.swift
@@ -59,7 +59,7 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
             _ priority: TaskPriority?,
             _ tracksFeedbacks: Bool,
             _ emit: @escaping @Sendable (Result<Output.Emission, any Error>) -> Void
-        ) async -> Task<(), any Error>?
+        ) async -> Task<(), Never>?
     )
 
     /// Process the reducer output, creating and managing tasks as needed.
@@ -73,5 +73,5 @@ public protocol EffectManager<Action, State, Output>: SendableMetatype
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Output.Emission, any Error>) -> Void
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
 }

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -21,10 +21,10 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 
     /// Effect-identified running tasks for manual cancellation or on-deinit cancellation.
     /// - Note: Multiple effects can have same ``_EffectID``.
-    private var runningTasks: [_EffectID: Set<Task<(), any Error>>] = [:]
+    private var runningTasks: [_EffectID: Set<Task<(), Never>>] = [:]
 
     /// Effect-queue-designated running tasks for automatic cancellation & suspension.
-    private var queuedRunningTasks: [_EffectQueue: [Task<(), any Error>]] = [:]
+    private var queuedRunningTasks: [_EffectQueue: [Task<(), Never>]] = [:]
 
     /// Suspended effects with their original send context.
     private var pendingEffects: [_EffectQueue: [PendingEffect]] = [:]
@@ -36,7 +36,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
     ///   task finishes. This is the task cancelled by `SendResult.cancel()`.
     /// - Value: the actual running effect task later created by `makeTask(...)` after queue
     ///   capacity opens and the pending effect is dequeued.
-    private var dequeuedTasks: [Task<(), any Error>: Task<(), any Error>] = [:]
+    private var dequeuedTasks: [Task<(), Never>: Task<(), Never>] = [:]
 
     /// Tracked latest effect start time for delayed effects calculation.
     private var latestEffectTime: [_EffectQueue: AnyClock<Duration>.Instant] = [:]
@@ -53,7 +53,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             TaskPriority?,
             Bool,
             _ emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-        ) async -> Task<(), any Error>?
+        ) async -> Task<(), Never>?
     )?
 
     /// `@Sendable` closure with **inherited sendability** from the parent safe container that
@@ -89,7 +89,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             _ priority: TaskPriority?,
             _ tracksFeedbacks: Bool,
             _ emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-        ) async -> Task<(), any Error>?
+        ) async -> Task<(), Never>?
     )
     {
         self.withSendability = withSendability
@@ -101,9 +101,9 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
-        var tasks: [Task<(), any Error>] = []
+        var tasks: [Task<(), Never>] = []
         for kind in output.kinds {
             tasks.append(
                 contentsOf: processEffectKind(
@@ -120,15 +120,15 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         let tasks_ = tasks
 
         // Keep the returned task unstructured, but run its supervisor work off any caller actor.
-        return Task(priority: priority) { @concurrent in
-            try await withTaskCancellationHandler {
-                try await withThrowingTaskGroup(of: Void.self) { group in
+        return Task<(), Never>(priority: priority) { @concurrent in
+            await withTaskCancellationHandler {
+                await withTaskGroup(of: Void.self) { group in
                     for task in tasks_ {
                         group.addTask(priority: priority) {
-                            try await _runTaskForwardingCancellation(task)
+                            await _runTaskForwardingCancellation(task)
                         }
                     }
-                    try await group.waitForAll()
+                    await group.waitForAll()
                 }
             } onCancel: {
                 for task in tasks_ {
@@ -140,7 +140,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 
     private func handleTaskCompleted(
         id: _EffectID,
-        task: Task<(), any Error>,
+        task: Task<(), Never>,
         queue: (any EffectQueue)?,
         priority: TaskPriority?,
         tracksFeedbacks: Bool
@@ -197,7 +197,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-    ) -> [Task<(), any Error>]
+    ) -> [Task<(), Never>]
     {
         switch kind {
         case .single, .sequence:
@@ -300,7 +300,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 
                     let (stream, continuation) = AsyncStream<Never>.makeStream()
 
-                    let suspendedEffectTask = Task<(), any Error> {
+                    let suspendedEffectTask = Task<(), Never> {
                         await withTaskCancellationHandler {
                             for await _ in stream {}
                         } onCancel: {
@@ -342,7 +342,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         let sendAction = self.sendAction
         let context = self.effectContext
@@ -354,7 +354,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 
         switch effectKind {
         case let .single(single):
-            let task = Task<(), any Error>(priority: priority) { @concurrent in
+            let task = Task<(), Never>(priority: priority) { @concurrent in
                 do {
                     if let time {
                         try? await context.clock.sleep(until: time, tolerance: nil)
@@ -368,7 +368,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                     if let action = outcome.action {
                         let feedbackTask = await sendAction?(action, priority, tracksFeedbacks, feedbackEmit)
                         if tracksFeedbacks, let feedbackTask {
-                            try await _runTaskForwardingCancellation(feedbackTask)
+                            await _runTaskForwardingCancellation(feedbackTask)
                         }
                     }
                 }
@@ -392,8 +392,8 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             return task
 
         case let .sequence(sequence):
-            let task = Task<(), any Error>(priority: priority) { @concurrent in
-                var feedbackTasks: [Task<(), any Error>] = []
+            let task = Task<(), Never>(priority: priority) { @concurrent in
+                var feedbackTasks: [Task<(), Never>] = []
 
                 do {
                     if let time {
@@ -412,7 +412,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                         }
                     }
                     if tracksFeedbacks {
-                        try await _runTasksForwardingCancellation(feedbackTasks, priority: priority)
+                        await _runTasksForwardingCancellation(feedbackTasks, priority: priority)
                     }
                 }
                 catch is CancellationError {
@@ -428,15 +428,9 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                     emit(.failure(error))
 
                     if tracksFeedbacks {
-                        do {
-                            try await _runTasksForwardingCancellation(feedbackTasks, priority: priority)
-                        }
-                        catch is CancellationError {
-                            await _cancelAndDrainTasks(feedbackTasks)
-                        }
-                        catch {
-                            emit(.failure(error))
-                        }
+                        // Feedback chain tasks never fail (their errors are surfaced in-band),
+                        // so awaiting them forwards cancellation and drains without throwing.
+                        await _runTasksForwardingCancellation(feedbackTasks, priority: priority)
                     }
                 }
             }
@@ -461,7 +455,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
     /// back as a parameter to the inner callback, so the cleanup task does NOT need to capture
     /// `self` — letting `EffectQueueManager` remain non-Sendable.
     private func enqueueTask(
-        _ task: Task<(), any Error>,
+        _ task: Task<(), Never>,
         id: _EffectID?,
         queue: (any EffectQueue)?,
         priority: TaskPriority?,
@@ -482,7 +476,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         let withSendability = self.withSendability
 
         // Clean up after `task` is completed.
-        Task<(), any Error>(priority: priority) { @concurrent in
+        Task<(), Never>(priority: priority) { @concurrent in
             // Wait for `task` to complete.
             _ = await task.result
 
@@ -511,7 +505,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
     /// the manager and cancels the represented effect: either by removing it from `pendingEffects`,
     /// or by forwarding cancellation to its dequeued running task.
     private func observeSuspendedEffectTaskCancellation(
-        _ suspendedEffectTask: Task<(), any Error>,
+        _ suspendedEffectTask: Task<(), Never>,
         priority: TaskPriority?
     )
     {
@@ -536,7 +530,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
     /// If it has already been dequeued, the pending entry is gone, so
     /// `dequeuedTasks` forwards cancellation from the suspended-effect task
     /// to the running effect task.
-    private func cancelPendingEffect(suspendedEffectTask: Task<(), any Error>)
+    private func cancelPendingEffect(suspendedEffectTask: Task<(), Never>)
     {
         // Remove pending effect that is associated with `suspendedEffectTask`.
         for (effectQueue, pendings) in pendingEffects {
@@ -721,7 +715,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         /// This task does not complete merely when the effect is dequeued. It stays alive until
         /// the suspended effect is dropped, or until the dequeued effect task finishes, so callers
         /// can await/cancel the full lifecycle through the original `SendResult`.
-        let suspendedEffectTask: Task<(), any Error>
+        let suspendedEffectTask: Task<(), Never>
 
         /// Original emission callback — preserved so a deferred dequeue still routes
         /// `Emission` emissions into the top-level result stream that issued the `send`.
@@ -743,7 +737,7 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
         /// The associated task represents the suspended effect's full lifecycle: it remains pending
         /// across dequeue and completes only after the dequeued effect task finishes, or after the
         /// pending effect is cancelled/dropped.
-        case suspend(suspendedEffectTask: Task<(), any Error>)
+        case suspend(suspendedEffectTask: Task<(), Never>)
 
         /// The effect was discarded (e.g. `discardNew` policy).
         case discard
@@ -752,40 +746,40 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
 
 /// Runs and awaits `task` while forwarding cancellation from the awaiting task into `task`.
 ///
-/// Plain `try await task.value` only waits for the task's result. If the awaiting
+/// Plain `await task.value` only waits for the task's result. If the awaiting
 /// task is cancelled, Swift does not automatically call `cancel()` on the task being
 /// awaited, which matters here because effect tasks are unstructured task handles rather
 /// than children of the waiter. This helper preserves
 /// `SendResult.cancel()` semantics by turning cancellation of the waiter into
 /// cancellation of the underlying effect task.
 private func _runTaskForwardingCancellation(
-    _ task: Task<(), any Error>
-) async throws
+    _ task: Task<(), Never>
+) async
 {
-    try await withTaskCancellationHandler {
-        try await task.value
+    await withTaskCancellationHandler {
+        await task.value
     } onCancel: {
         task.cancel()
     }
 }
 
 private func _runTasksForwardingCancellation(
-    _ tasks: [Task<(), any Error>],
+    _ tasks: [Task<(), Never>],
     priority: TaskPriority?
-) async throws
+) async
 {
-    try await withThrowingTaskGroup(of: Void.self) { group in
+    await withTaskGroup(of: Void.self) { group in
         for task in tasks {
             group.addTask(priority: priority) {
-                try await _runTaskForwardingCancellation(task)
+                await _runTaskForwardingCancellation(task)
             }
         }
-        try await group.waitForAll()
+        await group.waitForAll()
     }
 }
 
 private func _cancelAndDrainTasks(
-    _ tasks: [Task<(), any Error>]
+    _ tasks: [Task<(), Never>]
 ) async
 {
     for task in tasks {

--- a/Sources/ActomatonTesting/TestActomaton.swift
+++ b/Sources/ActomatonTesting/TestActomaton.swift
@@ -125,7 +125,7 @@ public actor TestActomaton<Action, State, Emission>
         priority: TaskPriority?,
         tracksFeedbacks: Bool,
         emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         let output = machine.send(action)
         return effectManager.processOutput(

--- a/Sources/ActomatonUI/Store/Internal/StoreCore.swift
+++ b/Sources/ActomatonUI/Store/Internal/StoreCore.swift
@@ -93,7 +93,7 @@ internal final class StoreCore<Action, State, Environment>
         _ action: BindableAction<Action, State>,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         let output = machine.send(action)
         return effectManager.processOutput(

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -60,7 +60,7 @@ public class Store<Action, State, Environment>
 
     private let _send: @MainActor (
         BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
 
     /// Initializer with `environment`.
     public convenience init(
@@ -109,7 +109,7 @@ public class Store<Action, State, Environment>
         environment: Environment,
         send: @escaping @MainActor (
             BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool
-        ) -> Task<(), any Error>?
+        ) -> Task<(), Never>?
     )
     {
         self._state = state
@@ -134,7 +134,7 @@ public class Store<Action, State, Environment>
         _ action: Action,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         self._send(.action(action), priority: priority, tracksFeedbacks: tracksFeedbacks)
     }
@@ -145,7 +145,7 @@ public class Store<Action, State, Environment>
         _ action: BindableAction<Action, State>,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         self._send(action, priority, tracksFeedbacks)
     }

--- a/Sources/ActomatonUI/SwiftUI/ViewStore.swift
+++ b/Sources/ActomatonUI/SwiftUI/ViewStore.swift
@@ -44,7 +44,7 @@ public final class ViewStore<Action, State>: ObservableObject
 
     private let _send: @MainActor (
         BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -53,7 +53,7 @@ public final class ViewStore<Action, State>: ObservableObject
         state: CurrentValuePublisher<State>,
         send: @escaping @MainActor (
             BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool
-        ) -> Task<(), any Error>?,
+        ) -> Task<(), Never>?,
         areStatesEqual: @escaping (State, State) -> Bool
     )
     {
@@ -86,7 +86,7 @@ public final class ViewStore<Action, State>: ObservableObject
         _ action: BindableAction<Action, State>,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         self._send(action, priority, tracksFeedbacks)
     }

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -81,7 +81,7 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
         _ action: Action,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
-    ) -> Task<(), any Error>?
+    ) -> Task<(), Never>?
     {
         let output = machine.send(action)
         return effectManager.processOutput(

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -43,7 +43,7 @@ final class DeinitTests: MainTestCase
         XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
 
         // Wait until deinit fully completes.
-        try? await task?.value
+        await task?.value
 
         // Check results.
         //


### PR DESCRIPTION
## Summary

**Breaking change (minor).** Narrows the failure type of the `Task` returned by the effect pipeline from `Task<(), any Error>?` to `Task<(), Never>?`, making the existing "the chain task never fails" guarantee explicit in the type system.

Each effect task already surfaces its own errors in-band as `SendResult` `.failure` elements and swallows cancellation, so the unified chain task never actually throws. Typing it as `any Error` was therefore wider than reality. This PR flips `EffectManager.processOutput` (and the `sendAction` callback) to return `Task<(), Never>?`, and the change propagates through the effect-manager internals and every wrapper's send API.

### What changed

- **`EffectManager` / `EffectQueueManager`** — `processOutput`, `sendAction`, task storage (`runningTasks` / `queuedRunningTasks` / `dequeuedTasks`), `makeTask`, the cancellation-forwarding helpers, and `PendingEffect` all move to `Task<(), Never>`. `withThrowingTaskGroup` → `withTaskGroup` and `try await task.value` → `await task.value` where the throwing forms are no longer needed.
- **Wrappers** — `Actomaton`, `MealyDriver`, and `TestActomaton` feedback dispatch return `Task<(), Never>?`.
- **Public API** — `Store.send` / `Store._send`, `ViewStore`, and `DistributedActomaton.sendLocal` now return `Task<(), Never>?`.

### Dead-code removal

Because the chain task can no longer throw, the `SendResult` supervisor's defensive error branch is now unreachable and is removed:

```swift
// Before
do { try await task?.value }
catch is CancellationError {}
catch { continuation.yield(.failure(error)) }
continuation.finish()

// After
await task?.value
continuation.finish()
```

The in-band `.failure` emission (the actual error channel) is unaffected — only the lifecycle task's `Failure` type changes.

### Migration

```swift
// Awaiting the returned task no longer needs `try`
try await store.send(.foo)?.value   ->  await store.send(.foo)?.value
```

## Test plan

- [x] Local `swift build` — passes, no warnings
- [x] Local `swift test`
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)
