### PR TITLE
Optimize Mealy output accumulation

### DIFF
--- a/Sources/ActomatonCore/MealyMachine.swift
+++ b/Sources/ActomatonCore/MealyMachine.swift
@@ -74,20 +74,31 @@ extension MealyMachine where Output: MealyOutput, Output.Action == Action
     /// until the returned `Output` contains only asynchronous remainders.
     ///
     /// Built on top of ``run(_:)``: runs the reducer once, then re-feeds each synchronous
-    /// action recursively through `send(_:)`, accumulating asynchronous remainders.
+    /// action recursively, accumulating asynchronous remainders into one output.
     ///
     /// - Returns: The combined asynchronous-remainder output. Wrappers hand this to their effect manager.
     @discardableResult
     public func send(_ action: Action) -> Output
     {
-        let initial = run(action)
-        let (syncActions, remainder) = initial.splitSynchronousActions()
-        var remainingOutputs = remainder
+        var output = run(action)
+        let syncActions = output.splitSynchronousActions()
 
-        for syncAction in syncActions {
-            let nestedRemainder = send(syncAction)
-            remainingOutputs = remainingOutputs + nestedRemainder
+        _send(actions: syncActions, accumulatedOutput: &output)
+        return output
+    }
+
+    private func _send(
+        actions: [Action],
+        accumulatedOutput: inout Output
+    )
+    {
+        for action in actions {
+            var output = run(action)
+            let syncActions = output.splitSynchronousActions()
+
+            accumulatedOutput.append(output)
+
+            _send(actions: syncActions, accumulatedOutput: &accumulatedOutput)
         }
-        return remainingOutputs
     }
 }

--- a/Sources/ActomatonCore/MealyOutput.swift
+++ b/Sources/ActomatonCore/MealyOutput.swift
@@ -4,19 +4,19 @@
 /// One `Output` value may contain both synchronous feedback actions (to be fed back into the
 /// reducer immediately, inside the same `send(_:)` call) and asynchronous remainders (which a
 /// downstream effect manager will turn into Swift Concurrency tasks). ``MealyMachine`` uses
-/// the three operations below to:
+/// the two operations below to:
 ///
-/// 1. Extract the synchronous feedback actions from the reducer's output.
-/// 2. Keep the asynchronous remainder around so it can be returned to the caller.
-/// 3. Merge the asynchronous remainders of every recursive reducer run into a single value.
+/// 1. Extract the synchronous feedback actions from the reducer's output, mutating the output
+///    itself into the asynchronous remainder.
+/// 2. Append the asynchronous remainders of every recursive reducer run into a single value.
 public protocol MealyOutput<Action>: SendableMetatype
 {
     associatedtype Action
 
     /// Splits this output into its synchronous feedback actions (to be re-fed into the reducer,
-    /// in order) and the asynchronous remainder (everything else).
-    func splitSynchronousActions() -> (actions: [Action], remainder: Self)
+    /// in order), mutating this output into the asynchronous remainder (everything else).
+    mutating func splitSynchronousActions() -> [Action]
 
-    /// Semigroup append: combines two outputs into one.
-    static func + (lhs: Self, rhs: Self) -> Self
+    /// In-place semigroup append: combines `other` into this output.
+    mutating func append(_ other: Self)
 }

--- a/Sources/ActomatonEffect/Effect+MealyOutput.swift
+++ b/Sources/ActomatonEffect/Effect+MealyOutput.swift
@@ -9,24 +9,25 @@ import ActomatonCore
 /// can deliver them to the caller's top-level result stream.
 extension Effect: MealyOutput
 {
-    public func splitSynchronousActions() -> (actions: [Action], remainder: Effect<Action, Emission>)
+    public mutating func splitSynchronousActions() -> [Action]
     {
         var actions: [Action] = []
-        var remainingKinds: [Effect<Action, Emission>.Kind] = []
 
-        for kind in kinds {
+        self.kinds.removeAll { kind in
             switch kind {
             case let .next(action):
                 actions.append(action)
+                return true
+
             case .single, .sequence, .emission, .cancel, .updateQueue:
-                remainingKinds.append(kind)
+                return false
             }
         }
 
-        return (actions: actions, remainder: Effect(kinds: remainingKinds))
+        return actions
     }
 
-    // `static func + (lhs:rhs:)` is already provided by `Effect`'s monoid extension.
+    // `append(_:)` is provided by `Effect`'s monoid extension.
 }
 
 /// ``Effect`` exposes its side-channel value type via ``EffectOutput`` so that

--- a/Sources/ActomatonEffect/Effect.swift
+++ b/Sources/ActomatonEffect/Effect.swift
@@ -10,7 +10,7 @@
 /// Async-effect steps produce ``Outcome`` values that may carry an action, an emission, or both.
 public struct Effect<Action, Emission>
 {
-    internal let kinds: [Kind]
+    internal var kinds: [Kind]
 }
 
 // MARK: - Public Initializers (canonical: Outcome)
@@ -659,9 +659,14 @@ extension Effect
         .init(kinds: l.kinds + r.kinds)
     }
 
+    public mutating func append(_ other: Effect)
+    {
+        self.kinds.append(contentsOf: other.kinds)
+    }
+
     public static func combine(_ effects: [Effect]) -> Effect
     {
-        effects.reduce(into: .empty, { $0 = $0 + $1 })
+        effects.reduce(into: .empty, { $0.append($1) })
     }
 
     public static func combine(_ effects: Effect...) -> Effect

--- a/Tests/TestFixtures/Array+MealyOutput.swift
+++ b/Tests/TestFixtures/Array+MealyOutput.swift
@@ -1,12 +1,18 @@
 import ActomatonCore
 
 /// `Array<Action>` is the simplest ``MealyOutput``: every element is itself a synchronous
-/// feedback action, the asynchronous remainder is always empty, and concatenation is the
-/// stdlib `+`.
+/// feedback action, and the asynchronous remainder is always empty.
 extension Array: MealyOutput
 {
-    public func splitSynchronousActions() -> (actions: [Element], remainder: [Element])
+    public mutating func splitSynchronousActions() -> [Element]
     {
-        (actions: self, remainder: [])
+        let actions = self
+        self.removeAll(keepingCapacity: true)
+        return actions
+    }
+
+    public mutating func append(_ other: [Element])
+    {
+        self.append(contentsOf: other)
     }
 }


### PR DESCRIPTION
## Summary

**Performance cleanup.** Reworks `MealyOutput` accumulation so synchronous feedback chains append asynchronous remainders in place instead of repeatedly concatenating growing output values.

The old recursive path returned a nested remainder from each feedback send and merged it with `+`. For `Effect`, that meant `l.kinds + r.kinds`, which can repeatedly allocate and copy larger prefixes in deep synchronous `.next` chains. The new path carries one accumulator through the recursive feedback walk and appends each remainder into it once.

### What changed

- **`MealyOutput`** — replaces the binary `+` requirement with `mutating append(_:)`, and changes `splitSynchronousActions()` to return only synchronous actions while mutating `self` into the asynchronous remainder.
- **`MealyMachine.send`** — uses a shared accumulator while recursively resolving synchronous feedback actions, avoiding nested remainder re-concatenation.
- **`Effect`** — makes `kinds` mutable, appends remainder effects in place, and removes `.next` kinds from `self.kinds` while collecting synchronous feedback actions.
- **Test fixture `Array: MealyOutput`** — updates the conformance to the new mutating split/append contract.

### API note

This changes the public `MealyOutput` conformance surface: custom conformers now implement `mutating splitSynchronousActions() -> [Action]` and `mutating append(_:)` instead of returning a `(actions, remainder)` tuple and providing `static func +`.

Runtime behavior for built-in `Effect` synchronous feedback resolution is intended to stay the same; the change is about how asynchronous remainders are accumulated.

## Test plan

- [x] Local `swift test` — 100 XCTest tests + 3 Swift Testing tests pass
- [x] Local `git diff --check origin/main...HEAD` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS) — pending
