### PR TITLE
Remove cancelEffectKind for pure-discard semantics

### DIFF
--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -169,10 +169,10 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             }
         }
 
-        // Drain and cancel pending effects to trigger their cancellation handlers.
+        // Drain pending effects. They never started, so there is nothing to cancel —
+        // just signal completion so their suspended-effect tasks finish.
         for (queue, pendings) in pendingEffects {
             for pending in pendings {
-                cancelEffectKind(pending.kind)
                 pending.onComplete.finish()
             }
             pendingEffects[queue] = nil
@@ -316,7 +316,6 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
                     return .suspend(suspendedEffectTask: suspendedEffectTask)
 
                 case .discardNew:
-                    cancelEffectKind(effectKind)
                     return .discard
                 }
             }
@@ -531,7 +530,6 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             }
 
             if let removed = pendingEffects[effectQueue]?.remove(at: index) {
-                cancelEffectKind(removed.kind)
                 removed.onComplete.finish()
             }
 
@@ -565,7 +563,6 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             for (i, pending) in pendings.enumerated().reversed() {
                 if let effectID = pending.kind.id, predicate(effectID.value) {
                     if let removed = pendingEffects[effectQueue]?.remove(at: i) {
-                        cancelEffectKind(removed.kind)
                         removed.onComplete.finish()
                     }
                 }
@@ -624,7 +621,6 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             let time = calculateEffectTime(queue: queue)
 
             if pending.suspendedEffectTask.isCancelled {
-                cancelEffectKind(pending.kind)
                 pending.onComplete.finish()
                 continue
             }
@@ -665,28 +661,6 @@ package final class EffectQueueManager<Action, State, Emission>: EffectManager
             else {
                 onComplete.finish()
             }
-        }
-    }
-
-    /// Cancels `effectKind`'s `single` or `sequence` immediately
-    /// so that cancellation can still be delivered to `Effect`'s async scope.
-    private func cancelEffectKind(_ effectKind: Effect<Action, Emission>.Kind)
-    {
-        let context = self.effectContext
-
-        switch effectKind {
-        case let .single(single):
-            Task<Void, any Error>(priority: single.priority) { @concurrent in
-                _ = try await single.run(context)
-            }
-            .cancel() // Cancel immediately.
-        case let .sequence(sequence):
-            Task<Void, any Error>(priority: sequence.priority) { @concurrent in
-                _ = try await sequence.sequence(context)
-            }
-            .cancel() // Cancel immediately.
-        case .next, .emission, .cancel, .updateQueue:
-            return
         }
     }
 

--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -209,8 +209,8 @@ final class EffectQueueDelayTests: MainTestCase
 
         await actomaton.send(.fetch(id: "1")) // fetch at t=0, comples at t=3
         await actomaton.send(.fetch(id: "2")) // delayed fetch at t=2, comples at t=5
-        await actomaton.send(.fetch(id: "3")) // delayed fetch at t=4, will be auto-cancelled by queue
-        await actomaton.send(.fetch(id: "4")) // delayed fetch at t=6, will be auto-cancelled by queue
+        await actomaton.send(.fetch(id: "3")) // discarded by queue without starting
+        await actomaton.send(.fetch(id: "4")) // discarded by queue without starting
 
         assertEqual(await actomaton.state.finishedIDs, [])
 
@@ -226,7 +226,11 @@ final class EffectQueueDelayTests: MainTestCase
             ["1", "2"],
             "Only first 2 should run effects."
         )
-        assertEqual(await cancelledIDs.results.sorted(), ["3", "4"])
+        assertEqual(
+            await cancelledIDs.results.sorted(),
+            [],
+            "Discarded effects \"3\"/\"4\" never start, so their `ifCancelled` never runs."
+        )
     }
 }
 

--- a/Tests/ActomatonTests/PendingEffectCancellationTests.swift
+++ b/Tests/ActomatonTests/PendingEffectCancellationTests.swift
@@ -65,8 +65,8 @@ final class PendingEffectCancellationTests: MainTestCase
                         return try await context.clock.sleep(for: .ticks(1)) {
                             return ._didFetch2
                         } ifCancelled: {
-                            // NOTE: When Effect 2 is suspended and cancelled before execution,
-                            // this scope won't even be called
+                            // NOTE: Effect 2 is suspended (pending) and cancelled before it ever
+                            // starts, so it is discarded without running — this scope is never called.
 
                             Debug.print("Effect 2 cancelled")
                             await flags.mark(result2: .cancelled)
@@ -120,8 +120,16 @@ final class PendingEffectCancellationTests: MainTestCase
 
         await clock.advance(by: .ticks(1.5))
 
-        assertEqual(await flags.result1, .cancelled)
-        assertEqual(await flags.result2, .cancelled)
+        assertEqual(
+            await flags.result1,
+            .cancelled,
+            "Effect 1 was running, so cancellation runs its `ifCancelled` cleanup."
+        )
+        assertEqual(
+            await flags.result2,
+            .initial,
+            "Effect 2 was still suspended (never started), so it is discarded without running `ifCancelled`."
+        )
     }
 }
 

--- a/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
+++ b/Tests/ActomatonTests/RunOldestDiscardNewTests.swift
@@ -83,8 +83,8 @@ final class RunOldestDiscardNewTests: MainTestCase
         let results = await resultsCollector.results.sorted()
         XCTAssertEqual(
             results,
-            [2],
-            "2nd increment's effect should be cancelled by discard."
+            [],
+            "Should be empty: 2nd increment's effect is discarded without starting, so `ifCancelled` never runs."
         )
     }
 
@@ -125,8 +125,8 @@ final class RunOldestDiscardNewTests: MainTestCase
         let results = await resultsCollector.results.sorted()
         XCTAssertEqual(
             results,
-            [3],
-            "3rd increment's effect should be cancelled by discard."
+            [],
+            "Should be empty: 3rd increment's effect is discarded without starting, so `ifCancelled` never runs."
         )
     }
 }

--- a/Tests/ActomatonTests/SendResultCancellationTests.swift
+++ b/Tests/ActomatonTests/SendResultCancellationTests.swift
@@ -95,7 +95,10 @@ final class SendResultCancellationTests: MainTestCase
         await settle()
 
         let isQueuedSecondCancelled = await flags.isQueuedSecondCancelled
-        XCTAssertTrue(isQueuedSecondCancelled)
+        XCTAssertFalse(
+            isQueuedSecondCancelled,
+            "Second effect was still suspended (never started), so dropping it does not run `ifCancelled`."
+        )
 
         await clock.advance(by: .ticks(2.5))
         await firstResult.completion()


### PR DESCRIPTION
## Summary

**Behavior change.** Discarded and pending effects are now true no-ops — neither their `run` closure body nor their cancellation handler runs. Previously they were partially started in order to deliver a *synthetic* cancellation, which was a footgun.

`EffectQueueManager.cancelEffectKind(_:)` started a discarded/pending effect's `run` closure inside an already-cancelled `Task`, relying on `single.run(context)` reaching its first suspension point and throwing `CancellationError` so the effect's cancellation path (`withTaskCancellationHandler` / `catch CancellationError`) would fire.

The problem: this was only ever applied to effects that **never genuinely started** — `runOldest(_, .discardNew)` overflow, suspended pending effects dropped via `Effect.cancel` / `SendResult.cancel()`, and `shutDown`. Such an effect acquired no resources, so delivering cancellation to it is semantically dubious. Worse, the only way the code reaches that cancellation path is by running the closure body up to its first cancellation check — so any **eager side effect performed before that check runs even though the effect was "discarded."** The API vocabulary ("discard") and the runtime behavior diverged.

This restores pure-discard semantics (the behavior prior to `e72e44a`): a discarded/pending effect is dropped without running anything.

### What changed

- **`EffectQueueManager`** — removes `cancelEffectKind(_:)` and its 5 call sites (`shutDown`, `runOldest(_, .discardNew)`, `cancelPendingEffect`, `cancelEffects`, `dequeuePendingIfPossible`). Each site now only signals `onComplete.finish()` so the suspended-effect task / `SendResult` still completes.
- **Tests** — updated to assert the corrected semantics (discarded/pending effects no longer run their `ifCancelled` cleanup). Also fixes a stale comment in `PendingEffectCancellationTests` that already contradicted its own assertion.

### Before

```swift
case .discardNew:
    cancelEffectKind(effectKind)   // starts the discarded effect's body, then cancels it
    return .discard

// ...

private func cancelEffectKind(_ effectKind: Effect<Action, Emission>.Kind) {
    switch effectKind {
    case let .single(single):
        Task<Void, any Error>(priority: single.priority) { @concurrent in
            _ = try await single.run(context)   // <- discarded body runs up to first await
        }
        .cancel() // Cancel immediately.
    case let .sequence(sequence):
        // ...same hack for sequence
    case .next, .emission, .cancel, .updateQueue:
        return
    }
}
```

### After

```swift
case .discardNew:
    return .discard   // discarded effect never starts
```

### Behavior change

| Path | Before | After |
| --- | --- | --- |
| `runOldest(_, .discardNew)` overflow | discarded effect's `ifCancelled` runs | not run |
| `Effect.cancel` / `SendResult.cancel()` on a *pending* effect | pending effect's `ifCancelled` runs | not run |
| `shutDown` draining pending effects | pending `ifCancelled` runs | not run |
| `Effect.cancel` / cancel on a *running* effect | unchanged (real `task.cancel()`) | unchanged |

Effects that genuinely started (created via `makeTask`) are unaffected — they are still cancelled via `task.cancel()` and run their cleanup as before. The old cancellation-delivery behavior was never documented (`EffectQueuePolicy.discardNew`'s doc-comment already reads "Discards new effects…").

## Test plan

- [x] `swift build` — clean, no warnings
- [x] Affected tests pass reliably in isolation (`RunOldestDiscardNewTests`, `PendingEffectCancellationTests`, `SendResultCancellationTests`, `EffectQueueDelayTests`)
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)

> Note: the full `swift test` run has pre-existing timing flakiness — intermittent failures move between unrelated timing-sensitive suites (e.g. `DistributedActomatonSmokeTests`, `EffectStreamTests`) and reproduce on `main`. The tests touched here pass consistently when run in isolation.
