### PR TITLE
Add DistributedSendID and generic Emission for DistributedActomaton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WASM_SDK_URL ?= https://download.swift.org/swift-6.2.1-release/wasm-sdk/swift-6.
 WASM_SDK_CHECKSUM ?= 482b9f95462b87bedfafca94a092cf9ec4496671ca13b43745097122d20f18af
 WASM_SWIFT ?= swiftly run swift
 WASM_SWIFT_SELECTOR ?= +$(WASM_SWIFT_TOOLCHAIN)
-WASM_BUILD_TARGETS = ActomatonCore ActomatonEffect Actomaton ActomatonDebugging ActomatonTesting
+WASM_BUILD_TARGETS = ActomatonCore ActomatonEffect Actomaton ActomatonDebugging ActomatonTesting DistributedActomaton DistributedActomatonTesting
 WASM_BUILD_TARGET_FLAGS = $(foreach target,$(WASM_BUILD_TARGETS),--target $(target))
 
 # Base path after host name, required for GitHub Pages.
@@ -122,6 +122,8 @@ _docc:
 		--target ActomatonUI \
 		--target ActomatonDebugging \
 		--target ActomatonTesting \
+		--target DistributedActomaton \
+		--target DistributedActomatonTesting \
 		--transform-for-static-hosting \
 		--hosting-base-path $(DOC_HOSTING_BASE_PATH) \
 		--output-path $(DOCBUILD_OUTPUT_DIR)

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
             name: "DistributedActomaton",
             targets: ["DistributedActomaton"]
         ),
+        .library(
+            name: "DistributedActomatonTesting",
+            targets: ["DistributedActomatonTesting"]
+        ),
     ],
     dependencies: {
         var deps: [Package.Dependency] = [
@@ -98,6 +102,10 @@ let package = Package(
             ]
         ),
         .target(
+            name: "DistributedActomatonTesting",
+            dependencies: []
+        ),
+        .target(
             name: "TestFixtures",
             dependencies: [
                 "Actomaton",
@@ -126,6 +134,7 @@ let package = Package(
             name: "DistributedActomatonTests",
             dependencies: [
                 "DistributedActomaton",
+                "DistributedActomatonTesting",
             ]
         ),
         .testTarget(
@@ -140,7 +149,7 @@ let package = Package(
         ),
         .testTarget(
             name: "ReadMeTests",
-            dependencies: ["Actomaton", "ActomatonDebugging"]
+            dependencies: ["Actomaton", "ActomatonDebugging", "DistributedActomaton"]
         )
     ],
     swiftLanguageModes: [.v6]

--- a/Sources/DistributedActomaton/DistributedActomaton+Init.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton+Init.swift
@@ -9,7 +9,7 @@ extension DistributedActomaton
     /// Initializer without `environment`.
     public init(
         state: State,
-        reducer: Reducer<Action, State, (), Never>,
+        reducer: Reducer<Action, State, (), Emission>,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         actorSystem: ActorSystem
     )
@@ -17,7 +17,7 @@ extension DistributedActomaton
         self.init(
             state: state,
             reducer: reducer,
-            effectManager: EffectQueueManager<Action, State, Never>(effectContext: effectContext),
+            effectManager: EffectQueueManager<Action, State, Emission>(effectContext: effectContext),
             actorSystem: actorSystem
         )
     }
@@ -25,7 +25,7 @@ extension DistributedActomaton
     /// Initializer with `environment`.
     public init<Environment>(
         state: State,
-        reducer: Reducer<Action, State, Environment, Never>,
+        reducer: Reducer<Action, State, Environment, Emission>,
         environment: Environment,
         effectContext: EffectContext = .init(clock: ContinuousClock()),
         actorSystem: ActorSystem
@@ -33,10 +33,10 @@ extension DistributedActomaton
     {
         self.init(
             state: state,
-            reducer: Reducer<Action, State, (), Never> { action, state, _ in
+            reducer: Reducer<Action, State, (), Emission> { action, state, _ in
                 reducer.run(action, &state, environment)
             },
-            effectManager: EffectQueueManager<Action, State, Never>(effectContext: effectContext),
+            effectManager: EffectQueueManager<Action, State, Emission>(effectContext: effectContext),
             actorSystem: actorSystem
         )
     }

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -3,16 +3,44 @@ import ActomatonEffect
 import Distributed
 
 /// `DistributedActomaton` wraps a ``MealyMachine`` specialized with
-/// `Output == Effect<Action, Never>` inside a Swift distributed actor, providing serial isolation
-/// for `send(_:)` and `state` access. It owns the
-/// ``EffectManager`` and turns the asynchronous-remainder output from ``MealyMachine`` into
-/// running Swift Concurrency tasks.
-public distributed actor DistributedActomaton<Action, State, ActorSystem>
-    where Action: Sendable, State: Sendable, ActorSystem: DistributedActorSystem
+/// `Output == Effect<Action, Emission>` inside a Swift distributed actor, providing serial
+/// isolation for `send(_:)` and `state` access. It owns the ``EffectManager`` and turns the
+/// asynchronous-remainder output from ``MealyMachine`` into running Swift Concurrency tasks.
+///
+/// ## Serialization requirements
+///
+/// `Action`, `State`, and `Emission` must be `Codable`, and the actor system's
+/// `SerializationRequirement` must be `any Codable` (the `DistributedActorSystem<any Codable>`
+/// primary-associated-type constraint). This makes the compiler verify at declaration and call
+/// sites that every distributed method's parameters and results can actually cross the wire —
+/// without the constraint, an unconstrained generic `ActorSystem` would skip the
+/// `SerializationRequirement` check entirely and defer failures to runtime on real remote calls.
+/// `Emission = Never` works because `Never` conforms to `Codable` (SE-0396).
+///
+/// ## Distributed face vs local face
+///
+/// The distributed methods — ``send(_:id:)`` and ``state`` — expose only what is meaningful to a
+/// remote peer. The richer local API — ``sendLocal(_:id:priority:tracksFeedbacks:)`` returning a
+/// ``SendResults`` — is reachable through `whenLocal { local in local.sendLocal(...) }`.
+/// `TaskPriority` is deliberately absent from the distributed face: although it is `Codable`, it is
+/// a *local scheduling hint* for the effect tasks, and a remote caller has no business steering the
+/// host's scheduler.
+///
+/// ## Remote observation is a non-goal
+///
+/// A remote caller cannot stream a `send`'s emissions or await its completion: `send` returns
+/// `Void`, and a ``SendResults`` (an `AsyncSequence` backed by a local `Task`) cannot cross the
+/// wire. This is intentional. When a peer needs results back, the host's reducer sends a *follow-up
+/// action* to the caller — the "reverse letter" / action-broadcast pattern — so every streaming or
+/// observation channel stays local to whichever node owns it. Cancellation likewise travels as an
+/// ordinary action (`send(.cancelXxx)` driving a reducer-side ``Effect/cancel(id:)``).
+public distributed actor DistributedActomaton<Action, State, Emission, ActorSystem>
+    where Action: Codable & Sendable, State: Codable & Sendable, Emission: Codable & Sendable,
+    ActorSystem: DistributedActorSystem<any Codable>
 {
-    private let machine: MealyMachine<Action, State, Effect<Action, Never>>
+    private let machine: MealyMachine<Action, State, Effect<Action, Emission>>
 
-    private let effectManager: any EffectManager<Action, State, Effect<Action, Never>>
+    private let effectManager: any EffectManager<Action, State, Effect<Action, Emission>>
 
     public distributed var state: State
     {
@@ -22,8 +50,8 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
     /// Designated initializer that takes an explicit ``EffectManager``.
     public init(
         state: State,
-        reducer: MealyReducer<Action, State, (), Effect<Action, Never>>,
-        effectManager: some EffectManager<Action, State, Effect<Action, Never>>,
+        reducer: MealyReducer<Action, State, (), Effect<Action, Emission>>,
+        effectManager: some EffectManager<Action, State, Effect<Action, Emission>>,
         actorSystem: ActorSystem
     )
     {
@@ -40,47 +68,99 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
                     self_.runIsolatedEffectManager(runEffM)
                 }
             },
-            sendAction: { [weak self] action, priority, tracksFeedbacks, _ in
-                return await self?.whenLocal { self_ in
-                    self_.sendLocal(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
+            sendAction: { [weak self] action, priority, tracksFeedbacks, emit in
+                await self?.whenLocal { self_ in
+                    self_.sendInternal(
+                        action,
+                        priority: priority,
+                        tracksFeedbacks: tracksFeedbacks,
+                        emit: emit
+                    )
                 } ?? nil
             }
         )
     }
 
-    /// Sends `action` to the underlying ``MealyMachine`` and forwards the resulting output
-    /// to ``EffectManager/processOutput(_:priority:tracksFeedbacks:)``.
+    // MARK: - Distributed face
+
+    /// Sends `action` to the underlying ``MealyMachine`` in a fire-and-forget manner,
+    /// forwarding the resulting output to the ``EffectManager``.
     ///
     /// The return type is `Void` because a `distributed func`'s return type must satisfy the
-    /// actor system's `SerializationRequirement` (typically `Codable`), and `Task` is not `Codable`.
-    /// For local-only access to the launched effect task, use ``sendLocal(_:priority:tracksFeedbacks:)``
-    /// via `whenLocal { ... }`.
+    /// actor system's `SerializationRequirement` (`any Codable`), and neither `Task` nor
+    /// ``SendResults`` is `Codable`. For local access to the triggered effect chain (emissions,
+    /// cancellation), use ``sendLocal(_:id:priority:tracksFeedbacks:)`` via `whenLocal { ... }`. A
+    /// remote caller observes results not through a return value but by receiving a follow-up
+    /// action that the host's reducer sends back (the action-broadcast / "reverse letter" pattern).
     ///
     /// - Parameters:
+    ///   - action: The action to deliver to the host's reducer.
+    ///   - id:
+    ///     Optional cancellation tag for the whole send (see ``DistributedSendID``). When non-`nil`,
+    ///     the triggered effect chain is registered under `id`, so a reducer-side
+    ///     ``Effect/cancel(id:)`` matching `id` aborts it — typically driven by routing a later
+    ///     cancel action back to this actor.
+    public distributed func send(
+        _ action: Action,
+        id: DistributedSendID? = nil
+    )
+    {
+        sendLocal(action, id: id)
+    }
+
+    // MARK: - Local face
+
+    /// Local-only variant of ``send(_:id:)`` that returns the full ``SendResults``. Use through
+    /// `whenLocal { local in local.sendLocal(...) }` when the caller needs to observe emissions
+    /// and in-band errors, await completion, or cancel the resulting effects.
+    ///
+    /// - Parameters:
+    ///   - action: The action to deliver to the underlying ``MealyMachine``.
+    ///   - id:
+    ///     Optional cancellation identifier for the whole `send`. When non-`nil`, the returned
+    ///     ``SendResults`` is registered under `id`, so a reducer-side ``Effect/cancel(id:)`` (or
+    ///     ``Effect/cancel(ids:)``) matching `id` cancels this ``SendResults`` exactly as
+    ///     ``SendResults/cancel()`` would — in addition to cancelling effect tasks sharing `id`.
+    ///     Unlike the distributed face this accepts any ``EffectID``, not just ``DistributedSendID``.
     ///   - priority:
     ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
     ///   - tracksFeedbacks:
-    ///     If `true`, the underlying effect task will also track its feedback effects that are
-    ///     triggered by next actions, so that wait-for-all and cancellations are possible
-    ///     (observable only through the local API).
-    ///     Default is `false`.
-    public distributed func send(
-        _ action: Action,
-        priority: TaskPriority? = nil,
-        tracksFeedbacks: Bool = false
-    )
-    {
-        sendLocal(action, priority: priority, tracksFeedbacks: tracksFeedbacks)
-    }
-
-    /// Local-only variant of ``send(_:priority:tracksFeedbacks:)`` that returns the launched
-    /// effect `Task`. Use through `whenLocal { local in local.sendLocal(...) }` when the caller
-    /// needs to `await` or cancel the resulting effects.
+    ///     If `true`, the returned ``SendResults`` will also track feedback effects triggered by
+    ///     next actions — so its `AsyncSequence` stays open until those downstream chains
+    ///     complete, and recursive emissions flow into the same stream. Default is `false`.
+    ///
+    /// - Returns:
+    ///   A ``SendResults`` exposing both a non-throwing `AsyncSequence` of
+    ///   `Result<Emission, any Error>` elements (effect errors are surfaced in-band as `.failure`
+    ///   without cancelling sibling effects) and a `cancel()` handle that aborts the entire chain.
     @discardableResult
     public func sendLocal(
         _ action: Action,
+        id: (any EffectID)? = nil,
         priority: TaskPriority? = nil,
         tracksFeedbacks: Bool = false
+    ) -> SendResults<Emission>
+    {
+        let output = machine.send(action)
+        return effectManager.processSendOutput(
+            output,
+            id: id,
+            priority: priority,
+            tracksFeedbacks: tracksFeedbacks
+        )
+    }
+
+    // MARK: - Internals
+
+    /// Reducer-side dispatch used internally by the recursive feedback path threaded through
+    /// ``EffectManager``'s `sendAction` callback. The `emit` parameter is the original caller's
+    /// emission sink, so all `Emission` values produced by downstream effects flow into the
+    /// single ``SendResults`` returned by ``sendLocal(_:id:priority:tracksFeedbacks:)``.
+    private func sendInternal(
+        _ action: Action,
+        priority: TaskPriority?,
+        tracksFeedbacks: Bool,
+        emit: @escaping @Sendable (Result<Emission, any Error>) -> Void
     ) -> Task<(), Never>?
     {
         let output = machine.send(action)
@@ -88,7 +168,7 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
             output,
             priority: priority,
             tracksFeedbacks: tracksFeedbacks,
-            emit: { _ in }
+            emit: emit
         )
     }
 
@@ -97,7 +177,7 @@ public distributed actor DistributedActomaton<Action, State, ActorSystem>
     /// capturing `self` themselves.
     fileprivate func runIsolatedEffectManager<EffM>(
         _ runEffM: (EffM) -> Void
-    ) where EffM: EffectManager<Action, State, Effect<Action, Never>>
+    ) where EffM: EffectManager<Action, State, Effect<Action, Emission>>
     {
         // Safe downcast from the existential storage to the conformer's concrete `Self`.
         runEffM(effectManager as! EffM)

--- a/Sources/DistributedActomaton/DistributedSendID.swift
+++ b/Sources/DistributedActomaton/DistributedSendID.swift
@@ -1,0 +1,83 @@
+import ActomatonEffect
+import Foundation
+
+/// A `Codable` cancellation identifier for a distributed `send`, suitable for crossing the wire.
+///
+/// ``DistributedActomaton``'s distributed `send` family is fire-and-forget across the network, so a
+/// remote caller cannot hold the local `SendResults` handle that ``DistributedActomaton/sendLocal``
+/// returns. To still make a previously-issued send cancellable, tag it with a `DistributedSendID`
+/// and route an ordinary cancel action back through the remote reducer:
+///
+/// ```swift
+/// let id = DistributedSendID()              // globally-unique (UUID-backed) by default
+/// try await actor.send(.startDownload, id: id)
+/// // …later, the remote reducer turns `.cancel(id)` into `Effect.cancel(id:)`:
+/// try await actor.send(.cancel(id))
+/// ```
+///
+/// ## Why UUID-backed by default
+///
+/// On the host, every remote caller's `send(id:)` funnels into a single cancellation registry keyed
+/// by the identifier's value. A client-local counter (`0, 1, 2…`) would therefore collide across
+/// clients — client A's `.cancel(1)` could abort client B's send. The default ``init()`` sidesteps
+/// this with a `UUID`, which is globally unique without any cross-client coordination, and also
+/// distinguishes the many concurrent sends a single client may have in flight.
+///
+/// For reproducible or human-readable identifiers (tests, logs, or namespaced schemes such as
+/// `"download-\(itemID)"`), use ``init(_:)`` or a string literal instead — but then *you* own
+/// uniqueness across clients, e.g. by prefixing a stable client identifier.
+///
+/// - Note: Cancellation matching is by value of ``rawValue`` *and* concrete type (`_EffectID` uses
+///   `AnyHashable`), so a reducer-side `Effect.cancel(id:)` must use a `DistributedSendID` carrying
+///   the same `rawValue` — a bare `String` with the same contents will not match.
+public struct DistributedSendID: EffectID
+{
+    /// The underlying identifier value. Equality and hashing — and therefore cancellation
+    /// matching — are entirely by this string.
+    public let rawValue: String
+
+    /// Creates a globally-unique identifier backed by a fresh `UUID`.
+    public init()
+    {
+        self.rawValue = UUID().uuidString
+    }
+
+    /// Creates an identifier from an explicit string. The caller owns cross-client uniqueness.
+    public init(_ rawValue: String)
+    {
+        self.rawValue = rawValue
+    }
+}
+
+extension DistributedSendID: ExpressibleByStringLiteral
+{
+    public init(stringLiteral value: String)
+    {
+        self.init(value)
+    }
+}
+
+extension DistributedSendID: CustomStringConvertible
+{
+    public var description: String
+    {
+        rawValue
+    }
+}
+
+extension DistributedSendID: Codable
+{
+    // Encode/decode as a bare string rather than `{ "rawValue": ... }`, keeping the wire form
+    // compact and consistent with the `ExpressibleByStringLiteral` surface.
+    public init(from decoder: any Decoder) throws
+    {
+        let container = try decoder.singleValueContainer()
+        self.rawValue = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws
+    {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Sources/DistributedActomatonTesting/InMemoryActorSystem.swift
+++ b/Sources/DistributedActomatonTesting/InMemoryActorSystem.swift
@@ -1,0 +1,357 @@
+import Distributed
+import Foundation
+import Synchronization
+
+// NOTE: All types in this file are top-level (non-nested) so that the runtime's `_typeByName`
+// can reliably resolve the mangled generic-substitution names recorded by remote calls —
+// nested or function-local types carry private discriminators that some toolchains refuse to
+// resolve (especially on Linux). Apply the same discipline to the `Action` / `State` /
+// `Emission` fixture types you use with this system in your own tests.
+
+/// Test-only actor ID: the hosting node plus a per-node serial number.
+public struct InMemoryActorID: Hashable, Codable, Sendable
+{
+    public let nodeID: String
+    public let number: Int
+
+    public init(nodeID: String, number: Int)
+    {
+        self.nodeID = nodeID
+        self.number = number
+    }
+}
+
+/// Serialized remote-call request routed between ``InMemoryActorSystem`` nodes.
+struct InMemoryInvocationEnvelope: Codable
+{
+    let targetID: InMemoryActorID
+    let method: String
+    let genericSubs: [String]
+    let arguments: [Data]
+}
+
+/// Serialized remote-call response.
+struct InMemoryReplyEnvelope: Codable
+{
+    let payload: Data?
+    let errorDescription: String?
+}
+
+public enum InMemoryActorSystemError: Error
+{
+    case actorNotFound(InMemoryActorID)
+    case nodeNotFound(String)
+    case remote(String)
+    case missingReturnPayload
+    case unsupported(String)
+    case decodingFailure(String)
+}
+
+/// In-process "wire" connecting multiple ``InMemoryActorSystem`` nodes.
+///
+/// Create one transport per test, then attach two or more systems to it:
+///
+/// ```swift
+/// let transport = InMemoryTransport()
+/// let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+/// let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+/// ```
+public final class InMemoryTransport: Sendable
+{
+    private let systems = Mutex<[String: InMemoryActorSystem]>([:])
+
+    public init() {}
+
+    func register(_ system: InMemoryActorSystem)
+    {
+        systems.withLock { $0[system.nodeID] = system }
+    }
+
+    func system(for nodeID: String) -> InMemoryActorSystem?
+    {
+        systems.withLock { $0[nodeID] }
+    }
+}
+
+/// Minimal `DistributedActorSystem` that performs a **real serialization round-trip**
+/// (encode invocation → JSON `Data` → decode → `executeDistributedTarget`) between two
+/// in-process "nodes", so that remote-proxy calls are actually exercised in tests —
+/// unlike `LocalTestingDistributedActorSystem`, which never serializes anything.
+///
+/// Typical usage with `DistributedActomaton`:
+///
+/// ```swift
+/// let transport = InMemoryTransport()
+/// let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+/// let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+///
+/// let host = MyActomaton(state: ..., reducer: ..., actorSystem: hostSystem)
+///
+/// // Resolving from ANOTHER node's system yields a true remote proxy.
+/// let proxy = try MyActomaton.resolve(id: host.id, using: clientSystem)
+/// try await proxy.send(action)  // JSON round-trips through the in-process wire
+/// ```
+public final class InMemoryActorSystem: DistributedActorSystem, Sendable
+{
+    public typealias ActorID = InMemoryActorID
+    public typealias SerializationRequirement = any Codable
+    public typealias InvocationEncoder = InMemoryInvocationEncoder
+    public typealias InvocationDecoder = InMemoryInvocationDecoder
+    public typealias ResultHandler = InMemoryResultHandler
+
+    public let nodeID: String
+
+    private let transport: InMemoryTransport
+
+    private let state = Mutex<MutableState>(MutableState())
+
+    public init(nodeID: String, transport: InMemoryTransport)
+    {
+        self.nodeID = nodeID
+        self.transport = transport
+        transport.register(self)
+    }
+
+    // MARK: - Actor lifecycle
+
+    public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor, Act.ID == ActorID
+    {
+        state.withLock {
+            $0.nextNumber += 1
+            return InMemoryActorID(nodeID: nodeID, number: $0.nextNumber)
+        }
+    }
+
+    public func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor, Act.ID == ActorID
+    {
+        state.withLock { $0.localActors[actor.id] = actor }
+    }
+
+    public func resignID(_ id: ActorID)
+    {
+        state.withLock { $0.localActors[id] = nil }
+    }
+
+    public func resolve<Act>(id: ActorID, as actorType: Act.Type) throws -> Act?
+        where Act: DistributedActor, Act.ID == ActorID
+    {
+        // Remote node: returning `nil` makes the compiler synthesize a remote proxy.
+        guard id.nodeID == nodeID else { return nil }
+
+        guard let actor = state.withLock({ $0.localActors[id] }) else {
+            throw InMemoryActorSystemError.actorNotFound(id)
+        }
+        guard let typed = actor as? Act else {
+            throw InMemoryActorSystemError.actorNotFound(id)
+        }
+        return typed
+    }
+
+    public func makeInvocationEncoder() -> InvocationEncoder
+    {
+        InMemoryInvocationEncoder()
+    }
+
+    // MARK: - Remote calls (caller side)
+
+    public func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: Codable
+    {
+        let reply = try await deliver(invocation: invocation, to: actor.id, target: target)
+        if let message = reply.errorDescription {
+            throw InMemoryActorSystemError.remote(message)
+        }
+        guard let payload = reply.payload else {
+            throw InMemoryActorSystemError.missingReturnPayload
+        }
+        return try JSONDecoder().decode(Res.self, from: payload)
+    }
+
+    public func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor, Act.ID == ActorID, Err: Error
+    {
+        let reply = try await deliver(invocation: invocation, to: actor.id, target: target)
+        if let message = reply.errorDescription {
+            throw InMemoryActorSystemError.remote(message)
+        }
+    }
+
+    private func deliver(
+        invocation: InvocationEncoder,
+        to targetID: InMemoryActorID,
+        target: RemoteCallTarget
+    ) async throws -> InMemoryReplyEnvelope
+    {
+        let envelope = InMemoryInvocationEnvelope(
+            targetID: targetID,
+            method: target.identifier,
+            genericSubs: invocation.genericSubs,
+            arguments: invocation.arguments
+        )
+
+        // Encode the whole envelope to `Data`, as a real wire would.
+        let wireData = try JSONEncoder().encode(envelope)
+
+        guard let remoteSystem = transport.system(for: targetID.nodeID) else {
+            throw InMemoryActorSystemError.nodeNotFound(targetID.nodeID)
+        }
+        return try await remoteSystem.receive(wireData: wireData)
+    }
+
+    // MARK: - Remote calls (callee side)
+
+    private func receive(wireData: Data) async throws -> InMemoryReplyEnvelope
+    {
+        let envelope = try JSONDecoder().decode(InMemoryInvocationEnvelope.self, from: wireData)
+
+        guard let actor = state.withLock({ $0.localActors[envelope.targetID] }) else {
+            return InMemoryReplyEnvelope(
+                payload: nil,
+                errorDescription: "actor not found: \(envelope.targetID)"
+            )
+        }
+
+        var decoder = InMemoryInvocationDecoder(envelope: envelope)
+        let handler = InMemoryResultHandler()
+
+        do {
+            try await executeDistributedTarget(
+                on: actor,
+                target: RemoteCallTarget(envelope.method),
+                invocationDecoder: &decoder,
+                handler: handler
+            )
+        }
+        catch {
+            return InMemoryReplyEnvelope(payload: nil, errorDescription: "\(error)")
+        }
+
+        return handler.takeReply()
+            ?? InMemoryReplyEnvelope(payload: nil, errorDescription: "no reply recorded")
+    }
+}
+
+extension InMemoryActorSystem
+{
+    private struct MutableState
+    {
+        var nextNumber: Int = 0
+        var localActors: [InMemoryActorID: any DistributedActor] = [:]
+    }
+}
+
+// MARK: - InMemoryInvocationEncoder
+
+public struct InMemoryInvocationEncoder: DistributedTargetInvocationEncoder
+{
+    public typealias SerializationRequirement = any Codable
+
+    private(set) var genericSubs: [String] = []
+    private(set) var arguments: [Data] = []
+
+    public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws
+    {
+        guard let mangled = _mangledTypeName(type) else {
+            throw InMemoryActorSystemError.unsupported("cannot mangle type \(type)")
+        }
+        genericSubs.append(mangled)
+    }
+
+    public mutating func recordArgument<Value: Codable>(_ argument: RemoteCallArgument<Value>) throws
+    {
+        arguments.append(try JSONEncoder().encode(argument.value))
+    }
+
+    public mutating func recordReturnType<R: Codable>(_ type: R.Type) throws {}
+
+    public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+
+    public mutating func doneRecording() throws {}
+}
+
+// MARK: - InMemoryInvocationDecoder
+
+public struct InMemoryInvocationDecoder: DistributedTargetInvocationDecoder
+{
+    public typealias SerializationRequirement = any Codable
+
+    private let envelope: InMemoryInvocationEnvelope
+    private var argumentIndex: Int = 0
+
+    init(envelope: InMemoryInvocationEnvelope)
+    {
+        self.envelope = envelope
+    }
+
+    public mutating func decodeGenericSubstitutions() throws -> [Any.Type]
+    {
+        try envelope.genericSubs.map { mangled in
+            guard let type = _typeByName(mangled) else {
+                throw InMemoryActorSystemError.decodingFailure("cannot resolve type \(mangled)")
+            }
+            return type
+        }
+    }
+
+    public mutating func decodeNextArgument<Argument: Codable>() throws -> Argument
+    {
+        guard argumentIndex < envelope.arguments.count else {
+            throw InMemoryActorSystemError.decodingFailure("no argument at index \(argumentIndex)")
+        }
+        defer { argumentIndex += 1 }
+        return try JSONDecoder().decode(Argument.self, from: envelope.arguments[argumentIndex])
+    }
+
+    public mutating func decodeReturnType() throws -> Any.Type? {
+        nil
+    }
+
+    public mutating func decodeErrorType() throws -> Any.Type? {
+        nil
+    }
+}
+
+// MARK: - InMemoryResultHandler
+
+public final class InMemoryResultHandler: DistributedTargetInvocationResultHandler, Sendable
+{
+    public typealias SerializationRequirement = any Codable
+
+    private let reply = Mutex<InMemoryReplyEnvelope?>(nil)
+
+    init() {}
+
+    func takeReply() -> InMemoryReplyEnvelope?
+    {
+        reply.withLock { $0 }
+    }
+
+    public func onReturn<Success: Codable>(value: Success) async throws
+    {
+        let payload = try JSONEncoder().encode(value)
+        reply.withLock { $0 = InMemoryReplyEnvelope(payload: payload, errorDescription: nil) }
+    }
+
+    public func onReturnVoid() async throws
+    {
+        reply.withLock { $0 = InMemoryReplyEnvelope(payload: nil, errorDescription: nil) }
+    }
+
+    public func onThrow<Err: Error>(error: Err) async throws
+    {
+        reply.withLock { $0 = InMemoryReplyEnvelope(payload: nil, errorDescription: "\(error)") }
+    }
+}

--- a/Tests/DistributedActomatonTests/Client-Server/DistributedObserverTests.swift
+++ b/Tests/DistributedActomatonTests/Client-Server/DistributedObserverTests.swift
@@ -20,7 +20,7 @@ final class DistributedObserverTests: XCTestCase
         let received = Mutex<[ObserverEmission]>([])
         let states = Mutex<[ObserverState]>([])
 
-        let observer = DistributedActomatonObserver<ObserverEmission, ObserverState, InMemoryActorSystem>(
+        let observer = DistributedActomatonObserver<ObserverEmission, ObserverState>(
             actorSystem: clientSystem,
             onEmission: { emission in
                 received.withLock { $0.append(emission) }
@@ -75,7 +75,7 @@ private struct ServerEnv: Sendable
 }
 
 private typealias Server = DistributedActomaton<ServerAction, ObserverState, Never, InMemoryActorSystem>
-private typealias Observer = DistributedActomatonObserver<ObserverEmission, ObserverState, InMemoryActorSystem>
+private typealias Observer = DistributedActomatonObserver<ObserverEmission, ObserverState>
 
 private let serverReducer = Reducer<ServerAction, ObserverState, ServerEnv, Never> { action, state, env in
     switch action {
@@ -97,14 +97,14 @@ private let serverReducer = Reducer<ServerAction, ObserverState, ServerEnv, Neve
 
 // MARK: - Observer sink (local test fixture)
 
-/// Concrete generic observer sink: parameterized only by the server's `Emission`/`State` +
-/// `ActorSystem`, so the server resolves it by its concrete type (no `@Resolvable`). The closures run
-/// on the observer's node and never cross the wire. Useful when the client side is not itself a
-/// `DistributedActomaton`.
-private distributed actor DistributedActomatonObserver<Emission, State, ActorSystem>
-    where Emission: Codable & Sendable, State: Codable & Sendable,
-    ActorSystem: DistributedActorSystem<any Codable>
+/// Concrete generic observer sink: parameterized only by the server's `Emission`/`State`, so the
+/// server resolves it by its concrete type (no `@Resolvable`). The closures run on the observer's
+/// node and never cross the wire. Useful when the client side is not itself a `DistributedActomaton`.
+private distributed actor DistributedActomatonObserver<Emission, State>
+    where Emission: Codable & Sendable, State: Codable & Sendable
 {
+    typealias ActorSystem = InMemoryActorSystem
+
     let onEmission: @Sendable (Emission) -> Void
     let onStateChanged: @Sendable (State) -> Void
 

--- a/Tests/DistributedActomatonTests/Client-Server/DistributedObserverTests.swift
+++ b/Tests/DistributedActomatonTests/Client-Server/DistributedObserverTests.swift
@@ -1,0 +1,131 @@
+import Distributed
+import DistributedActomaton
+import DistributedActomatonTesting
+import Synchronization
+import XCTest
+
+/// A server `DistributedActomaton` pushes its `Emission` and `State` to a client-side
+/// `DistributedActomatonObserver` (a local sink, defined below). The server resolves the observer by
+/// its **concrete** generic type — parameterized only by the server's `Emission`/`State`, so no
+/// `@Resolvable` — and the observer's closures run on the client node.
+final class DistributedObserverTests: XCTestCase
+{
+    func test_observer_serverPushesEmissionsAndStateToClientObserver() async throws
+    {
+        let transport = InMemoryTransport()
+        let serverSystem = InMemoryActorSystem(nodeID: "server", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        // Client-side collectors. Callbacks fire on the observer's (client node's) executor.
+        let received = Mutex<[ObserverEmission]>([])
+        let states = Mutex<[ObserverState]>([])
+
+        let observer = DistributedActomatonObserver<ObserverEmission, ObserverState, InMemoryActorSystem>(
+            actorSystem: clientSystem,
+            onEmission: { emission in
+                received.withLock { $0.append(emission) }
+            },
+            onStateChanged: { state in
+                states.withLock { $0.append(state) }
+            }
+        )
+
+        let emissions = [ObserverEmission(title: "a"), ObserverEmission(title: "b")]
+        let server = Server(
+            state: ObserverState(),
+            reducer: serverReducer,
+            environment: ServerEnv(system: serverSystem, emissions: emissions),
+            actorSystem: serverSystem
+        )
+
+        // Trigger the server locally; `.completion()` awaits the effect — including every awaited
+        // `observer.receive(...)` / `observer.stateChanged(...)` round-trip to the client.
+        await server.whenLocal { local in
+            await local.sendLocal(.push(observerID: observer.id)).completion()
+        }
+
+        XCTAssertEqual(received.withLock { $0 }, emissions, "emissions pushed over the wire to the observer")
+        XCTAssertEqual(states.withLock { $0 }, [ObserverState(count: 1)], "state snapshot pushed too")
+    }
+}
+
+// MARK: - Fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve them as generic substitutions on the wire.
+struct ObserverEmission: Codable, Equatable, Sendable
+{
+    var title: String
+}
+
+struct ObserverState: Codable, Equatable, Sendable
+{
+    var count: Int = 0
+}
+
+// Server-side: triggered locally, pushes to the observer in its effect.
+private enum ServerAction: Codable, Sendable
+{
+    case push(observerID: InMemoryActorID)
+}
+
+private struct ServerEnv: Sendable
+{
+    let system: InMemoryActorSystem
+    let emissions: [ObserverEmission]
+}
+
+private typealias Server = DistributedActomaton<ServerAction, ObserverState, Never, InMemoryActorSystem>
+private typealias Observer = DistributedActomatonObserver<ObserverEmission, ObserverState, InMemoryActorSystem>
+
+private let serverReducer = Reducer<ServerAction, ObserverState, ServerEnv, Never> { action, state, env in
+    switch action {
+    case let .push(observerID):
+        state.count += 1
+        let emissions = env.emissions
+        let snapshot = state
+        return Effect { _ in
+            // Resolve the observer by its CONCRETE generic type (server knows Emission/State).
+            let observer = try Observer.resolve(id: observerID, using: env.system)
+            for emission in emissions {
+                try await observer.receive(emission: emission) // server → client emission push
+            }
+            try await observer.stateChanged(snapshot) // server → client state snapshot push
+            return nil
+        }
+    }
+}
+
+// MARK: - Observer sink (local test fixture)
+
+/// Concrete generic observer sink: parameterized only by the server's `Emission`/`State` +
+/// `ActorSystem`, so the server resolves it by its concrete type (no `@Resolvable`). The closures run
+/// on the observer's node and never cross the wire. Useful when the client side is not itself a
+/// `DistributedActomaton`.
+private distributed actor DistributedActomatonObserver<Emission, State, ActorSystem>
+    where Emission: Codable & Sendable, State: Codable & Sendable,
+    ActorSystem: DistributedActorSystem<any Codable>
+{
+    let onEmission: @Sendable (Emission) -> Void
+    let onStateChanged: @Sendable (State) -> Void
+
+    init(
+        actorSystem: ActorSystem,
+        onEmission: @escaping @Sendable (Emission) -> Void = { _ in },
+        onStateChanged: @escaping @Sendable (State) -> Void = { _ in }
+    )
+    {
+        self.actorSystem = actorSystem
+        self.onEmission = onEmission
+        self.onStateChanged = onStateChanged
+    }
+
+    distributed func receive(emission: Emission)
+    {
+        onEmission(emission)
+    }
+
+    distributed func stateChanged(_ state: State)
+    {
+        onStateChanged(state)
+    }
+}

--- a/Tests/DistributedActomatonTests/Client-Server/DistributedResolvableLimitationTests.swift
+++ b/Tests/DistributedActomatonTests/Client-Server/DistributedResolvableLimitationTests.swift
@@ -1,0 +1,71 @@
+import Distributed
+import DistributedActomaton
+import DistributedActomatonTesting
+import Foundation
+import XCTest
+
+/// Documents a toolchain limitation (verified on Xcode 26.5.0): a **generic (associated-type)**
+/// `@Resolvable` distributed-actor protocol *compiles*, but **aborts at runtime** on a remote call
+/// with `Expected a metadata pack but got metadata` (signal 6).
+///
+/// A **concrete-`Action`** `@Resolvable` protocol works fine over the wire — see `ServerEmissionSink`
+/// in `DistributedObserverTests.swift`. Only the associated-type form fails, which is why a
+/// framework-level generic `DistributedActomatonSink<Action>` is not viable today.
+///
+/// The crashing call is kept (it still compiles) but the test is skipped by default so a full
+/// `swift test` stays green. Set `RUN_RESOLVABLE_CRASH_SPIKE=1` to reproduce the abort (it kills the
+/// whole test process).
+
+/// Generic over `Action` (an associated type) — the shape that aborts on remote calls.
+@Resolvable
+protocol DistributedActomatonProtocol<Action>: DistributedActor
+    where ActorSystem: DistributedActorSystem<any Codable>
+{
+    associatedtype Action: Codable & Sendable
+    distributed func send(_ action: Action, id: DistributedSendID?)
+}
+
+extension DistributedActomaton: DistributedActomatonProtocol {}
+
+enum ProbeAction: Codable, Sendable
+{
+    case ping
+}
+
+struct ProbeState: Codable, Equatable, Sendable
+{
+    var pinged = false
+}
+
+final class DistributedResolvableLimitationTests: XCTestCase
+{
+    func test_genericResolvableProtocol_remoteSend_abortsAtRuntime() async throws
+    {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_RESOLVABLE_CRASH_SPIKE"] != nil,
+            "associated-type @Resolvable aborts at runtime: 'Expected a metadata pack but got metadata'"
+        )
+
+        let transport = InMemoryTransport()
+        let serverSystem = InMemoryActorSystem(nodeID: "server", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = DistributedActomaton<ProbeAction, ProbeState, Never, InMemoryActorSystem>(
+            state: ProbeState(),
+            reducer: Reducer { _, state, _ in
+                state.pinged = true
+                return .empty
+            },
+            actorSystem: serverSystem
+        )
+
+        // Resolve via the generic `@Resolvable` stub (Action bound by the existential).
+        let proxy: any DistributedActomatonProtocol<ProbeAction> =
+            try $DistributedActomatonProtocol.resolve(id: host.id, using: clientSystem)
+
+        try await proxy.send(.ping, id: nil) // ← aborts here: "Expected a metadata pack but got metadata"
+
+        let state = try await host.state
+        XCTAssertTrue(state.pinged)
+    }
+}

--- a/Tests/DistributedActomatonTests/Client-Server/DistributedResolvableSinkTests.swift
+++ b/Tests/DistributedActomatonTests/Client-Server/DistributedResolvableSinkTests.swift
@@ -1,0 +1,120 @@
+import Distributed
+import DistributedActomaton
+import DistributedActomatonTesting
+import XCTest
+
+/// Asymmetric push **with the receiver's `State` type-erased**. The client receiver is a full
+/// ``DistributedActomaton`` whose `Action` *is* the server's emission type (`ServerEmission`), but the
+/// server resolves it through a concrete-`Action` `@Resolvable` protocol (`any ServerEmissionSink`).
+/// So the server's source references only `ServerEmission` — never the receiver's `ClientState`,
+/// removing the coupling a concrete-type resolve would carry.
+///
+/// The protocol method is **concrete** (not an associated type), so unlike a generic
+/// `Sink<Action>` it resolves and calls over the wire without aborting — see
+/// `DistributedResolvableLimitationTests` for the associated-type form that crashes.
+final class DistributedResolvableSinkTests: XCTestCase
+{
+    func test_typeErasedSink_serverPushesToClientActomatonWithoutNamingClientState() async throws
+    {
+        let transport = InMemoryTransport()
+        let serverSystem = InMemoryActorSystem(nodeID: "server", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let emissions = [ServerEmission(title: "a"), ServerEmission(title: "b")]
+
+        // The receiver is a full DistributedActomaton; its `Action` is `ServerEmission`.
+        let client = Client(
+            state: ClientState(),
+            reducer: clientReducer,
+            actorSystem: clientSystem
+        )
+
+        let server = Server(
+            state: ServerState(),
+            reducer: serverReducer,
+            environment: ServerEnv(system: serverSystem, emissions: emissions),
+            actorSystem: serverSystem
+        )
+
+        await server.whenLocal { local in
+            await local.sendLocal(.push(receiverID: client.id)).completion()
+        }
+
+        let clientState = try await client.state
+        XCTAssertEqual(
+            clientState.received,
+            emissions,
+            "type-erased sink delivered; server never named ClientState"
+        )
+    }
+}
+
+// MARK: - @Resolvable sink (concrete `Action`)
+
+/// Concrete-`Action` `@Resolvable` protocol: its method is `send(_: ServerEmission, …)` — not an
+/// associated type — so it works over the wire. The server resolves `any ServerEmissionSink`, naming
+/// only `ServerEmission`, never the receiver's `State`.
+@Resolvable
+protocol ServerEmissionSink: DistributedActor where ActorSystem: DistributedActorSystem<any Codable>
+{
+    distributed func send(_ emission: ServerEmission, id: DistributedSendID?)
+}
+
+// Any `DistributedActomaton` whose `Action` is `ServerEmission` is a `ServerEmissionSink`. The
+// conditional conformance constrains only `Action`, so `State`/`Emission` stay unconstrained — the
+// receiver keeps its own (possibly private) `State` while the server addresses it type-erased.
+extension DistributedActomaton: ServerEmissionSink where Action == ServerEmission {}
+
+// MARK: - Server fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve it as a generic substitution on the wire.
+struct ServerEmission: Codable, Equatable, Sendable
+{
+    var title: String
+}
+
+private struct ServerState: Codable, Equatable, Sendable {}
+
+private enum ServerAction: Codable, Sendable
+{
+    case push(receiverID: InMemoryActorID)
+}
+
+private struct ServerEnv: Sendable
+{
+    let system: InMemoryActorSystem
+    let emissions: [ServerEmission]
+}
+
+private typealias Server = DistributedActomaton<ServerAction, ServerState, Never, InMemoryActorSystem>
+
+private let serverReducer = Reducer<ServerAction, ServerState, ServerEnv, Never> { action, _, env in
+    switch action {
+    case let .push(receiverID):
+        let emissions = env.emissions
+        return Effect { _ in
+            // Resolve `any ServerEmissionSink`: server names ONLY `ServerEmission`, never `ClientState`.
+            let sink: any ServerEmissionSink =
+                try $ServerEmissionSink.resolve(id: receiverID, using: env.system)
+            for emission in emissions {
+                try await sink.send(emission, id: nil)
+            }
+            return nil
+        }
+    }
+}
+
+// MARK: - Client (receiver) fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve it as a generic substitution on the wire.
+struct ClientState: Codable, Equatable, Sendable
+{
+    var received: [ServerEmission] = []
+}
+
+private typealias Client = DistributedActomaton<ServerEmission, ClientState, Never, InMemoryActorSystem>
+
+private let clientReducer = Reducer<ServerEmission, ClientState, Void, Never> { emission, state, _ in
+    state.received.append(emission)
+    return .empty
+}

--- a/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedActomatonSmokeTests.swift
+++ b/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedActomatonSmokeTests.swift
@@ -8,7 +8,7 @@ final class DistributedActomatonSmokeTests: XCTestCase
     {
         let recorder = Recorder()
 
-        let actomaton = DistributedActomaton<Int, Int, LocalTestingDistributedActorSystem>(
+        let actomaton = DistributedActomaton<Int, Int, Never, LocalTestingDistributedActorSystem>(
             state: 0,
             reducer: Reducer { action, state, _ in
                 state += action
@@ -20,13 +20,12 @@ final class DistributedActomatonSmokeTests: XCTestCase
             actorSystem: LocalTestingDistributedActorSystem()
         )
 
-        // Await each send's effect task before the next send so the recorder's
-        // append order is deterministic (concurrent fire-and-forget effects would
-        // otherwise race, e.g. recording [1, 6, 3]).
+        // `SendResults.completion()` awaits the whole effect chain deterministically,
+        // so no polling is needed before asserting.
         await actomaton.whenLocal { local in
-            await local.sendLocal(1)?.value
-            await local.sendLocal(2)?.value
-            await local.sendLocal(3)?.value
+            await local.sendLocal(1).completion()
+            await local.sendLocal(2).completion()
+            await local.sendLocal(3).completion()
         }
 
         let values = await recorder.values

--- a/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedGenericActionTests.swift
+++ b/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedGenericActionTests.swift
@@ -1,0 +1,144 @@
+import Distributed
+import DistributedActomaton
+import DistributedActomatonTesting
+import XCTest
+
+/// Verifies that a **bound-generic** `Action`/`State` — e.g. `GenericPeerAction<InMemoryActorID>` —
+/// resolves as a wire generic-substitution over ``InMemoryActorSystem``. This is the exact shape the
+/// *generalized* PeerToPeer demo produces: parametrizing the payload over the actor system's
+/// `ActorID` turns the substitution recorded on the wire from a plain nominal type (`ChatAction`)
+/// into a bound generic (`ChatAction<InMemoryActorID>`).
+///
+/// The repeated "top-level, non-nested" discipline keeps `_typeByName` happy for *plain* nominal
+/// substitutions; the open question is whether it also holds when the substitution is itself a bound
+/// generic — including on Linux, where `_typeByName` resolution is historically the most fragile. If
+/// it does not, the callee's `decodeGenericSubstitutions` throws `decodingFailure`, and these remote
+/// sends fail instead of mutating host state.
+final class DistributedGenericActionTests: XCTestCase
+{
+    func test_boundGenericAction_resolvesAsWireSubstitution() async throws
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = GenericPeer(
+            state: GenericPeerState(name: "host"),
+            reducer: makeGenericPeerReducer(),
+            environment: GenericPeerEnv(system: hostSystem),
+            actorSystem: hostSystem
+        )
+
+        let proxy = try GenericPeer.resolve(id: host.id, using: clientSystem)
+
+        // `whenLocal` returns `nil` on remote proxies, proving the call is NOT local.
+        let isLocal = await proxy.whenLocal { _ in true }
+        XCTAssertNil(isLocal, "resolve from another node should synthesize a remote proxy")
+
+        let a = InMemoryActorID(nodeID: "host", number: 1)
+        let b = InMemoryActorID(nodeID: "host", number: 2)
+
+        // The argument is `GenericPeerAction<InMemoryActorID>.connect`, and the target actor's generic
+        // arguments include `GenericPeerAction<InMemoryActorID>` / `GenericPeerState<InMemoryActorID>` —
+        // all recorded as bound-generic substitutions the callee must resolve via `_typeByName`.
+        try await proxy.send(.connect(peers: [a, b]))
+
+        let state = try await proxy.state
+        XCTAssertEqual(state.peerIDs, [a, b], "bound-generic Action/State must round-trip over the wire")
+    }
+
+    /// Mirrors the demo's fan-out: the host posts locally and forwards a `.deliver` reverse letter to
+    /// each known peer, whose own node commits it locally — exercising the bound-generic `Action` in
+    /// the host → peer direction too.
+    func test_boundGenericAction_reverseLetterRoundTrip() async throws
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = GenericPeer(
+            state: GenericPeerState(name: "host"),
+            reducer: makeGenericPeerReducer(),
+            environment: GenericPeerEnv(system: hostSystem),
+            actorSystem: hostSystem
+        )
+        let client = GenericPeer(
+            state: GenericPeerState(name: "client"),
+            reducer: makeGenericPeerReducer(),
+            environment: GenericPeerEnv(system: clientSystem),
+            actorSystem: clientSystem
+        )
+
+        // Host learns the client's ID over the wire, then posts — fanning a `.deliver` letter back.
+        let hostProxy = try GenericPeer.resolve(id: host.id, using: clientSystem)
+        try await hostProxy.send(.connect(peers: [client.id]))
+
+        // `.completion()` awaits the whole effect chain, including the reverse letter to the client.
+        await host.whenLocal { local in
+            await local.sendLocal(.post("hello")).completion()
+        }
+
+        let clientState = try await client.state
+        XCTAssertEqual(clientState.received, ["hello"], "reverse-letter `.deliver` must reach the peer")
+    }
+}
+
+// MARK: - Fixtures (top-level + generic, mirroring the generalized PeerToPeer demo)
+
+// Top-level (non-nested) so `_typeByName` can resolve the *bound generic* (e.g.
+// `GenericPeerState<InMemoryActorID>`) as a wire substitution.
+
+struct GenericPeerState<ID: Codable & Sendable & Hashable>: Codable, Equatable, Sendable
+{
+    var name: String
+    var peerIDs: [ID] = []
+    var received: [String] = []
+}
+
+enum GenericPeerAction<ID: Codable & Sendable & Hashable>: Codable, Sendable
+{
+    case connect(peers: [ID])
+    case post(String)
+    case deliver(text: String)
+}
+
+// Local-only (never crosses the wire): carries the actor system so effects can resolve peers.
+private struct GenericPeerEnv<System: DistributedActorSystem<any Codable>>: Sendable
+    where System.ActorID: Codable & Sendable & Hashable
+{
+    let system: System
+}
+
+private typealias GenericPeerActomaton<System: DistributedActorSystem<any Codable>> =
+    DistributedActomaton<GenericPeerAction<System.ActorID>, GenericPeerState<System.ActorID>, Never, System>
+        where System.ActorID: Codable & Sendable & Hashable
+
+private typealias GenericPeer = GenericPeerActomaton<InMemoryActorSystem>
+
+private func makeGenericPeerReducer<System: DistributedActorSystem<any Codable>>()
+    -> Reducer<GenericPeerAction<System.ActorID>, GenericPeerState<System.ActorID>, GenericPeerEnv<System>, Never>
+    where System.ActorID: Codable & Sendable & Hashable
+{
+    Reducer { action, state, env in
+        switch action {
+        case let .connect(peers):
+            state.peerIDs = peers
+            return .empty
+
+        case let .post(text):
+            let peers = state.peerIDs
+            return Effect { _ in
+                // The "reverse letter": forward a follow-up action to each peer's node.
+                for peerID in peers {
+                    let peer = try GenericPeerActomaton<System>.resolve(id: peerID, using: env.system)
+                    try await peer.send(.deliver(text: text))
+                }
+                return nil
+            }
+
+        case let .deliver(text):
+            state.received.append(text)
+            return .empty
+        }
+    }
+}

--- a/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedRoundTripTests.swift
+++ b/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedRoundTripTests.swift
@@ -1,0 +1,406 @@
+import Distributed
+import DistributedActomaton
+import DistributedActomatonTesting
+import XCTest
+
+/// Tests that exercise **real remote-proxy calls** over ``InMemoryActorSystem``, including the
+/// full serialization round-trip (JSON-encoded invocation envelopes between two "nodes").
+final class DistributedRoundTripTests: XCTestCase
+{
+    func test_remoteSend_runsReducerOnHostNode() async throws
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = Counter(
+            state: 0,
+            reducer: Reducer { action, state, _ in
+                state += action
+                return .empty
+            },
+            actorSystem: hostSystem
+        )
+
+        let proxy = try Counter.resolve(id: host.id, using: clientSystem)
+
+        // `whenLocal` returns `nil` on remote proxies, proving we are NOT calling locally.
+        let isLocal = await proxy.whenLocal { _ in true }
+        XCTAssertNil(isLocal, "resolve from another node should synthesize a remote proxy")
+
+        try await proxy.send(40)
+        try await proxy.send(2)
+
+        // The reducer runs synchronously inside the awaited remote `send`,
+        // so the host state is already updated when the calls return.
+        let state = try await proxy.state
+        XCTAssertEqual(state, 42)
+    }
+
+    // MARK: - Echo (Emission = String) round-trips
+
+    func test_remoteStateGetter_decodesCodableSnapshot() async throws
+    {
+        // `host` is unused by name: the actor system retains it for the test's duration, so the
+        // remote proxy stays resolvable without an explicit lifetime extension.
+        let (_, proxy) = try makeEchoPair()
+
+        try await proxy.send("a")
+        try await proxy.send("b")
+
+        let state = try await proxy.state
+        XCTAssertEqual(state, EchoState(history: ["a", "b"]))
+    }
+
+    func test_effectErrors_visibleLocallyInBand() async throws
+    {
+        let (host, _) = try makeEchoPair()
+
+        // Effect failures are surfaced in-band through the **local** `SendResults` only — they
+        // never cross the wire (a remote caller's `send` is fire-and-forget `Void`).
+        let errorCount = await host.whenLocal { local in
+            await local.sendLocal("fail").errors.count
+        }
+        XCTAssertEqual(errorCount, 1)
+    }
+
+    // MARK: - Action-broadcast ("reverse letter") round-trip
+
+    /// The supported way for a remote peer to receive results: the host's reducer sends a
+    /// **follow-up action** back to the subscriber, whose own node commits it locally. No
+    /// `SendResults` crosses the wire; observation stays local to each node.
+    func test_actionBroadcast_hostSendsFollowUpActionBackToClient() async throws
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = ChatActomaton(
+            state: ChatState(),
+            reducer: chatReducer,
+            environment: ChatEnv(system: hostSystem),
+            actorSystem: hostSystem
+        )
+        let client = ChatActomaton(
+            state: ChatState(),
+            reducer: chatReducer,
+            environment: ChatEnv(system: clientSystem),
+            actorSystem: clientSystem
+        )
+
+        // Client subscribes over the wire, enclosing its own `ActorID` as the return address.
+        let hostProxy = try ChatActomaton.resolve(id: host.id, using: clientSystem)
+        try await hostProxy.send(.subscribe(peerID: client.id))
+
+        // Host posts locally; `.completion()` awaits the whole effect chain — including the
+        // reducer-driven `peer.send(.received(...))` back to the client — so no polling is needed.
+        await host.whenLocal { local in
+            await local.sendLocal(.post("hello")).completion()
+        }
+
+        // The follow-up `.received` committed on the client node: observation is purely local.
+        let clientState = try await client.state
+        XCTAssertEqual(clientState.received, ["hello"])
+    }
+
+    // MARK: - Feedback-loop stream reconstructed via reverse letters
+
+    /// A client action triggers a host-side **feedback loop** that produces a stream of values
+    /// (multiple effects + emissions). Since a `SendResults` cannot cross the wire, the host
+    /// forwards each value to the client as a follow-up `.received` action — reconstructing, on
+    /// the client, the exact sequence a local `SendResults.emissions` would have yielded.
+    func test_feedbackLoopStream_reconstructedOnClientViaReverseLetters() async throws
+    {
+        // Baseline: the emission sequence a *local* `SendResults` yields for the same loop, with
+        // no forwarding (`replyTo: nil`). `tracksFeedbacks` keeps the stream open across feedback.
+        let baselineSystem = InMemoryActorSystem(nodeID: "baseline", transport: InMemoryTransport())
+        let baselineHost = StreamActomaton(
+            state: StreamState(),
+            reducer: streamReducer,
+            environment: StreamEnv(system: baselineSystem, onFinished: {}),
+            actorSystem: baselineSystem
+        )
+        let baselineEmissions = await baselineHost.whenLocal { local in
+            await local.sendLocal(.start(from: 3, replyTo: nil), tracksFeedbacks: true).emissions
+        }
+        let baseline = try XCTUnwrap(baselineEmissions)
+        XCTAssertEqual(baseline, [3, 2, 1])
+
+        // Cross-wire: the client reconstructs the same sequence from reverse-letter `.received`s.
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let (finishedStream, finishedContinuation) = AsyncStream.makeStream(of: Void.self)
+
+        let host = StreamActomaton(
+            state: StreamState(),
+            reducer: streamReducer,
+            environment: StreamEnv(system: hostSystem, onFinished: {}),
+            actorSystem: hostSystem
+        )
+        let client = StreamActomaton(
+            state: StreamState(),
+            reducer: streamReducer,
+            environment: StreamEnv(system: clientSystem, onFinished: { finishedContinuation.yield(()) }),
+            actorSystem: clientSystem
+        )
+
+        let hostProxy = try StreamActomaton.resolve(id: host.id, using: clientSystem)
+        try await hostProxy.send(.start(from: 3, replyTo: client.id))
+
+        // The terminal `.finished` letter resolves this await — deterministic, no polling.
+        for await _ in finishedStream {
+            break
+        }
+
+        let clientState = try await client.state
+        XCTAssertEqual(clientState.received, baseline, "reverse letters must reconstruct the local SendResults stream")
+        XCTAssertTrue(clientState.finished)
+    }
+
+    // MARK: - Remote cancellation via DistributedSendID
+
+    /// A remote caller cancels an in-flight host effect by **tagging the send with a
+    /// `DistributedSendID`**, then sending a `.cancel(id)` action whose reducer returns
+    /// `Effect.cancel(id:)`. The identifier crosses the wire twice — out-of-band on `send(_:id:)`
+    /// and in-band in the `.cancel` payload — and matches by its string `rawValue`.
+    func test_remoteCancellation_viaDistributedSendID() async throws
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let (startedStream, startedContinuation) = AsyncStream.makeStream(of: Void.self)
+        let (cancelledStream, cancelledContinuation) = AsyncStream.makeStream(of: Void.self)
+
+        let host = CancelActomaton(
+            state: CancelState(),
+            reducer: cancelReducer,
+            environment: CancelEnv(
+                onStarted: { startedContinuation.yield(()) },
+                onCancelled: { cancelledContinuation.yield(()) }
+            ),
+            actorSystem: hostSystem
+        )
+
+        let proxy = try CancelActomaton.resolve(id: host.id, using: clientSystem)
+
+        // Out-of-band: tag the send (and its whole effect chain) with the id.
+        let jobID = DistributedSendID("job-1")
+        try await proxy.send(.start, id: jobID)
+
+        // Wait until the long effect is running, so the cancel lands on a live task.
+        for await _ in startedStream {
+            break
+        }
+
+        // In-band: the id rides in the action payload; the reducer turns it into `Effect.cancel(id:)`.
+        try await proxy.send(.cancel(jobID))
+
+        // The effect observes cancellation, resolving this await. If the id did not match across
+        // the wire, nothing would cancel and this would hang (test timeout = failure).
+        for await _ in cancelledStream {
+            break
+        }
+    }
+
+    private func makeEchoPair() throws -> (host: Echo, proxy: Echo)
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = Echo(
+            state: EchoState(),
+            reducer: echoReducer,
+            actorSystem: hostSystem
+        )
+        let proxy = try Echo.resolve(id: host.id, using: clientSystem)
+        return (host, proxy)
+    }
+}
+
+extension DistributedRoundTripTests
+{
+    fileprivate typealias Counter = DistributedActomaton<Int, Int, Never, InMemoryActorSystem>
+
+    fileprivate typealias Echo = DistributedActomaton<String, EchoState, String, InMemoryActorSystem>
+}
+
+// MARK: - Echo fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve it as a generic substitution.
+struct EchoState: Codable, Equatable, Sendable
+{
+    var history: [String] = []
+}
+
+private struct EchoError: Error {}
+
+private let echoReducer = Reducer<String, EchoState, Void, String> { action, state, _ in
+    state.history.append(action)
+
+    if action == "fail" {
+        return .emit("before-failure") + Effect { _ in throw EchoError() }
+    }
+    else if action == "slow" {
+        return .emit("fast:\(action)") + Effect { _ in
+            try await Task.sleep(for: .seconds(60))
+            return .emission("never:\(action)")
+        }
+    }
+    else {
+        return .emit("sync:\(action)") + Effect { _ in .emission("async:\(action)") }
+    }
+}
+
+// MARK: - Chat (action-broadcast) fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve them as generic substitutions on the wire.
+struct ChatState: Codable, Equatable, Sendable
+{
+    var subscribers: [InMemoryActorID] = []
+    var received: [String] = []
+}
+
+enum ChatAction: Codable, Sendable
+{
+    case subscribe(peerID: InMemoryActorID)
+    case post(String)
+    case received(String)
+}
+
+// Local-only (never crosses the wire): carries the actor system so effects can resolve peers.
+private struct ChatEnv: Sendable
+{
+    let system: InMemoryActorSystem
+}
+
+private typealias ChatActomaton = DistributedActomaton<ChatAction, ChatState, Never, InMemoryActorSystem>
+
+private let chatReducer = Reducer<ChatAction, ChatState, ChatEnv, Never> { action, state, env in
+    switch action {
+    case let .subscribe(peerID):
+        state.subscribers.append(peerID)
+        return .empty
+
+    case let .post(text):
+        let subscribers = state.subscribers
+        return Effect { _ in
+            // The "reverse letter": push a follow-up action back to each subscriber's node.
+            for peerID in subscribers {
+                let peer = try ChatActomaton.resolve(id: peerID, using: env.system)
+                try await peer.send(.received(text))
+            }
+            return nil
+        }
+
+    case let .received(text):
+        state.received.append(text)
+        return .empty
+    }
+}
+
+// MARK: - Feedback-loop stream fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve them as generic substitutions on the wire.
+struct StreamState: Codable, Equatable, Sendable
+{
+    var received: [Int] = []
+    var finished = false
+}
+
+enum StreamAction: Codable, Sendable
+{
+    case start(from: Int, replyTo: InMemoryActorID?) // client → host: begin a countdown stream
+    case tick(remaining: Int, replyTo: InMemoryActorID?) // host-internal feedback step
+    case received(Int) // host → client: one streamed value
+    case finished // host → client: terminal marker
+}
+
+// Local-only: carries the actor system (to resolve peers) plus the client's completion signal.
+private struct StreamEnv: Sendable
+{
+    let system: InMemoryActorSystem
+    let onFinished: @Sendable () -> Void
+}
+
+private typealias StreamActomaton = DistributedActomaton<StreamAction, StreamState, Int, InMemoryActorSystem>
+
+private let streamReducer = Reducer<StreamAction, StreamState, StreamEnv, Int> { action, state, env in
+    switch action {
+    case let .start(from, replyTo):
+        // Kick off the loop via synchronous feedback.
+        return .next(action: .tick(remaining: from, replyTo: replyTo))
+
+    case let .tick(remaining, replyTo):
+        guard remaining > 0 else {
+            // Loop finished: close the stream with a terminal letter (only when streaming to a peer).
+            guard let replyTo else { return .empty }
+            return Effect { _ in
+                let peer = try StreamActomaton.resolve(id: replyTo, using: env.system)
+                try await peer.send(.finished)
+                return nil
+            }
+        }
+        let value = remaining
+        return Effect { _ in
+            // The reverse letter: forward this value to the subscriber (the wire stand-in for a
+            // `SendResults` emission); `.both` re-emits it into the local stream AND feeds the loop.
+            if let replyTo {
+                let peer = try StreamActomaton.resolve(id: replyTo, using: env.system)
+                try await peer.send(.received(value))
+            }
+            return .both(.tick(remaining: remaining - 1, replyTo: replyTo), value)
+        }
+
+    case let .received(value):
+        state.received.append(value)
+        return .empty
+
+    case .finished:
+        state.finished = true
+        return Effect.fireAndForget { _ in env.onFinished() }
+    }
+}
+
+// MARK: - Remote-cancellation fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve them as generic substitutions on the wire.
+struct CancelState: Codable, Equatable, Sendable {}
+
+enum CancelAction: Codable, Sendable
+{
+    case start
+    case cancel(DistributedSendID)
+}
+
+// Local-only: the test's "effect started" / "effect cancelled" signals.
+private struct CancelEnv: Sendable
+{
+    let onStarted: @Sendable () -> Void
+    let onCancelled: @Sendable () -> Void
+}
+
+private typealias CancelActomaton = DistributedActomaton<CancelAction, CancelState, Never, InMemoryActorSystem>
+
+private let cancelReducer = Reducer<CancelAction, CancelState, CancelEnv, Never> { action, _, env in
+    switch action {
+    case .start:
+        // A long effect, registered under the send's id, so `Effect.cancel(id:)` can abort it.
+        return Effect { _ in
+            env.onStarted()
+            do {
+                try await Task.sleep(for: .seconds(60))
+            }
+            catch {
+                env.onCancelled() // CancellationError from `Effect.cancel(id:)`
+            }
+            return nil
+        }
+
+    case let .cancel(id):
+        return Effect.cancel(id: id)
+    }
+}


### PR DESCRIPTION
## Summary

**Distributed API hardening.** Generalizes `DistributedActomaton` from `Effect<Action, Never>` to `Effect<Action, Emission>`, and adds a `DistributedSendID` so remote callers can tag a fire-and-forget distributed `send` and later cancel that hosted effect chain through an ordinary reducer action.

The distributed face stays intentionally small: remote callers can `send(_:id:)` and read `state`, while the richer `SendResults` stream/cancellation handle remains local-only through `whenLocal { local in local.sendLocal(...) }`. When a remote peer needs values back, the supported shape is now documented and tested as a follow-up-action / "reverse letter" pattern rather than trying to send `SendResults` over the wire.

### What changed

- **`DistributedActomaton<Action, State, Emission, ActorSystem>`** — adds a codable/sendable `Emission` generic, constrains the actor system to `DistributedActorSystem<any Codable>`, and threads `Effect<Action, Emission>` through the machine and effect manager.
- **Distributed vs local send split** — the distributed `send` now returns `Void` and accepts only an optional `DistributedSendID`; the local `sendLocal(_:id:priority:tracksFeedbacks:)` returns `SendResults<Emission>` and keeps priority / feedback tracking local to the host actor.
- **`DistributedSendID`** — new UUID-backed, string-literal, codable `EffectID` that can cross the wire and match reducer-side `Effect.cancel(id:)` by value and concrete id type.
- **Initializer updates** — convenience initializers now preserve the reducer's `Emission` type instead of forcing `Never`, so distributed actors can emit typed local results while remote callers still observe via follow-up actions.
- **`DistributedActomatonTesting`** — adds an in-process `InMemoryActorSystem` / `InMemoryTransport` that performs a real JSON invocation-envelope round trip between test nodes, so remote-proxy calls exercise distributed serialization instead of staying purely local.
- **Distributed test coverage** — adds remote-proxy tests for in-memory send/state round trips, reverse-letter action broadcast, feedback-stream reconstruction, remote cancellation via `DistributedSendID`, bound-generic action substitution, type-erased concrete-`Action` sinks, and a skipped spike documenting the current associated-type `@Resolvable` limitation.
- **Package surface** — adds `DistributedActomatonTesting` as a library product / target and includes it in the Wasm build target list for the new in-memory distributed actor test support.

### API note

This is a public API change for explicit `DistributedActomaton` type references: the type now has an `Emission` generic before `ActorSystem`, and `Action`, `State`, and `Emission` must be `Codable & Sendable`. Existing `Never`-emission use sites should become `DistributedActomaton<Action, State, Never, ActorSystem>` when type inference cannot fill the generic.

The remote `send` no longer exposes `priority` or `tracksFeedbacks`, because those are local scheduling / local stream-lifetime concerns. Use `whenLocal { local in local.sendLocal(..., priority: ..., tracksFeedbacks: ...) }` when the caller is on the host node and needs the full `SendResults` surface.

## Test plan

- [x] Local `git diff --check origin/main...HEAD` — passes
- [x] Clean temporary worktree `swift build` — passes
- [x] Clean temporary worktree `swift test -Xswiftc -DTEST_CLOCK --filter DistributedActomatonTests` — 12 tests pass, including 1 intentionally skipped `@Resolvable` crash spike
- [x] Clean temporary worktree `swift test -Xswiftc -DTEST_CLOCK` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS) — pending
