### PR TITLE
Add sendCollectAll and sendCollectFirst to DistributedActomaton

### DIFF
--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -28,14 +28,18 @@ import Distributed
 ///
 /// ## Remote observation is a non-goal
 ///
-/// A remote caller cannot stream a `send`'s emissions or await its completion: `send` returns
-/// `Void`, and a ``SendResults`` (an `AsyncSequence` backed by a local `Task`) cannot cross the
-/// wire. This is intentional. When a peer needs results back, the host's reducer sends a *follow-up
-/// action* to the caller — the "reverse letter" / action-broadcast pattern — so every streaming or
-/// observation channel stays local to whichever node owns it. Cancellation likewise travels as an
-/// ordinary action (`send(.cancelXxx)` driving a reducer-side ``Effect/cancel(id:)``).
+/// A remote caller cannot *stream* a `send`'s emissions incrementally: a ``SendResults`` (an
+/// `AsyncSequence` backed by a local `Task`) cannot cross the wire, so `send` returns `Void`. This
+/// is intentional — every live streaming/observation channel stays local to whichever node owns it.
+/// A caller that can wait for the chain to settle may instead use
+/// ``sendCollectAll(_:id:tracksFeedbacks:)`` (or ``sendCollectFirst(_:id:tracksFeedbacks:)`` for
+/// just the first outcome), which awaits the effects on the host and returns the collected outcomes
+/// as `Codable` ``DistributedEffectResult`` values (so they cross the wire). For truly incremental
+/// or push-based results, the host's reducer sends a
+/// *follow-up action* back to the caller — the "reverse letter" / action-broadcast pattern.
+/// Cancellation likewise travels as an ordinary action (`send(.cancelXxx)` driving a reducer-side ``Effect/cancel(id:)``).
 public distributed actor DistributedActomaton<Action, State, Emission, ActorSystem>
-    where Action: Codable & Sendable, State: Codable & Sendable, Emission: Codable & Sendable,
+    where Action: Codable & Sendable, State: Codable & Sendable,
     ActorSystem: DistributedActorSystem<any Codable>
 {
     private let machine: MealyMachine<Action, State, Effect<Action, Emission>>
@@ -93,6 +97,11 @@ public distributed actor DistributedActomaton<Action, State, Emission, ActorSyst
     /// remote caller observes results not through a return value but by receiving a follow-up
     /// action that the host's reducer sends back (the action-broadcast / "reverse letter" pattern).
     ///
+    /// To instead *await* the triggered effects and get their collected outcomes back across the
+    /// wire, use ``sendCollectAll(_:id:tracksFeedbacks:)`` (or ``sendCollectFirst(_:id:tracksFeedbacks:)``)
+    /// — their `Codable` ``DistributedEffectResult`` returns cross the wire, unlike the live
+    /// ``SendResults`` stream this fire-and-forget variant discards.
+    ///
     /// - Parameters:
     ///   - action: The action to deliver to the host's reducer.
     ///   - id:
@@ -106,6 +115,78 @@ public distributed actor DistributedActomaton<Action, State, Emission, ActorSyst
     )
     {
         sendLocal(action, id: id)
+    }
+
+    /// Collecting counterpart of ``send(_:id:)``: sends `action`, awaits completion of the
+    /// triggered effect chain, and returns its **collected outcomes** — successes *and* failures,
+    /// in arrival order — as serializable ``DistributedEffectResult`` values.
+    ///
+    /// With the default `tracksFeedbacks: false` this covers only the directly-triggered effects'
+    /// own work (sleep + run + feedback *dispatch*); pass `true` to also await — and collect
+    /// results from — their downstream feedback descendants.
+    ///
+    /// The actor stays reentrant while suspended awaiting the chain, so effects that hop back onto
+    /// this actor (feedback dispatch, queue bookkeeping) still make progress — no deadlock.
+    ///
+    /// `[DistributedEffectResult<Emission>]` crosses the wire because it is `Codable`. The live
+    /// ``SendResults`` `AsyncSequence` cannot, and its ``SendResults/allResults`` —
+    /// `[Result<Emission, any Error>]` — is not `Codable` either (neither `Result` nor `any Error`
+    /// is), so each element is bridged into the serializable envelope (failures stringified). This
+    /// returns the *fully collected* results once the chain settles, not an incremental stream.
+    ///
+    /// - Important: This keeps the distributed call open (suspended, not thread-blocked) for the
+    ///   entire effect duration. A remote caller therefore stays suspended until the host's effects
+    ///   settle, which can hit the actor system's call timeout for long-running effects (the effects
+    ///   keep running on the host regardless). Prefer ``send(_:id:)`` when fire-and-forget is
+    ///   acceptable.
+    ///
+    /// - Parameters:
+    ///   - action: The action to deliver to the host's reducer.
+    ///   - id: Optional cancellation tag for the whole send (see ``send(_:id:)``).
+    ///   - tracksFeedbacks:
+    ///     If `true`, also awaits and collects results from the downstream feedback chains
+    ///     triggered by next actions, not just the directly-triggered effects' own work. Default
+    ///     is `false`.
+    /// - Returns: Every outcome produced by this `action`'s effect chain, in arrival order. Empty
+    ///   if the chain produced nothing (or was cancelled before producing any).
+    public distributed func sendCollectAll(
+        _ action: Action,
+        id: DistributedSendID? = nil,
+        tracksFeedbacks: Bool = false
+    ) async -> [DistributedEffectResult<Emission>]
+        where Emission: Codable & Sendable
+    {
+        await sendLocal(action, id: id, tracksFeedbacks: tracksFeedbacks)
+            .allResults
+            .map(DistributedEffectResult.init)
+    }
+
+    /// Like ``sendCollectAll(_:id:tracksFeedbacks:)`` but returns only the **first** outcome the
+    /// effect chain produces (success or failure), as a serializable ``DistributedEffectResult``.
+    ///
+    /// Returns as soon as the first outcome arrives — unlike ``sendCollectAll(_:id:tracksFeedbacks:)``
+    /// it does not await the whole chain. The remaining effects keep running on the host
+    /// (fire-and-forget); they are neither awaited nor cancelled. Pass `id` and route a cancel action
+    /// back if you need to stop them.
+    ///
+    /// - Parameters:
+    ///   - action: The action to deliver to the host's reducer.
+    ///   - id: Optional cancellation tag for the whole send (see ``send(_:id:)``).
+    ///   - tracksFeedbacks:
+    ///     If `true`, the first outcome may also come from a downstream feedback chain, not just the
+    ///     directly-triggered effects. Default is `false`.
+    /// - Returns: The first outcome produced by this `action`'s effect chain, or `nil` if the chain
+    ///   produced nothing (or was cancelled before producing any).
+    public distributed func sendCollectFirst(
+        _ action: Action,
+        id: DistributedSendID? = nil,
+        tracksFeedbacks: Bool = false
+    ) async -> DistributedEffectResult<Emission>?
+        where Emission: Codable & Sendable
+    {
+        await sendLocal(action, id: id, tracksFeedbacks: tracksFeedbacks)
+            .firstResult
+            .map(DistributedEffectResult.init)
     }
 
     // MARK: - Local face

--- a/Sources/DistributedActomaton/DistributedActomaton.swift
+++ b/Sources/DistributedActomaton/DistributedActomaton.swift
@@ -37,7 +37,8 @@ import Distributed
 /// as `Codable` ``DistributedEffectResult`` values (so they cross the wire). For truly incremental
 /// or push-based results, the host's reducer sends a
 /// *follow-up action* back to the caller — the "reverse letter" / action-broadcast pattern.
-/// Cancellation likewise travels as an ordinary action (`send(.cancelXxx)` driving a reducer-side ``Effect/cancel(id:)``).
+/// Cancellation likewise travels as an ordinary action (`send(.cancelXxx)` driving a reducer-side
+/// ``Effect/cancel(id:)``).
 public distributed actor DistributedActomaton<Action, State, Emission, ActorSystem>
     where Action: Codable & Sendable, State: Codable & Sendable,
     ActorSystem: DistributedActorSystem<any Codable>

--- a/Sources/DistributedActomaton/DistributedEffectResult.swift
+++ b/Sources/DistributedActomaton/DistributedEffectResult.swift
@@ -1,0 +1,37 @@
+/// A `Codable` stand-in for one element of ``SendResults/allResults``, so that
+/// ``DistributedActomaton/sendCollectAll(_:id:tracksFeedbacks:)`` (and
+/// ``DistributedActomaton/sendCollectFirst(_:id:tracksFeedbacks:)``) can convey an effect chain's
+/// per-effect outcomes — successes *and* failures, in arrival order — across the wire.
+///
+/// `SendResults.allResults` is `[Result<Emission, any Error>]`, which cannot cross a distributed
+/// boundary: `Result` has no `Codable` conformance, and an `any Error` is not `Codable` (its
+/// concrete type need not even exist on the caller's node). This envelope preserves the in-band
+/// success/failure distinction while staying serializable, capturing each failure as text rather
+/// than as a reconstructable error value.
+public enum DistributedEffectResult<Emission>: Sendable
+    where Emission: Codable & Sendable
+{
+    /// A value emitted by an effect.
+    case success(Emission)
+
+    /// A non-cancellation error thrown by a single effect, captured as
+    /// `String(describing:)`. The original error type is intentionally not carried — concrete
+    /// error types need not exist on the caller's node.
+    case failure(description: String)
+
+    /// Bridges one in-band ``SendResults`` element into its serializable form, stringifying any
+    /// error.
+    init(_ result: Result<Emission, any Error>)
+    {
+        switch result {
+        case let .success(emission):
+            self = .success(emission)
+        case let .failure(error):
+            self = .failure(description: String(describing: error))
+        }
+    }
+}
+
+extension DistributedEffectResult: Codable {}
+
+extension DistributedEffectResult: Equatable where Emission: Equatable {}

--- a/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedSendCollectTests.swift
+++ b/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedSendCollectTests.swift
@@ -1,0 +1,168 @@
+import Distributed
+import DistributedActomaton
+import DistributedActomatonTesting
+import XCTest
+
+/// Tests for the collecting distributed face — ``DistributedActomaton/sendCollectAll(_:id:tracksFeedbacks:)``
+/// and ``DistributedActomaton/sendCollectFirst(_:id:tracksFeedbacks:)`` — which await the effect chain
+/// and return its outcomes as `Codable` ``DistributedEffectResult`` values.
+final class DistributedSendCollectTests: XCTestCase
+{
+    // MARK: - sendCollectAll
+
+    func test_sendCollectAll_returnsAllOutcomes_inArrivalOrder() async throws
+    {
+        let actomaton = makeLocal()
+
+        // `.values` emits a synchronous `v0` then an asynchronous `v1`, so arrival order is fixed.
+        let results = try await actomaton.sendCollectAll(.values)
+        XCTAssertEqual(results, [.success("v0"), .success("v1")])
+    }
+
+    func test_sendCollectAll_includesInBandFailure_afterSuccess() async throws
+    {
+        let actomaton = makeLocal()
+
+        // `.failing` emits `before`, then a sibling effect throws — surfaced in-band, not by throwing.
+        let results = try await actomaton.sendCollectAll(.failing)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.first, .success("before"))
+        try assertFailure(results.last, descriptionContains: "CollectError")
+    }
+
+    func test_sendCollectAll_emptyWhenNoOutcomes() async throws
+    {
+        let actomaton = makeLocal()
+
+        let results = try await actomaton.sendCollectAll(.silent)
+        XCTAssertEqual(results, [])
+    }
+
+    func test_sendCollectAll_tracksFeedbacks_collectsDescendantEmissions() async throws
+    {
+        let actomaton = makeLocal()
+
+        // `.ping` emits `ping` and feeds `.pong`, whose effect emits `pong`.
+        let untracked = try await actomaton.sendCollectAll(.ping)
+        XCTAssertEqual(untracked, [.success("ping")], "feedback descendant must NOT be collected by default")
+
+        let tracked = try await actomaton.sendCollectAll(.ping, tracksFeedbacks: true)
+        XCTAssertEqual(tracked, [.success("ping"), .success("pong")], "tracksFeedbacks must collect the descendant")
+    }
+
+    // MARK: - sendCollectFirst
+
+    func test_sendCollectFirst_returnsFirstOutcome() async throws
+    {
+        let actomaton = makeLocal()
+
+        let first = try await actomaton.sendCollectFirst(.values)
+        XCTAssertEqual(first, .success("v0"))
+    }
+
+    func test_sendCollectFirst_nilWhenNoOutcomes() async throws
+    {
+        let actomaton = makeLocal()
+
+        let first = try await actomaton.sendCollectFirst(.silent)
+        XCTAssertNil(first)
+    }
+
+    // MARK: - Over-the-wire serialization
+
+    /// Proves `[DistributedEffectResult]` actually crosses the wire (JSON round-trip), unlike the
+    /// non-`Codable` `SendResults.allResults` it bridges from. Both a success and a stringified
+    /// failure survive the trip.
+    func test_sendCollectAll_overTheWire_serializesOutcomes() async throws
+    {
+        let transport = InMemoryTransport()
+        let hostSystem = InMemoryActorSystem(nodeID: "host", transport: transport)
+        let clientSystem = InMemoryActorSystem(nodeID: "client", transport: transport)
+
+        let host = CollectActomaton(
+            state: CollectState(),
+            reducer: collectReducer,
+            actorSystem: hostSystem
+        )
+        let proxy = try CollectActomaton.resolve(id: host.id, using: clientSystem)
+
+        // `whenLocal` returns `nil` on a remote proxy, proving the call really serializes.
+        let isLocal = await proxy.whenLocal { _ in true }
+        XCTAssertNil(isLocal, "resolve from another node should synthesize a remote proxy")
+
+        let results = try await proxy.sendCollectAll(.failing)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.first, .success("before"))
+        try assertFailure(results.last, descriptionContains: "CollectError")
+    }
+
+    // MARK: - Helpers
+
+    private func makeLocal() -> LocalCollectActomaton
+    {
+        LocalCollectActomaton(
+            state: CollectState(),
+            reducer: collectReducer,
+            actorSystem: LocalTestingDistributedActorSystem()
+        )
+    }
+
+    private func assertFailure(
+        _ result: DistributedEffectResult<String>?,
+        descriptionContains needle: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        guard case let .failure(description) = result else {
+            return XCTFail("expected a .failure element, got \(String(describing: result))", file: file, line: line)
+        }
+        XCTAssertTrue(description.contains(needle), "description = \(description)", file: file, line: line)
+    }
+}
+
+extension DistributedSendCollectTests
+{
+    fileprivate typealias LocalCollectActomaton =
+        DistributedActomaton<CollectAction, CollectState, String, LocalTestingDistributedActorSystem>
+}
+
+private typealias CollectActomaton =
+    DistributedActomaton<CollectAction, CollectState, String, InMemoryActorSystem>
+
+// MARK: - Fixtures
+
+// Top-level (non-nested) so `_typeByName` can resolve them as generic substitutions on the wire.
+struct CollectState: Codable, Equatable, Sendable {}
+
+enum CollectAction: Codable, Sendable
+{
+    case values  // sync `v0` + async `v1`
+    case failing // sync `before` + a sibling effect that throws
+    case silent  // no outcomes
+    case ping    // emits `ping`, then feeds `.pong`
+    case pong    // emits `pong`
+}
+
+private struct CollectError: Error {}
+
+private let collectReducer = Reducer<CollectAction, CollectState, Void, String> { action, _, _ in
+    switch action {
+    case .values:
+        return .emit("v0") + Effect { _ in .emission("v1") }
+
+    case .failing:
+        return .emit("before") + Effect { _ in throw CollectError() }
+
+    case .silent:
+        return .empty
+
+    case .ping:
+        // Async emission + feedback: emits `ping` and feeds `.pong` (a tracked descendant).
+        return Effect { _ in .both(.pong, "ping") }
+
+    case .pong:
+        return Effect { _ in .emission("pong") }
+    }
+}

--- a/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedSendCollectTests.swift
+++ b/Tests/DistributedActomatonTests/Peer-to-Peer/DistributedSendCollectTests.swift
@@ -138,11 +138,11 @@ struct CollectState: Codable, Equatable, Sendable {}
 
 enum CollectAction: Codable, Sendable
 {
-    case values  // sync `v0` + async `v1`
+    case values // sync `v0` + async `v1`
     case failing // sync `before` + a sibling effect that throws
-    case silent  // no outcomes
-    case ping    // emits `ping`, then feeds `.pong`
-    case pong    // emits `pong`
+    case silent // no outcomes
+    case ping // emits `ping`, then feeds `.pong`
+    case pong // emits `pong`
 }
 
 private struct CollectError: Error {}


### PR DESCRIPTION
## Summary

**New API.** Adds two awaiting variants to the `DistributedActomaton` distributed face: `sendCollectAll(_:id:tracksFeedbacks:)` and `sendCollectFirst(_:id:tracksFeedbacks:)`. Unlike the fire-and-forget `send(_:id:)` (which returns `Void`), these await the triggered effect chain on the host and return its outcomes back across the wire as `Codable` `DistributedEffectResult` values.

This fills the gap noted in #156: a remote caller could previously only fire-and-forget and observe results through the follow-up-action / "reverse letter" pattern. When the caller can wait for the chain to settle, it can now collect the outcomes directly.

```swift
// every outcome (success and failure), in arrival order
let results = try await actomaton.sendCollectAll(.fetch)

// just the first outcome, or nil
let first = try await actomaton.sendCollectFirst(.fetch)
```

### Why a new result type

`SendResults.allResults` is `[Result<Emission, any Error>]`, which cannot cross a distributed boundary: `Result` has no `Codable` conformance, and an `any Error` is not `Codable` (its concrete type need not even exist on the caller node). `DistributedEffectResult` is a `Codable` stand-in that preserves the in-band success/failure distinction, capturing each failure as its `String(describing:)` text rather than a reconstructable error value.

### What changed

- **`sendCollectAll(_:id:tracksFeedbacks:)`** — distributed method returning `[DistributedEffectResult<Emission>]`: every outcome (success and failure) in arrival order, bridged from `SendResults.allResults`.
- **`sendCollectFirst(_:id:tracksFeedbacks:)`** — distributed method returning `DistributedEffectResult<Emission>?`: the first outcome only, or `nil` if the chain produced none. Returns as soon as the first outcome arrives; remaining effects keep running on the host (neither awaited nor cancelled).
- **`DistributedEffectResult<Emission>`** — new `Codable` / `Sendable` / conditionally `Equatable` envelope (`.success(Emission)` / `.failure(description:)`) bridging one `SendResults.allResults` element.
- **`tracksFeedbacks` (default `false`)** — both methods can optionally await and collect from downstream feedback descendants, not just the directly-triggered effects.
- **Doc updates** — the distributed `send` and the type-level "Remote observation is a non-goal" section now cross-reference the new collecting methods.

### API note

Additive only. `send(_:id:)` stays fire-and-forget `Void`; the new methods are opt-in. They carry a `where Emission: Codable & Sendable` clause (required to serialize the result), so a `Never`-emission actor simply does not expose them. The richer local `SendResults` surface remains available through `whenLocal { local in local.sendLocal(...) }`.

A remote caller still cannot *stream* emissions incrementally — `sendCollectAll` returns the fully collected results once the chain settles, and keeps the distributed call suspended (not thread-blocked) for the effect duration, so a long-running chain can hit the actor system call timeout. Prefer `send(_:id:)` when fire-and-forget is acceptable.

## Test plan

- [x] New `DistributedSendCollectTests` — 7 tests pass:
  - `test_sendCollectAll_returnsAllOutcomes_inArrivalOrder`
  - `test_sendCollectAll_includesInBandFailure_afterSuccess`
  - `test_sendCollectAll_emptyWhenNoOutcomes`
  - `test_sendCollectAll_tracksFeedbacks_collectsDescendantEmissions`
  - `test_sendCollectFirst_returnsFirstOutcome`
  - `test_sendCollectFirst_nilWhenNoOutcomes`
  - `test_sendCollectAll_overTheWire_serializesOutcomes` (real JSON round trip over `InMemoryActorSystem`)
- [x] Local `swift build` — passes
- [x] Local `swift test --filter DistributedActomatonTests` — 19 tests pass (1 intentionally skipped)
- [x] Local `git diff --check origin/main...HEAD` — passes
- [x] CI: Ubuntu / Wasm / Xcode (macOS, iOS, tvOS, watchOS, visionOS) — pending
