### PR TITLE
Remove non-deterministic feedback-drain shim in TestActomaton

### DIFF
--- a/Sources/ActomatonTesting/TestActomaton.swift
+++ b/Sources/ActomatonTesting/TestActomaton.swift
@@ -215,8 +215,10 @@ public actor TestActomaton<Action, State, Emission>
             assert: assert
         )
 
-        await Self.drainImmediateFeedbacks()
-
+        // No barrier is needed here: synchronous feedback (`.next`) is already surfaced into
+        // `receivedActions` by `machine.send`'s recursive resolution, so the fail-fast check on the
+        // next `send` sees it. Asynchronous feedback is awaited deterministically by `receive` via
+        // `receivedActionSignal`, not eagerly drained here.
         return .init(sendResult: sendResult, timeout: timeout)
     }
 
@@ -344,10 +346,18 @@ extension TestActomaton
                 assert: updateStateToExpectedResult
             )
         }
-
-        await Self.drainImmediateFeedbacks()
     }
 
+    /// Waits until at least one unconsumed received action is available, or `timeout` elapses.
+    ///
+    /// Feedback arrival is awaited deterministically rather than by spinning the scheduler:
+    /// - Synchronous feedback (`.next`) is already appended to `receivedActions` by
+    ///   `machine.send`'s recursive resolution, so the count check below returns immediately.
+    /// - Asynchronous feedback wakes this method through `receivedActionSignal`, which fires
+    ///   exactly when an effect-originated action is appended (see the `.receive` reducer branch).
+    ///
+    /// The `timeout` is a real-time failsafe for the "no feedback ever arrives" assertion failure,
+    /// not part of the happy path; a delivered feedback returns as soon as its signal fires.
     private func waitForReceivedAction(
         timeout: Duration,
         fileID: StaticString,
@@ -355,8 +365,6 @@ extension TestActomaton
         line: UInt
     ) async -> Bool
     {
-        await Self.drainImmediateFeedbacks()
-
         if await self.unconsumedReceivedActionsCount > 0 {
             return true
         }
@@ -476,18 +484,6 @@ extension TestActomaton
                 file: filePath,
                 line: line
             )
-        }
-    }
-
-    /// Gives the concurrency runtime a few turns to surface already-triggered feedback actions.
-    ///
-    /// This is intentionally a small race-avoidance shim for tests, not a way to wait for full
-    /// effect completion. Time-based effects should still be driven explicitly by a test clock or
-    /// by awaiting the task returned from `send`.
-    private static func drainImmediateFeedbacks(count: Int = 20) async
-    {
-        for _ in 0 ..< count {
-            await Task.yield()
         }
     }
 }


### PR DESCRIPTION
## Summary

**Internal cleanup (test utility).** Removes `TestActomaton.drainImmediateFeedbacks`, a race-avoidance shim that spun `Task.yield()` 20 times to wait for feedback actions to surface. The fixed yield count is machine-speed dependent and flaky on CI: effect tasks run as `@concurrent`, so yielding on the test executor never actually synchronizes with them.

Feedback arrival was already covered by two deterministic mechanisms, so the shim was redundant:

- **Synchronous feedback** (`.next`) is appended to `receivedActions` by `MealyMachine.send`'s recursive resolution *during* the `send` call, so the count is updated before `send` returns. The fail-fast "must handle received actions" check and `receive`'s initial count check both see it immediately.
- **Asynchronous feedback** wakes `receive` through `receivedActionSignal`, which fires exactly when an effect-originated action is appended. The `AsyncStream` buffers tokens (no lost wake-up), and `receive`'s `timeout` is a real-time failsafe for the "no feedback ever arrives" assertion failure — not part of the happy path.

### What changed

- **`TestActomaton`** — deletes `drainImmediateFeedbacks(count:)` and its three call sites (end of `send`, end of `_receive`, start of `waitForReceivedAction`). `receive` now blocks precisely until the awaited feedback is delivered via `receivedActionSignal`, instead of yielding a fixed number of times and hoping.

### Before

```swift
await Self.drainImmediateFeedbacks()
return .init(sendResult: sendResult, timeout: timeout)

// ...

private static func drainImmediateFeedbacks(count: Int = 20) async {
    for _ in 0 ..< count {
        await Task.yield()
    }
}
```

### After

```swift
// Synchronous feedback is already surfaced by `machine.send`; asynchronous
// feedback is awaited by `receive` via `receivedActionSignal`.
return .init(sendResult: sendResult, timeout: timeout)
```

### Behavior note

The only behavior dropped is the *best-effort* fail-fast on an **asynchronous** feedback that a test forgot to `receive` before the next `send` — which was exactly the non-deterministic part (it fired only when the drain happened to outrun the `@concurrent` effect). Synchronous-feedback fail-fast is unchanged and still deterministic. A deterministic async fail-fast is fundamentally at odds with the "don't wait for full effect completion" design (it would hang on time-based effects), so removal is the right trade-off.

## Test plan

- [x] Local `swift test --filter ActomatonTestingTests` — 13 tests pass
- [x] Local `TEST_CLOCK=1 swift test --filter ActomatonTestingTests` — 13 tests pass (and faster: 0.67s vs 4.4s)
- [x] `test_sendFailsFastWhenReceivedActionIsUnhandled` still passes, confirming synchronous feedback is surfaced for the fail-fast check
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS)

> Note: `ActomatonTestingTests` is the only suite that exercises `TestActomaton` (`WasmSmokeTests` imports `ActomatonTesting` only for `TestTimeoutError`), so it fully covers this change.
