### PR TITLE
Skip task-group allocation for single-task cancellation forwarding

### DIFF
--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -737,7 +737,7 @@ private func _runTasksForwardingCancellation(
     case 1:
         if let task = tasks.first {
             await _runTaskForwardingCancellation(task)
-        } 
+        }
     default:
         await withTaskGroup(of: Void.self) { group in
             for task in tasks {

--- a/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
+++ b/Sources/ActomatonEffect/Internal/EffectQueueManager.swift
@@ -731,13 +731,22 @@ private func _runTasksForwardingCancellation(
     priority: TaskPriority?
 ) async
 {
-    await withTaskGroup(of: Void.self) { group in
-        for task in tasks {
-            group.addTask(priority: priority) {
-                await _runTaskForwardingCancellation(task)
+    switch tasks.count {
+    case 0:
+        break
+    case 1:
+        if let task = tasks.first {
+            await _runTaskForwardingCancellation(task)
+        } 
+    default:
+        await withTaskGroup(of: Void.self) { group in
+            for task in tasks {
+                group.addTask(priority: priority) {
+                    await _runTaskForwardingCancellation(task)
+                }
             }
+            await group.waitForAll()
         }
-        await group.waitForAll()
     }
 }
 


### PR DESCRIPTION
## Summary

**Internal optimization.** Avoids spinning up a `withTaskGroup` in `_runTasksForwardingCancellation` when there is nothing to fan out — i.e. when the task list is empty or holds a single task.

`_runTasksForwardingCancellation` is the cancellation-forwarding helper that the effect supervisor task (and the tracked-feedback paths) use to await child tasks while propagating cancellation down into them. It unconditionally built a `withTaskGroup` and added one child task per element, even for the common single-task case.

The single-task case is the hot path: a typical `send(_:)` produces one effect, so the supervisor task at the main call site awaits a one-element array. Paying for a task-group allocation and an extra child-task hop just to `await` one task is pure overhead — the lone task can be awaited directly. The empty case (reachable from the tracked-feedback call sites, where `feedbackTasks` may be empty) can likewise skip the group entirely.

### What changed

- **`EffectQueueManager._runTasksForwardingCancellation`** — switches on `tasks.count`: no-op when empty, `await _runTaskForwardingCancellation(task)` directly when there is exactly one, and the existing `withTaskGroup` fan-out only for two or more. Behavior is identical in every case — cancellation is still forwarded into each task via its per-task `withTaskCancellationHandler`; only the zero/one cases now skip the group machinery.

### Before

```swift
private func _runTasksForwardingCancellation(
    _ tasks: [Task<(), Never>],
    priority: TaskPriority?
) async
{
    await withTaskGroup(of: Void.self) { group in
        for task in tasks {
            group.addTask(priority: priority) {
                await _runTaskForwardingCancellation(task)
            }
        }
        await group.waitForAll()
    }
}
```

### After

```swift
private func _runTasksForwardingCancellation(
    _ tasks: [Task<(), Never>],
    priority: TaskPriority?
) async
{
    switch tasks.count {
    case 0:
        break
    case 1:
        if let task = tasks.first {
            await _runTaskForwardingCancellation(task)
        }
    default:
        await withTaskGroup(of: Void.self) { group in
            for task in tasks {
                group.addTask(priority: priority) {
                    await _runTaskForwardingCancellation(task)
                }
            }
            await group.waitForAll()
        }
    }
}
```

### Behavior note

No behavior change. The single task in `case 1` runs on the current task context instead of a freshly spawned child task; since `priority` was only ever used to spawn that child, dropping the spawn makes it a no-op for one task. Cancellation forwarding is unchanged — `_runTaskForwardingCancellation` carries the per-task `withTaskCancellationHandler` either way.

## Test plan

- [x] Local `swift build` — clean, no warnings
- [x] Local `TEST_CLOCK=1 swift test --filter 'SendTaskCancellationTests|SendResultCancellationTests|PendingEffectCancellationTests'` — 8 cancellation-forwarding tests pass
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS) — pending
